### PR TITLE
move foreground notification to own channel

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -248,6 +248,10 @@
     <string name="alert_title">Calendar notifications</string>
     <!-- Notification window messages: -->
     <skip/>
+    <string name="foreground_notification_channel_name">Calendar Sync</string>
+    <string name="foreground_notification_channel_description">
+        Foreground notification required for calendar sync
+    </string>
 
     <!-- Event info/edit screen labels:-->
     <skip/>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -248,9 +248,9 @@
     <string name="alert_title">Calendar notifications</string>
     <!-- Notification window messages: -->
     <skip/>
-    <string name="foreground_notification_channel_name">Calendar Sync</string>
+    <string name="foreground_notification_channel_name">Alert Sync</string>
     <string name="foreground_notification_channel_description">
-        Foreground notification required for calendar sync
+        Foreground notification required for internal alert sync. Please mute
     </string>
 
     <!-- Event info/edit screen labels:-->

--- a/src/com/android/calendar/AllInOneActivity.java
+++ b/src/com/android/calendar/AllInOneActivity.java
@@ -95,6 +95,7 @@ import static android.provider.CalendarContract.EXTRA_EVENT_ALL_DAY;
 import static android.provider.CalendarContract.EXTRA_EVENT_BEGIN_TIME;
 import static android.provider.CalendarContract.EXTRA_EVENT_END_TIME;
 import static com.android.calendar.alerts.AlertService.ALERT_CHANNEL_ID;
+import static com.android.calendar.alerts.AlertService.FOREGROUND_CHANNEL_ID;
 
 public class AllInOneActivity extends AbstractCalendarActivity implements EventHandler,
         OnSharedPreferenceChangeListener, SearchView.OnQueryTextListener, SearchView.OnSuggestionListener, NavigationView.OnNavigationItemSelectedListener {
@@ -265,9 +266,20 @@ public class AllInOneActivity extends AbstractCalendarActivity implements EventH
         NotificationMgr nm = new AlertService.NotificationMgrWrapper(
                 (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE));
         if (Utils.isOreoOrLater()) {
-            String appName = this.getString(R.string.standalone_app_label);
-            NotificationChannel channel  = new NotificationChannel(ALERT_CHANNEL_ID, appName, NotificationManager.IMPORTANCE_HIGH);
+            NotificationChannel channel  = new NotificationChannel(
+                    ALERT_CHANNEL_ID,
+                    this.getString(R.string.standalone_app_label),
+                    NotificationManager.IMPORTANCE_HIGH);
+
+            NotificationChannel foregroundChannel = new NotificationChannel(
+                    FOREGROUND_CHANNEL_ID,
+                    this.getString(R.string.foreground_notification_channel_name),
+                    NotificationManager.IMPORTANCE_LOW);
+            foregroundChannel.setDescription(
+                    this.getString(R.string.foreground_notification_channel_description));
+
             nm.createNotificationChannel(channel);
+            nm.createNotificationChannel(foregroundChannel);
         }
 
         // Check and ask for most needed permissions

--- a/src/com/android/calendar/alerts/AlertService.java
+++ b/src/com/android/calendar/alerts/AlertService.java
@@ -66,6 +66,7 @@ import ws.xsoh.etar.R;
 public class AlertService extends Service {
 
     public static final String ALERT_CHANNEL_ID = "alert_channel_01";// The id of the channel.
+    public static final String FOREGROUND_CHANNEL_ID = "foreground_channel_01";
 
     // Hard limit to the number of notifications displayed.
     public static final int MAX_NOTIFICATIONS = 20;
@@ -983,7 +984,7 @@ public class AlertService extends Service {
         if (intent != null) {
 
             if (Utils.isOreoOrLater()) {
-                Notification notification = new NotificationCompat.Builder(this, ALERT_CHANNEL_ID)
+                Notification notification = new NotificationCompat.Builder(this, FOREGROUND_CHANNEL_ID)
                         .setContentTitle("Event notifications")
                         .setSmallIcon(R.drawable.stat_notify_calendar)
                         .setShowWhen(false)


### PR DESCRIPTION
Since the android 10 update rolled out, my phone buzzes every time the foreground service runs and it's been driving me bonkers. This commit moves the foreground service notification to its own notification channel and sets the priority to low, so it shouldn't make noise anymore. You can also hide the notification completely this way.
I did look into the JobIntentService solution from #520, but wasn't able to get that working.