### PR TITLE
Allow user to squeeze display so that whole day is visible, amd omit …

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:2.3.0'
     }
 }
 

--- a/src/com/android/calendar/DayView.java
+++ b/src/com/android/calendar/DayView.java
@@ -2469,14 +2469,15 @@ public class DayView extends View implements View.OnCreateContextMenuListener,
     private void drawHours(Rect r, Canvas canvas, Paint p) {
         setupHourTextPaint(p);
 
-        int y = mCellHeight + mHoursTextHeight / 2 + HOUR_GAP;
         int totCellHeight =  mCellHeight + HOUR_GAP;
         int hourStep = (mHoursTextHeight + totCellHeight - 1)/ totCellHeight;
+        int deltaY = hourStep * totCellHeight;
+        int y = deltaY + mHoursTextHeight / 2 - HOUR_GAP;
         //Draw only from 1:00 to 23:00
         for (int i = hourStep; i < 24; i += hourStep) {
             String time = mHourStrs[i];
             canvas.drawText(time, HOURS_LEFT_MARGIN, y, p);
-            y += hourStep * totCellHeight;
+            y += deltaY;
         }
     }
 


### PR DESCRIPTION
Allow user to squeeze display so that whole day is visible, amd omit some hour numbers if they get too close together.

I want to be able to see all my events in the week view, so that I can see if I have any commitments on a particular day. This is viable on devices with high resolution displays, provided you only show every n'th hour number if they get too close together. This patch saves the last cell height set by gesture in the preference, and then adjusts it for each day or week if there are fewer all day events at the top.