### PR TITLE
Set seconds to zero when creating new event

### DIFF
--- a/src/com/android/calendar/AllInOneActivity.java
+++ b/src/com/android/calendar/AllInOneActivity.java
@@ -504,6 +504,7 @@ public class AllInOneActivity extends AbstractCalendarActivity implements EventH
                 //Create new Event
                 Time t = new Time();
                 t.set(mController.getTime());
+                t.second = 0;
                 if (t.minute > 30) {
                     t.hour++;
                     t.minute = 0;


### PR DESCRIPTION
Fixes #13.

When creating a new event using the FloatingActionButton the seconds of the current time are used instead of setting them to zero.  Afaik creating a new event by other means does not show this behavior.

Although seconds are never displayed in Etar it seems reasonable to set them to zero, especially since other programs, with which events are synced, might show them.