### PR TITLE
Update submodule datetimepicker

### DIFF
--- a/res/layout/all_in_one_material.xml
+++ b/res/layout/all_in_one_material.xml
@@ -29,8 +29,7 @@
                 style="@style/Widget.CalendarAppTheme.ActionBar"
                 android:layout_width="match_parent"
                 android:layout_height="?attr/actionBarSize"
-                android:minHeight="?attr/actionBarSize"
-                app:layout_scrollFlags="scroll|enterAlways" />
+                android:minHeight="?attr/actionBarSize" />
         </android.support.design.widget.AppBarLayout>
 
         <android.support.design.widget.FloatingActionButton

--- a/res/layout/day_activity.xml
+++ b/res/layout/day_activity.xml
@@ -17,11 +17,9 @@
 <FrameLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
-    android:layout_height="0dip"
-    android:layout_weight="1.0"
+    android:layout_height="match_parent"
     android:background="@color/day_past_background_color"
     android:foregroundGravity="fill_horizontal|top"
-    android:paddingBottom="?attr/actionBarSize"
     android:paddingTop="1dip">
     <ViewSwitcher
         android:id="@+id/switcher"


### PR DESCRIPTION
This updates datetimepicker to the newest version available in your [fork](https://github.com/xsoh/android_frameworks_opt_datetimepicker) (branch cm-13.0).
Although there is a more current version in the [upstream repo](https://github.com/CyanogenMod/android_frameworks_opt_datetimepicker) by CyanogenMod, the problem described in #128 is already fixed by this commit.