### PR TITLE
Max number of lines in event made configurable

### DIFF
--- a/res/values-pl/strings.xml
+++ b/res/values-pl/strings.xml
@@ -342,9 +342,10 @@
     <string name="two_hours">2 godziny</string>
     <string name="view_settings">Ustawienia widoku</string>
     <string name="default_start_title">Widok domyślny</string>
-    <string name="view_details">Pokaż szczegóły</string>
-    <string name="display_time">Czas wyświetlania</string>
+    <string name="view_details">Szczegóły widoku</string>
+    <string name="display_time">Wyśietl czas</string>
     <string name="display_location">Wyświetl lokalizację</string>
+    <string name="maximum_number_of_lines">Maksymalna ilość lini w wydarzeniu</string>
     <string name="default_start_last">Poprzednio używany widok</string>
     <string name="error_generating_ics">Podczas udostępniania zdarzenia wystąpiły problemy</string>
     <string name="cal_share_intent_title">Wyślij zdarzenie, aby:</string>
@@ -354,7 +355,7 @@
     <string name="cal_import_error_msg">Importowanie do kalendarza nie powiodło się</string>
     <string name="cal_import_error_date_msg">Nie można zrozumieć podanej daty: %s</string>
     <string name="cal_pick_ics">Wybierz plik do zaimportowania</string>
-    <string name="show_time_no">Nie</string>
+    <string name="show_time_no">Nie wyświetlaj</string>
     <string name="show_time_start">Tylko czas rozpoczęcia</string>
     <string name="show_time_start_end">Czas rozpoczęcia i zakończenia</string>
     <string name="show_time_start_end_below">Czas rozpoczęcia i zakończenia poniżej wydarzenia</string>

--- a/res/values/arrays.xml
+++ b/res/values/arrays.xml
@@ -419,4 +419,13 @@
         <!--<item>"3"</item>-->
         <item>"4"</item>
     </string-array>
+    <string-array name="number_of_lines" translatable="false">
+        <item>"1"</item>
+        <item>"2"</item>
+        <item>"3"</item>
+        <item>"4"</item>
+        <item>"5"</item>
+        <item>"6"</item>
+        <item>"7"</item>
+    </string-array>
 </resources>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -546,9 +546,11 @@
     <string name="preferences_hide_declined_title">Hide declined events</string>
     <!-- Label values for the default start page preference. -->
     <string name="default_start_title">Default view</string>
-    <string name="view_details">View Details</string>
-    <string name="display_time">Display Time</string>
-    <string name="display_location">Display Location</string>
+    <string name="view_details">View details</string>
+    <string name="display_time">Display time</string>
+    <string name="display_location">Display location</string>
+    <string name="maximum_number_of_lines">Max number of lines in event</string>
+
 
     <string name="default_start_last">Previously used view</string>
     <!-- Settings week start label to start week on specific day-->
@@ -839,7 +841,7 @@
     <string name="cal_pick_ics">Pick file to import</string>
 
     <!-- Strings to describe view details array -->
-    <string name="show_time_no">No</string>
+    <string name="show_time_no">Don't show time</string>
     <string name="show_time_start">Only start time</string>
     <string name="show_time_start_end">Start and end time</string>
     <string name="show_time_start_end_below">Start and end time below the event</string>

--- a/res/xml/view_details_preferences.xml
+++ b/res/xml/view_details_preferences.xml
@@ -2,6 +2,13 @@
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
     <PreferenceCategory android:title="@string/preferences_month_view_portrait">
         <ListPreference
+            android:key="pref_number_of_lines_vertical"
+            android:title="@string/maximum_number_of_lines"
+            android:summary="%s"
+            android:entries="@array/number_of_lines"
+            android:entryValues="@array/number_of_lines"
+            android:defaultValue="7" />
+        <ListPreference
             android:key="pref_display_time_vertical"
             android:title="@string/display_time"
             android:summary="%s"
@@ -13,6 +20,13 @@
             android:defaultValue="false" />
     </PreferenceCategory>
     <PreferenceCategory android:title="@string/preferences_month_view_landscape">
+        <ListPreference
+            android:key="pref_number_of_lines_horizontal"
+            android:title="@string/maximum_number_of_lines"
+            android:summary="%s"
+            android:entries="@array/number_of_lines"
+            android:entryValues="@array/number_of_lines"
+            android:defaultValue="7" />
         <ListPreference
             android:key="pref_display_time_horizontal"
             android:title="@string/display_time"

