### PR TITLE
calendar: fix first notification after boot

### DIFF
--- a/src/com/android/calendar/alerts/AlertService.java
+++ b/src/com/android/calendar/alerts/AlertService.java
@@ -911,7 +911,8 @@ public class AlertService extends Service {
         if (providerReminder ||
                 action.equals(Intent.ACTION_PROVIDER_CHANGED) ||
                 action.equals(android.provider.CalendarContract.ACTION_EVENT_REMINDER) ||
-                action.equals(AlertReceiver.EVENT_REMINDER_APP_ACTION) ||
+                (action.equals(AlertReceiver.EVENT_REMINDER_APP_ACTION) &&
+                 !Boolean.TRUE.equals(sReceivedProviderReminderBroadcast)) ||
                 action.equals(Intent.ACTION_LOCALE_CHANGED)) {
 
             // b/7652098: Add a delay after the provider-changed event before refreshing


### PR DESCRIPTION
AlertService.java has some workaround code for OEMs that
messed up ACTION_EVENT_REMINDER alarms in CalendarProvider by using
an additional EVENT_REMINDER_APP_ACTION alarm. The correct
working of EVENT_REMINDER is detected when the event fires the
first time, and it's saved in a preference item, however not loaded
during init, thus the first calendar event after boot will get
both EVENT_REMINDER and EVENT_REMINDER_APP events.  The result is that
the second event acts as a quiet update which cancels the playback
of the notification sound.  The sound is either not played at all
or starts playing but is cut off after a fraction of a second.

logcat excerpt:
11-30 08:50:02.255  3197  3197 D AlertReceiver: onReceive: a=android.intent.action.EVENT_REMINDER Intent { act=android.intent.action.EVENT_REMINDER dat=content://com.android.calendar/1512028200000 flg=0x14 cmp=com.android.calendar/.alerts.AlertReceiver (has extras) }
11-30 08:50:02.287  3197  3197 D AlertReceiver: onReceive: a=com.android.calendar.EVENT_REMINDER_APP Intent { act=com.android.calendar.EVENT_REMINDER_APP flg=0x14 cmp=com.android.calendar/.alerts.AlertReceiver (has extras) }
11-30 08:50:02.526  2216  7876 D RingtonePlayer: PLAY
11-30 08:50:02.529  3197  7857 D AlertService: Posting individual alarm notification, eventId:62, notificationId:1, LOUD, high-priority
11-30 08:50:02.654  3197  7857 D AlertService: Posting individual alarm notification, eventId:62, notificationId:1, quiet, high-priority
11-30 08:50:02.660  2216  7433 D RingtonePlayer: stopAsync()

Change-Id: I4f420c9804e88eb75bb5c5cce16665190e08e91a

(cherry picked from commit bf88827)