### PR TITLE
Remove min/targetSDK from manifest

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -40,7 +40,7 @@
     <uses-permission android:name="android.permission.READ_SYNC_SETTINGS" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
     <uses-permission android:name="com.google.android.googleapps.permission.GOOGLE_AUTH.mail" />
-    <uses-sdk android:minSdkVersion="15" android:targetSdkVersion="18"></uses-sdk>
+    
 
     <application android:name="com.android.calendar.CalendarApplication"
         android:hardwareAccelerated="true"


### PR DESCRIPTION
The value of (for example) minSdkVersion is only used if it is not specified in the build.gradle build scripts. When specified in the Gradle build scripts, the manifest value is ignored and can be misleading, so should be removed to avoid ambiguity. Fixes #61 