### PR TITLE
Close the EditEvent view upon pause

### DIFF
--- a/src/com/android/calendar/event/EditEventFragment.java
+++ b/src/com/android/calendar/event/EditEventFragment.java
@@ -574,6 +574,7 @@ public class EditEventFragment extends Fragment implements EventHandler, OnColor
             mOnDone.setDoneCode(Utils.DONE_SAVE);
             mOnDone.run();
         }
+        act.finish();
         super.onPause();
     }
 


### PR DESCRIPTION
When switching apps, the onPause() function saves the current event. But
if the user switches back, the view is still open and if the save button
is pressed, two events are created. This closes the view, so the user
would have to open it again, to edit it.

An alternative solution would be to create the event only temporary and
not save it in onPause(), as discussed in #361.