### PR TITLE
Navigation should represent the current calendar view

### DIFF
--- a/res/menu/calendar_view.xml
+++ b/res/menu/calendar_view.xml
@@ -21,7 +21,7 @@
             android:title="@string/agenda_view" />
 
     </group>
-    <group android:id="@+id/navigation_subheader" android:checkableBehavior="single">
+    <group android:id="@+id/navigation_subheader" android:checkableBehavior="none">
         <item
             android:id="@+id/action_select_visible_calendars"
             android:icon="@drawable/ic_menu_select_visible_calendars"

--- a/src/com/android/calendar/AllInOneActivity.java
+++ b/src/com/android/calendar/AllInOneActivity.java
@@ -937,7 +937,6 @@ public class AllInOneActivity extends AbstractCalendarActivity implements EventH
                 break;
         }
         mDrawerLayout.closeDrawers();
-        item.setChecked(true);
         return false;
     }
 


### PR DESCRIPTION
When selecting "Calendars to display" or "Settings" in the navigation menu, these items are highlighted after returning to the calendar activity.  IMO the navigation menu should always represent the current calendar view, i.e., hightlighting only Day, Week, Month or Agenda, which is done by this pull request.

Note that the item.setChecked(true) could be removed without substitution since the navigation items are also checked in setMainPane().