### PR TITLE
Fix height in month view

### DIFF
--- a/src/com/android/calendar/month/MonthByWeekAdapter.java
+++ b/src/com/android/calendar/month/MonthByWeekAdapter.java
@@ -261,8 +261,7 @@ public class MonthByWeekAdapter extends SimpleWeeksAdapter {
             selectedDay = mSelectedDay.weekDay;
         }
 
-        drawingParams.put(SimpleWeekView.VIEW_PARAMS_HEIGHT,
-                (parent.getHeight() + (parent.getTop() * 2)) / (mNumWeeks + 1));
+        drawingParams.put(SimpleWeekView.VIEW_PARAMS_HEIGHT, parent.getHeight() / mNumWeeks);
         drawingParams.put(SimpleWeekView.VIEW_PARAMS_SELECTED_DAY, selectedDay);
         drawingParams.put(SimpleWeekView.VIEW_PARAMS_SHOW_WK_NUM, mShowWeekNumber ? 1 : 0);
         drawingParams.put(SimpleWeekView.VIEW_PARAMS_WEEK_START, mFirstDayOfWeek);


### PR DESCRIPTION
Fixes #158.  I hope I didn't miss any side effects this time since the month view is quite complex.

The height of a box in the month view is calculated [here](https://github.com/Etar-Group/Etar-Calendar/blob/master/src/com/android/calendar/month/MonthByWeekAdapter.java#L264) using the formula `(parent.getHeight() + (parent.getTop() * 2)) / (mNumWeeks + 1)`.  The origin of this formula is not clear to me but apparently it sets the height such that _approximately_ `mNumWeeks` boxes are visible.
 
After commit 3ebc9c11fafb3baf212731ec3739ce4ad4c9e583 the toolbar is no longer scrollable and this reduces the result of `parent.getHeight()` leading to the behavior described in #158.  I think the reason is that with a scrollable toolbar the area occupied by the toolbar is included in `parent.getHeight()` since the toolbar could be removed by scrolling.

However, after making the toolbar unscrollable `parent.getHeight()` should give the actual size excluding the area occupied by the toolbar.  Thus, the correct height of the boxes can be calculated by the simple formula `parent.getHeight() / mNumWeeks` as done in this pull request.

This does not restore the exact original behavior but the height of the boxes is now calculated such that `mNumWeeks=6` boxes (and a tiny bit more if you look carefully) are visible.  In the original behavior approximately `mNumWeeks=6` boxes were visible (afaik it can be either more or less depending on the resolution). For comparison see the following screenshots.

Original behavior
![1_scrollable_toolbar](https://cloud.githubusercontent.com/assets/6775792/22906104/5daac74e-f243-11e6-8dfc-c4510243dff3.jpg)

After making the toolbar unscrollable
![2_noscrollable_toolbar](https://cloud.githubusercontent.com/assets/6775792/22906111/662691aa-f243-11e6-89b5-9d33770eee7e.jpg)

Unscrollable toolbar + this pull request
![3_fixheight](https://cloud.githubusercontent.com/assets/6775792/22906131/74750c1e-f243-11e6-86fe-71224e7488a7.jpg)
