### PR TITLE
Calendar: Always set timezone when populating CalendarEventModel

### DIFF
--- a/src/com/android/calendar/event/EditEventHelper.java
+++ b/src/com/android/calendar/event/EditEventHelper.java
@@ -1056,7 +1056,10 @@ public class EditEventHelper {
         model.mCalendarId = cursor.getInt(EVENT_INDEX_CALENDAR_ID);
         model.mStart = cursor.getLong(EVENT_INDEX_DTSTART);
         String tz = cursor.getString(EVENT_INDEX_TIMEZONE);
-        if (!TextUtils.isEmpty(tz)) {
+        if (TextUtils.isEmpty(tz)) {
+            Log.w(TAG, "Query did not return a timezone for the event.");
+            model.mTimezone = TimeZone.getDefault().getID();
+        } else {
             model.mTimezone = tz;
         }
         String rRule = cursor.getString(EVENT_INDEX_RRULE);


### PR DESCRIPTION
An event may not always contain a timezone, leaving the model with a timezone set to null.
This causes the following NullPointerException, so use default timezone if the cursor has none.

java.lang.NullPointerException: key == null
       at libcore.util.BasicLruCache.get(BasicLruCache.java:46)
       at libcore.util.ZoneInfoDB$TzData.makeTimeZone(ZoneInfoDB.java:253)
       at android.text.format.Time$TimeCalculator.lookupZoneInfo(Time.java:1111)
       at android.text.format.Time$TimeCalculator.updateZoneInfoFromTimeZone(Time.java:1105)
       at android.text.format.Time$TimeCalculator.setTimeInMillis(Time.java:1091)
       at android.text.format.Time.set(Time.java:766)
       at com.android.calendar.event.EditEventView.setModel(EditEventView.java:1089)
       at com.android.calendar.event.EditEventFragment.setModelIfDone(EditEventFragment.java:427)
       at com.android.calendar.event.EditEventFragment.-wrap1(EditEventFragment.java)
       at com.android.calendar.event.EditEventFragment$QueryHandler.onQueryComplete(EditEventFragment.java:382)

Change-Id: If215cab45909b01fa39481c6a544abba9dde7baf

(cherry picked from commit 3e2f221)