### PR TITLE
Local calendars: Remove events from database, not just mark them deleted

### DIFF
--- a/src/com/android/calendar/CalendarEventModel.java
+++ b/src/com/android/calendar/CalendarEventModel.java
@@ -61,7 +61,7 @@ public class CalendarEventModel implements Serializable {
     public String mCalendarAllowedAttendeeTypes;
     public String mCalendarAllowedAvailability;
     public String mSyncId = null;
-    public String mSyncAccount = null;
+    public String mSyncAccountName = null;
     public String mSyncAccountType = null;
     public EventColorCache mEventColorCache;
     // PROVIDER_NOTES owner account comes from the calendars table
@@ -232,7 +232,7 @@ public class CalendarEventModel implements Serializable {
         mEventColorInitialized = false;
 
         mSyncId = null;
-        mSyncAccount = null;
+        mSyncAccountName = null;
         mSyncAccountType = null;
         mOwnerAccount = null;
 
@@ -349,7 +349,7 @@ public class CalendarEventModel implements Serializable {
         result = prime * result + mSelfAttendeeStatus;
         result = prime * result + mOwnerAttendeeId;
         result = prime * result + (int) (mStart ^ (mStart >>> 32));
-        result = prime * result + ((mSyncAccount == null) ? 0 : mSyncAccount.hashCode());
+        result = prime * result + ((mSyncAccountName == null) ? 0 : mSyncAccountName.hashCode());
         result = prime * result + ((mSyncAccountType == null) ? 0 : mSyncAccountType.hashCode());
         result = prime * result + ((mSyncId == null) ? 0 : mSyncId.hashCode());
         result = prime * result + ((mTimezone == null) ? 0 : mTimezone.hashCode());
@@ -639,11 +639,11 @@ public class CalendarEventModel implements Serializable {
         if (mOwnerAttendeeId != originalModel.mOwnerAttendeeId) {
             return false;
         }
-        if (mSyncAccount == null) {
-            if (originalModel.mSyncAccount != null) {
+        if (mSyncAccountName == null) {
+            if (originalModel.mSyncAccountName != null) {
                 return false;
             }
-        } else if (!mSyncAccount.equals(originalModel.mSyncAccount)) {
+        } else if (!mSyncAccountName.equals(originalModel.mSyncAccountName)) {
             return false;
         }
 

--- a/src/com/android/calendar/event/EditEventHelper.java
+++ b/src/com/android/calendar/event/EditEventHelper.java
@@ -90,7 +90,9 @@ public class EditEventHelper {
             Events.STATUS, // 21
             Events.CALENDAR_COLOR, // 22
             Events.EVENT_COLOR, // 23
-            Events.EVENT_COLOR_KEY // 24
+            Events.EVENT_COLOR_KEY, // 24
+            Events.ACCOUNT_NAME, // 25
+            Events.ACCOUNT_TYPE // 26
     };
     protected static final int EVENT_INDEX_ID = 0;
     protected static final int EVENT_INDEX_TITLE = 1;
@@ -117,6 +119,8 @@ public class EditEventHelper {
     protected static final int EVENT_INDEX_CALENDAR_COLOR = 22;
     protected static final int EVENT_INDEX_EVENT_COLOR = 23;
     protected static final int EVENT_INDEX_EVENT_COLOR_KEY = 24;
+    protected static final int EVENT_INDEX_ACCOUNT_NAME = 25;
+    protected static final int EVENT_INDEX_ACCOUNT_TYPE = 26;
 
     public static final String[] REMINDERS_PROJECTION = new String[] {
             Reminders._ID, // 0
@@ -1065,6 +1069,8 @@ public class EditEventHelper {
         String rRule = cursor.getString(EVENT_INDEX_RRULE);
         model.mRrule = rRule;
         model.mSyncId = cursor.getString(EVENT_INDEX_SYNC_ID);
+        model.mSyncAccountName = cursor.getString(EVENT_INDEX_ACCOUNT_NAME);
+        model.mSyncAccountType = cursor.getString(EVENT_INDEX_ACCOUNT_TYPE);
         model.mAvailability = cursor.getInt(EVENT_INDEX_AVAILABILITY);
         int accessLevel = cursor.getInt(EVENT_INDEX_ACCESS_LEVEL);
         model.mOwnerAccount = cursor.getString(EVENT_INDEX_OWNER_ACCOUNT);


### PR DESCRIPTION
If an event is part of a local calendar, really remove it from the database by making the operation as a sync adapter.

Related issue: https://github.com/SufficientlySecure/calendar-import-export/issues/44

> There are two versions of delete: as an app and as a sync adapter.
> An app delete will set the deleted column on an event and remove all instances of that event.
> A sync adapter delete will remove the event from the database and all associated data."

from https://developer.android.com/reference/android/provider/CalendarContract.Events