--- a/src/com/android/calendar/CalendarApplication.java
+++ b/src/com/android/calendar/CalendarApplication.java
@@ -17,6 +17,7 @@
 package com.android.calendar;
 
 import android.app.Application;
+import android.content.SharedPreferences;
 
 public class CalendarApplication extends Application {
     @Override
@@ -26,8 +27,17 @@ public class CalendarApplication extends Application {
         /*
          * Ensure the default values are set for any receiver, activity,
          * service, etc. of Calendar
+         * please increment SHARED_PREFS_VERSION each time the new default value appears
+         * in a layout xml file in order to make sure it will be initialized
          */
-        GeneralPreferences.setDefaultValues(this);
+        final int SHARED_PREFS_VERSION = 1;
+        final String VERSION_KEY = "spv";
+        SharedPreferences preferences = GeneralPreferences.getSharedPreferences(this);
+        if (preferences.getInt(VERSION_KEY, 0) != SHARED_PREFS_VERSION) {
+            GeneralPreferences.setDefaultValues(this);
+            ViewDetailsPreferences.setDefaultValues(this);
+            preferences.edit().putInt(VERSION_KEY, SHARED_PREFS_VERSION).apply();
+        }
 
         // Save the version number, for upcoming 'What's new' screen.  This will be later be
         // moved to that implementation.

--- a/src/com/android/calendar/GeneralPreferences.java
+++ b/src/com/android/calendar/GeneralPreferences.java
@@ -153,10 +153,10 @@ public class GeneralPreferences extends PreferenceFragment implements
     public static void setDefaultValues(Context context) {
         if (Utils.isOreoOrLater()) {
             PreferenceManager.setDefaultValues(context, SHARED_PREFS_NAME, Context.MODE_PRIVATE,
-                R.xml.general_preferences_oreo_and_up, false);
+                R.xml.general_preferences_oreo_and_up, true);
         } else {
             PreferenceManager.setDefaultValues(context, SHARED_PREFS_NAME, Context.MODE_PRIVATE,
-                    R.xml.general_preferences, false);
+                    R.xml.general_preferences, true);
         }
     }
 

--- a/src/com/android/calendar/ViewDetailsPreferences.java
+++ b/src/com/android/calendar/ViewDetailsPreferences.java
@@ -1,29 +1,33 @@
 package com.android.calendar;
 
+import android.app.Activity;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.content.res.Configuration;
 import android.os.Bundle;
+import android.preference.CheckBoxPreference;
 import android.preference.ListPreference;
 import android.preference.PreferenceFragment;
 import android.preference.PreferenceManager;
 import android.preference.PreferenceScreen;
 
