### PR TITLE
AOSP/Calendar - Fix improperly formatted resource string in Calendar.

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -43,7 +43,7 @@
     <string name="tomorrow_at_time_fmt">"Tomorrow at <xliff:g id="time_interval">%s</xliff:g>"</string>
     <!-- Format string for a date and time description.  For ex:
          "April 19, 2012, 3:00pm - 4:00pm" [CHAR LIMIT=NONE] -->
-    <string name="date_time_fmt">"<xliff:g id="date">%s</xliff:g>, <xliff:g id="time_interval">%s</xliff:g>"</string>
+    <string name="date_time_fmt">"<xliff:g id="date">%1$s</xliff:g>, <xliff:g id="time_interval">%2$s</xliff:g>"</string>
 
     <!-- Some events repeat daily, weekly, monthly, or yearly.  This is the label
          for all the choices about how often an event repeats (including the choice


### PR DESCRIPTION
TODO: Need to run translation to fix across all languages.

Bug: 135613806

Test: manual - Did a "make -j40" and verified that there are no warnings in strings.xml.
Change-Id: Idb9666ee2153464152a25d48608a13fdc641222e