### PR TITLE
Only use setExactAndAllowWhileIdle for devices with API23+. 

### DIFF
--- a/src/com/android/calendar/alerts/AlertUtils.java
+++ b/src/com/android/calendar/alerts/AlertUtils.java
@@ -82,7 +82,11 @@ public class AlertUtils {
         return new AlarmManagerInterface() {
             @Override
             public void set(int type, long triggerAtMillis, PendingIntent operation) {
-                mgr.setExactAndAllowWhileIdle(type, triggerAtMillis, operation);
+                if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.M) {
+                    mgr.setExactAndAllowWhileIdle(type, triggerAtMillis, operation);
+                } else {
+                    mgr.setExact(type, triggerAtMillis, operation);
+                }
             }
         };
     }


### PR DESCRIPTION
Tested with an API19 device. Would be good if someone can test this with a Android 6.0 or higher phone. 
Fix #155