+import java.util.Arrays;
+
 import ws.xsoh.etar.R;
 
 
 public class ViewDetailsPreferences extends PreferenceFragment {
-    protected final static boolean DISPLAY_LOCATION_DEFAULT = false;
+    private final static String KEY_DISPLAY_TIME_V_PREF = "pref_display_time_vertical";
+    private final static String KEY_DISPLAY_TIME_H_PREF = "pref_display_time_horizontal";
+    private final static String KEY_DISPLAY_LOCATION_V_PREF = "pref_display_location_vertical";
+    private final static String KEY_DISPLAY_LOCATION_H_PREF = "pref_display_location_horizontal";
+    private final static String KEY_MAX_NUMBER_OF_LINES_V_PREF = "pref_number_of_lines_vertical";
+    private final static String KEY_MAX_NUMBER_OF_LINES_H_PREF = "pref_number_of_lines_horizontal";
+    private final static PreferenceKeys LANDSCAPE_PREFS = new PreferenceKeys(KEY_DISPLAY_TIME_H_PREF, KEY_DISPLAY_LOCATION_H_PREF, KEY_MAX_NUMBER_OF_LINES_H_PREF);
+    private final static PreferenceKeys PORTRAIT_PREFS = new PreferenceKeys(KEY_DISPLAY_TIME_V_PREF, KEY_DISPLAY_LOCATION_V_PREF, KEY_MAX_NUMBER_OF_LINES_V_PREF);
 
-    protected final static String KEY_DISPLAY_TIME_V_PREF = "pref_display_time_vertical";
-    protected final static String KEY_DISPLAY_TIME_H_PREF = "pref_display_time_horizontal";
-    protected final static String KEY_DISPLAY_LOCATION_V_PREF = "pref_display_location_vertical";
-    protected final static String KEY_DISPLAY_LOCATION_H_PREF = "pref_display_location_horizontal";
-    protected final static PreferenceKeys LANDSCAPE_PREFS = new PreferenceKeys(KEY_DISPLAY_TIME_H_PREF, KEY_DISPLAY_LOCATION_H_PREF);
-    protected final static PreferenceKeys PORTRAIT_PREFS = new PreferenceKeys(KEY_DISPLAY_TIME_V_PREF, KEY_DISPLAY_LOCATION_V_PREF);
-
-    protected ListPreference mDisplayTimeH;
-    protected ListPreference mDisplayTimeV;
+    private PreferenceConfiguration mLandscapeConf = new PreferenceConfiguration(LANDSCAPE_PREFS);
+    private PreferenceConfiguration mPortraitConf = new PreferenceConfiguration(PORTRAIT_PREFS);
 
     public enum TimeVisibility {
         SHOW_NONE(0),
@@ -39,26 +43,89 @@ public class ViewDetailsPreferences extends PreferenceFragment {
             return mValue;
         }
     }
-    protected static class PreferenceKeys {
-        public final String KEY_DISPLAY_TIME;
-        public final String KEY_DISPLAY_LOCATION;
-
-        public PreferenceKeys(String keyDisplayTime, String keyDisplayLocation) {
+    private static class PreferenceKeys {
+        final String KEY_DISPLAY_TIME;
+        final String KEY_DISPLAY_LOCATION;
+        final String KEY_MAX_NUMBER_OF_LINES;
+        PreferenceKeys(String keyDisplayTime, String keyDisplayLocation, String keyMaxNumberOfLInes) {
             KEY_DISPLAY_TIME = keyDisplayTime;
             KEY_DISPLAY_LOCATION = keyDisplayLocation;
+            KEY_MAX_NUMBER_OF_LINES = keyMaxNumberOfLInes;
+        }
+    }
+
+    protected static class PreferenceConfiguration {
+        PreferenceKeys mKeys;
+        ListPreference mDisplayTime;
+        ListPreference mMaxLines;
+        CheckBoxPreference mDisplayLocation;
+
+        PreferenceConfiguration(PreferenceKeys keys) {
+            mKeys = keys;
+        }
+
+        void onCreate(PreferenceScreen preferenceScreen, Activity activity)
+        {
+            mDisplayTime = (ListPreference) preferenceScreen.findPreference(mKeys.KEY_DISPLAY_TIME);
+            mMaxLines = (ListPreference) preferenceScreen.findPreference(mKeys.KEY_MAX_NUMBER_OF_LINES);
+            mDisplayLocation = (CheckBoxPreference) preferenceScreen.findPreference(mKeys.KEY_DISPLAY_LOCATION);
+            initDisplayTime(activity);
+        }
+        private void initDisplayTime(Activity activity) {
+            if (!Utils.getConfigBool(activity, R.bool.show_time_in_month)) {
+                CharSequence[] entries = mDisplayTime.getEntries();
+                CharSequence[] newEntries = Arrays.copyOf(entries, entries.length-1);
+                mDisplayTime.setEntries(newEntries);
+            }
+            if (mDisplayTime.getEntry() == null || mDisplayTime.getEntry().length() == 0) {
+                mDisplayTime.setValue(getDefaultTimeToShow(activity).toString());
+            }
+        }
+    }
+    static class DynamicPreferences {
+        private Context mContext;
+        private SharedPreferences mPrefs;
+        DynamicPreferences(Context context)
+        {
+            mContext = context;
+            mPrefs = GeneralPreferences.getSharedPreferences(context);
+        }
+        PreferenceKeys getPreferenceKeys() {
+            int orientation = mContext.getResources().getConfiguration().orientation;
+            boolean landscape = (orientation == Configuration.ORIENTATION_LANDSCAPE);
+            return landscape ? LANDSCAPE_PREFS : PORTRAIT_PREFS;
+        }
+        TimeVisibility getTimeVisibility(PreferenceKeys keys) {
+            String visibility = mPrefs.getString(keys.KEY_DISPLAY_TIME, getDefaultTimeToShow(mContext).toString());
+            return TimeVisibility.values()[Integer.parseInt(visibility)];
+        }
+        boolean getShowLocation(PreferenceKeys keys) {
+            return mPrefs.getBoolean(keys.KEY_DISPLAY_LOCATION, false);
+        }
+        Integer getMaxNumberOfLines(PreferenceKeys keys) {
+            return Integer.parseInt(mPrefs.getString(keys.KEY_MAX_NUMBER_OF_LINES, null));
         }
     }
     public static class Preferences {
         public final TimeVisibility TIME_VISIBILITY;
-        public final boolean SHOW_LOCATION;
+        public final boolean LOCATION_VISIBILITY;
+        public final int MAX_LINES;
 
-        protected Preferences(TimeVisibility timeVisibility, boolean showLocation) {
-            TIME_VISIBILITY = timeVisibility;
-            SHOW_LOCATION = showLocation;
+        protected Preferences(Context context) {
+            DynamicPreferences prefs = new DynamicPreferences(context);
+            PreferenceKeys keys = prefs.getPreferenceKeys();
+            TIME_VISIBILITY = prefs.getTimeVisibility(keys);
+            LOCATION_VISIBILITY = prefs.getShowLocation(keys);
+            MAX_LINES = prefs.getMaxNumberOfLines(keys);
+        }
+        private Preferences(Preferences prefs) {
+            TIME_VISIBILITY = TimeVisibility.SHOW_NONE;
+            LOCATION_VISIBILITY = prefs.LOCATION_VISIBILITY;
+            MAX_LINES = prefs.MAX_LINES;
         }
         public Preferences hideTime() {
             if (TIME_VISIBILITY == TimeVisibility.SHOW_TIME_RANGE_BELOW) {
-                return new Preferences(TimeVisibility.SHOW_NONE, SHOW_LOCATION);
+                return new Preferences(this);
             }
             return this;
         }
@@ -79,31 +146,6 @@ public class ViewDetailsPreferences extends PreferenceFragment {
             return (TIME_VISIBILITY == TimeVisibility.SHOW_START_TIME_AND_DURATION);
         }
     }
-    protected static class PreferenceFactory {
-        protected SharedPreferences mPrefs;
-        protected Context mContext;
-
-        public PreferenceFactory(Context context) {
-            mContext = context;
-            mPrefs = GeneralPreferences.getSharedPreferences(context);
-        }
-        public PreferenceKeys getPreferenceKeys() {
-            int orientation = mContext.getResources().getConfiguration().orientation;
-            boolean landscape = (orientation == Configuration.ORIENTATION_LANDSCAPE);
-            return landscape ? LANDSCAPE_PREFS : PORTRAIT_PREFS;
-        }
-        protected TimeVisibility getTimeVisibility(PreferenceKeys keys) {
-            String visibility = mPrefs.getString(keys.KEY_DISPLAY_TIME, getDefaultTimeToShow(mContext).toString());
-            return TimeVisibility.values()[Integer.parseInt(visibility)];
-        }
-        protected boolean getShowTime(PreferenceKeys keys) {
-            return mPrefs.getBoolean(keys.KEY_DISPLAY_LOCATION, DISPLAY_LOCATION_DEFAULT);
-        }
-        public Preferences getPreferences() {
-            PreferenceKeys keys = getPreferenceKeys();
-            return new Preferences(getTimeVisibility(keys), getShowTime(keys));
-        }
-    }
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
@@ -112,9 +154,9 @@ public class ViewDetailsPreferences extends PreferenceFragment {
         preferenceManager.setSharedPreferencesName(GeneralPreferences.SHARED_PREFS_NAME);
         addPreferencesFromResource(R.xml.view_details_preferences);
         PreferenceScreen preferenceScreen = getPreferenceScreen();
-        mDisplayTimeH = (ListPreference) preferenceScreen.findPreference(KEY_DISPLAY_TIME_H_PREF);
-        mDisplayTimeV = (ListPreference) preferenceScreen.findPreference(KEY_DISPLAY_TIME_V_PREF);
-        initDisplayTime();
+        Activity activity = getActivity();
+        mLandscapeConf.onCreate(preferenceScreen, activity);
+        mPortraitConf.onCreate(preferenceScreen, activity);
     }
 
     protected static Integer getDefaultTimeToShow(Context context) {
@@ -122,26 +164,12 @@ public class ViewDetailsPreferences extends PreferenceFragment {
                 TimeVisibility.SHOW_TIME_RANGE_BELOW.getValue() : TimeVisibility.SHOW_NONE.getValue();
     }
 
-    protected void initDisplayTime() {
-        if (!Utils.getConfigBool(getActivity(), R.bool.show_time_in_month)) {
-            CharSequence[] entries = mDisplayTimeH.getEntries();
-            CharSequence[] newEntries = new CharSequence[entries.length - 1];
-            for (int i = 0; i < newEntries.length; ++i) {
-                newEntries[i] = entries[i];
-            }
-            mDisplayTimeH.setEntries(newEntries);
-            mDisplayTimeV.setEntries(newEntries);
-        }
-        if (mDisplayTimeH.getEntry() == null || mDisplayTimeH.getEntry().length() == 0) {
-            mDisplayTimeH.setValue(getDefaultTimeToShow(getActivity()).toString());
-        }
-        if (mDisplayTimeV.getEntry() == null || mDisplayTimeV.getEntry().length() == 0) {
-            mDisplayTimeV.setValue(getDefaultTimeToShow(getActivity()).toString());
-        }
+    public static Preferences getPreferences(Context context) {
+        return new Preferences(context);
     }
 
-    public static Preferences getPreferences(Context context) {
-        //consider using static factory instead
-        return new PreferenceFactory(context).getPreferences();
+    public static void setDefaultValues(Context context) {
+        PreferenceManager.setDefaultValues(context, GeneralPreferences.SHARED_PREFS_NAME, Context.MODE_PRIVATE,
+                    R.xml.view_details_preferences, true);
     }
 }

--- a/src/com/android/calendar/ViewDetailsPreferences.java
+++ b/src/com/android/calendar/ViewDetailsPreferences.java
@@ -5,7 +5,6 @@ import android.content.Context;
 import android.content.SharedPreferences;
 import android.content.res.Configuration;
 import android.os.Bundle;
-import android.preference.CheckBoxPreference;
 import android.preference.ListPreference;
 import android.preference.PreferenceFragment;
 import android.preference.PreferenceManager;
@@ -44,9 +43,9 @@ public class ViewDetailsPreferences extends PreferenceFragment {
         }
     }
     private static class PreferenceKeys {
-        final String KEY_DISPLAY_TIME;
-        final String KEY_DISPLAY_LOCATION;
-        final String KEY_MAX_NUMBER_OF_LINES;
+        protected final String KEY_DISPLAY_TIME;
+        protected final String KEY_DISPLAY_LOCATION;
+        protected final String KEY_MAX_NUMBER_OF_LINES;
         PreferenceKeys(String keyDisplayTime, String keyDisplayLocation, String keyMaxNumberOfLInes) {
             KEY_DISPLAY_TIME = keyDisplayTime;
             KEY_DISPLAY_LOCATION = keyDisplayLocation;
@@ -55,20 +54,16 @@ public class ViewDetailsPreferences extends PreferenceFragment {
     }
 
     protected static class PreferenceConfiguration {
-        PreferenceKeys mKeys;
-        ListPreference mDisplayTime;
-        ListPreference mMaxLines;
-        CheckBoxPreference mDisplayLocation;
+        private PreferenceKeys mKeys;
+        private ListPreference mDisplayTime;
 
         PreferenceConfiguration(PreferenceKeys keys) {
             mKeys = keys;
         }
 
-        void onCreate(PreferenceScreen preferenceScreen, Activity activity)
+        protected void onCreate(PreferenceScreen preferenceScreen, Activity activity)
         {
             mDisplayTime = (ListPreference) preferenceScreen.findPreference(mKeys.KEY_DISPLAY_TIME);
-            mMaxLines = (ListPreference) preferenceScreen.findPreference(mKeys.KEY_MAX_NUMBER_OF_LINES);
-            mDisplayLocation = (CheckBoxPreference) preferenceScreen.findPreference(mKeys.KEY_DISPLAY_LOCATION);
             initDisplayTime(activity);
         }
         private void initDisplayTime(Activity activity) {
@@ -90,19 +85,19 @@ public class ViewDetailsPreferences extends PreferenceFragment {
             mContext = context;
             mPrefs = GeneralPreferences.getSharedPreferences(context);
         }
-        PreferenceKeys getPreferenceKeys() {
+        public PreferenceKeys getPreferenceKeys() {
             int orientation = mContext.getResources().getConfiguration().orientation;
             boolean landscape = (orientation == Configuration.ORIENTATION_LANDSCAPE);
             return landscape ? LANDSCAPE_PREFS : PORTRAIT_PREFS;
         }
-        TimeVisibility getTimeVisibility(PreferenceKeys keys) {
+        public TimeVisibility getTimeVisibility(PreferenceKeys keys) {
             String visibility = mPrefs.getString(keys.KEY_DISPLAY_TIME, getDefaultTimeToShow(mContext).toString());
             return TimeVisibility.values()[Integer.parseInt(visibility)];
         }
-        boolean getShowLocation(PreferenceKeys keys) {
+        public boolean getShowLocation(PreferenceKeys keys) {
             return mPrefs.getBoolean(keys.KEY_DISPLAY_LOCATION, false);
         }
-        Integer getMaxNumberOfLines(PreferenceKeys keys) {
+        public Integer getMaxNumberOfLines(PreferenceKeys keys) {
             return Integer.parseInt(mPrefs.getString(keys.KEY_MAX_NUMBER_OF_LINES, null));
         }
     }

--- a/src/com/android/calendar/month/MonthWeekEventsView.java
+++ b/src/com/android/calendar/month/MonthWeekEventsView.java
@@ -104,7 +104,6 @@ public class MonthWeekEventsView extends SimpleWeekView {
     private static int mStrokeWidthAdj;
     private static boolean mInitialized = false;
     private static boolean mShowDetailsInMonth;
-    private static int mMaxLinesInEvent = 7; //todo - should be configurable
     private final TodayAnimatorListener mAnimatorListener = new TodayAnimatorListener();
     protected Time mToday = new Time();
     protected boolean mHasToday = false;
@@ -1016,9 +1015,9 @@ public class MonthWeekEventsView extends SimpleWeekView {
          * Initializes members storing information about events in mEventDay
          */
         protected void init() {
-            mMaxNumberOfLines = mMaxLinesInEvent;
-            mEventsByHeight = new ArrayList<>(mMaxLinesInEvent + 1);
-            for (int i = 0; i < mMaxLinesInEvent + 1; i++) {
+            mMaxNumberOfLines = mViewPreferences.MAX_LINES;
+            mEventsByHeight = new ArrayList<>(mMaxNumberOfLines + 1);
+            for (int i = 0; i < mMaxNumberOfLines + 1; i++) {
                 mEventsByHeight.add(new ArrayList<FormattedEventBase>());
             }
             ListIterator<FormattedEventBase> iterator = mEventDay.listIterator();
@@ -1537,7 +1536,7 @@ public class MonthWeekEventsView extends SimpleWeekView {
                 if (span == 1) {
                     /* make events higher only if they are not spanning multiple days to avoid
                         tricky situations */
-                    mFormat.setEventLines(Math.min(mTextLayout.getLineCount(), mMaxLinesInEvent));
+                    mFormat.setEventLines(Math.min(mTextLayout.getLineCount(), preferences.MAX_LINES));
                 }
             }
         }
@@ -1553,7 +1552,7 @@ public class MonthWeekEventsView extends SimpleWeekView {
                 baseText.append(" ");
             }
             baseText.append(mEvent.title);
-            if (preferences.SHOW_LOCATION && mEvent.location != null && mEvent.location.length() > 0) {
+            if (preferences.LOCATION_VISIBILITY && mEvent.location != null && mEvent.location.length() > 0) {
                 baseText.append("\n@ ");
                 baseText.append(mEvent.location);
             }


### PR DESCRIPTION
I have fixed Polish translations to better match the context and intention of settings.
But I have also changed the text of "show_time_no" (I'm not sure if it was the right thing to do, but I suppose that it looks better now).

I also had to add a mechanism to allow updating of xml files containing default settings (previously if the file was updated, the default value wound not be loaded into shared prefs, simple changing the "readAgain" to true would on the other hand force it to parse the file on every re-setart).