### PR TITLE
Remove duplicate string

### DIFF
--- a/res/values/cm_strings.xml
+++ b/res/values/cm_strings.xml
@@ -40,9 +40,6 @@
     <!-- Default value for the default snooze delay (in minutes) -->
     <string name="preferences_default_snooze_delay_default" translatable="false">5</string>
 
-    <!-- No maps found in phone -->
-    <string name="no_map">No maps were found.</string>
-
     <!-- Delete events -->
     <string name="events_delete">Delete events</string>
     <string name="action_select_all">Select all</string>


### PR DESCRIPTION
This string was added in 351167d9445dfaa6332766f6e76d15446aa65e78 but it already existed in the same file, and thus breaks compilation.