### PR TITLE
Disable scrolling of the toolbar

### DIFF
--- a/res/layout/all_in_one_material.xml
+++ b/res/layout/all_in_one_material.xml
@@ -29,8 +29,7 @@
                 style="@style/Widget.CalendarAppTheme.ActionBar"
                 android:layout_width="match_parent"
                 android:layout_height="?attr/actionBarSize"
-                android:minHeight="?attr/actionBarSize"
-                app:layout_scrollFlags="scroll|enterAlways" />
+                android:minHeight="?attr/actionBarSize" />
         </android.support.design.widget.AppBarLayout>
 
         <android.support.design.widget.FloatingActionButton

--- a/res/layout/day_activity.xml
+++ b/res/layout/day_activity.xml
@@ -17,11 +17,9 @@
 <FrameLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
-    android:layout_height="0dip"
-    android:layout_weight="1.0"
+    android:layout_height="match_parent"
     android:background="@color/day_past_background_color"
     android:foregroundGravity="fill_horizontal|top"
-    android:paddingBottom="?attr/actionBarSize"
     android:paddingTop="1dip">
     <ViewSwitcher
         android:id="@+id/switcher"


### PR DESCRIPTION
Fixes #150 

The change in all_in_one_material.xml disables the scrolling but this change alone will leave an empty gray area at the bottom.  Therefore it is required to remove the paddingBottom in day_activity.xml.