### PR TITLE
create notification channels before using

### DIFF
--- a/src/com/android/calendar/AllInOneActivity.java
+++ b/src/com/android/calendar/AllInOneActivity.java
@@ -263,24 +263,7 @@ public class AllInOneActivity extends AbstractCalendarActivity implements EventH
         mController = CalendarController.getInstance(this);
 
         // Create notification channel
-        NotificationMgr nm = new AlertService.NotificationMgrWrapper(
-                (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE));
-        if (Utils.isOreoOrLater()) {
-            NotificationChannel channel  = new NotificationChannel(
-                    ALERT_CHANNEL_ID,
-                    this.getString(R.string.standalone_app_label),
-                    NotificationManager.IMPORTANCE_HIGH);
-
-            NotificationChannel foregroundChannel = new NotificationChannel(
-                    FOREGROUND_CHANNEL_ID,
-                    this.getString(R.string.foreground_notification_channel_name),
-                    NotificationManager.IMPORTANCE_LOW);
-            foregroundChannel.setDescription(
-                    this.getString(R.string.foreground_notification_channel_description));
-
-            nm.createNotificationChannel(channel);
-            nm.createNotificationChannel(foregroundChannel);
-        }
+        AlertService.createChannels(this);
 
         // Check and ask for most needed permissions
         checkAppPermissions();

--- a/src/com/android/calendar/alerts/AlertService.java
+++ b/src/com/android/calendar/alerts/AlertService.java
@@ -984,6 +984,8 @@ public class AlertService extends Service {
         if (intent != null) {
 
             if (Utils.isOreoOrLater()) {
+
+                createChannels(this);
                 Notification notification = new NotificationCompat.Builder(this, FOREGROUND_CHANNEL_ID)
                         .setContentTitle("Event notifications")
                         .setSmallIcon(R.drawable.stat_notify_calendar)
@@ -1008,6 +1010,29 @@ public class AlertService extends Service {
     @Override
     public IBinder onBind(Intent intent) {
         return null;
+    }
+
+    public static void createChannels(Context context) {
+        if (Utils.isOreoOrLater()) {
+            // Create notification channel
+            NotificationMgr nm = new NotificationMgrWrapper(
+                    (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE));
+
+            NotificationChannel channel  = new NotificationChannel(
+                    ALERT_CHANNEL_ID,
+                    context.getString(R.string.standalone_app_label),
+                    NotificationManager.IMPORTANCE_HIGH);
+
+            NotificationChannel foregroundChannel = new NotificationChannel(
+                    FOREGROUND_CHANNEL_ID,
+                    context.getString(R.string.foreground_notification_channel_name),
+                    NotificationManager.IMPORTANCE_LOW);
+            foregroundChannel.setDescription(
+                    context.getString(R.string.foreground_notification_channel_description));
+
+            nm.createNotificationChannel(channel);
+            nm.createNotificationChannel(foregroundChannel);
+        }
     }
 
     // Added wrapper for testing


### PR DESCRIPTION
Moves notification channel creation into AlertService.java so it can be done before sending foreground notifications.
Fixes #517 