### PR TITLE
Don't save event if onPause() is triggert

### DIFF
--- a/src/com/android/calendar/event/EditEventFragment.java
+++ b/src/com/android/calendar/event/EditEventFragment.java
@@ -568,12 +568,6 @@ public class EditEventFragment extends Fragment implements EventHandler, OnColor
 
     @Override
     public void onPause() {
-        Activity act = getActivity();
-        if (mSaveOnDetach && act != null && !mIsReadOnly && !act.isChangingConfigurations()
-                && mView.prepareForSave()) {
-            mOnDone.setDoneCode(Utils.DONE_SAVE);
-            mOnDone.run();
-        }
         super.onPause();
     }
 


### PR DESCRIPTION
The use of the homebutton during a event creation shouldn't trigger a save event. Fixes #216