### PR TITLE
Calendar settings: show number of events and reorder elements

### DIFF
--- a/res/values-de/strings.xml
+++ b/res/values-de/strings.xml
@@ -302,7 +302,6 @@
     <string name="preferences_calendar_account">%1$s Konto</string>
     <string name="preferences_calendar_delete">Kalender löschen</string>
     <string name="preferences_calendar_display_name">Namen ändern</string>
-    <string name="preferences_calendar_account_category">Kontoart</string>
     <string name="preferences_calendar_color">Farbe</string>
     <string name="preferences_calendar_visible">Ereignisse anzeigen</string>
     <string name="preferences_calendar_synchronize">Kalender synchronisieren</string>

--- a/res/values-es/strings.xml
+++ b/res/values-es/strings.xml
@@ -307,7 +307,6 @@
     <string name="preferences_calendar_account">Cuenta %1$s</string>
     <string name="preferences_calendar_delete">Borrar calendario</string>
     <string name="preferences_calendar_display_name">Cambiar nombre</string>
-    <string name="preferences_calendar_account_category">Tipo de cuenta</string>
     <string name="preferences_calendar_color">Color</string>
     <string name="preferences_calendar_visible">Mostrar eventos</string>
     <string name="preferences_calendar_synchronize">Sincronizar este calendario</string>

--- a/res/values-hr/strings.xml
+++ b/res/values-hr/strings.xml
@@ -318,7 +318,6 @@
     <string name="preferences_calendar_account">%1$s račun</string>
     <string name="preferences_calendar_delete">Izbriši kalendar</string>
     <string name="preferences_calendar_display_name">Promijeni ime</string>
-    <string name="preferences_calendar_account_category">Vrsta računa</string>
     <string name="preferences_calendar_color">Boja</string>
     <string name="preferences_calendar_visible">Prikaži događaje</string>
     <string name="preferences_calendar_synchronize">Sinkroniziraj ovaj kalendar</string>

--- a/res/values-in/strings.xml
+++ b/res/values-in/strings.xml
@@ -292,7 +292,6 @@
     <string name="preferences_calendar_account">%1$s akun</string>
     <string name="preferences_calendar_delete">Hapus kalender</string>
     <string name="preferences_calendar_display_name">Ubah nama</string>
-    <string name="preferences_calendar_account_category">Tipe akun</string>
     <string name="preferences_calendar_color">Warna</string>
     <string name="preferences_calendar_visible">Tampilkan acara</string>
     <string name="preferences_calendar_synchronize">Sinkronkan kalender ini</string>

--- a/res/values-nb/strings.xml
+++ b/res/values-nb/strings.xml
@@ -303,7 +303,6 @@
     <string name="preferences_calendar_account">%1$s konto</string>
     <string name="preferences_calendar_delete">Slett kalender</string>
     <string name="preferences_calendar_display_name">Endre navn</string>
-    <string name="preferences_calendar_account_category">Kontotype</string>
     <string name="preferences_calendar_color">Farge</string>
     <string name="preferences_calendar_visible">Vis aktiviteter</string>
     <string name="preferences_calendar_synchronize">Synkroniser denne kalenderen</string>

--- a/res/values-ru/strings.xml
+++ b/res/values-ru/strings.xml
@@ -318,7 +318,6 @@
     <string name="preferences_calendar_account">Аккаунт %1$s</string>
     <string name="preferences_calendar_delete">Удалить календарь</string>
     <string name="preferences_calendar_display_name">Переименовать</string>
-    <string name="preferences_calendar_account_category">Тип аккаунта</string>
     <string name="preferences_calendar_color">Цвет</string>
     <string name="preferences_calendar_visible">Отображение событий</string>
     <string name="preferences_calendar_synchronize">Синхронизировать этот календарь</string>

--- a/res/values-tr/strings.xml
+++ b/res/values-tr/strings.xml
@@ -305,7 +305,6 @@
     <string name="preferences_calendar_account">%1$s hesap</string>
     <string name="preferences_calendar_delete">Takvimi sil</string>
     <string name="preferences_calendar_display_name">İsmini değiştir</string>
-    <string name="preferences_calendar_account_category">Hesap tipi</string>
     <string name="preferences_calendar_color">Renk</string>
     <string name="preferences_calendar_visible">Olayları görüntüle</string>
     <string name="preferences_calendar_synchronize">Bu takvimi senkronize et</string>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -763,9 +763,12 @@
     <!-- Preferences -->
     <string name="preferences_calendar_no_display_name">Unnamed calendar</string>
     <string name="preferences_calendar_account">%1$s account</string>
+    <string name="preferences_calendar_account_local">Offline calendar</string>
+    <string name="preferences_calendar_configure_account">Configure calendar in %1$s</string>
+    <string name="preferences_calendar_number_of_events">%1d events</string>
     <string name="preferences_calendar_delete">Delete calendar</string>
     <string name="preferences_calendar_display_name">Change name</string>
-    <string name="preferences_calendar_account_category">Account type</string>
+    <string name="preferences_calendar_info_category">Calendar information</string>
     <string name="preferences_calendar_color">Color</string>
     <string name="preferences_calendar_visible">Display events</string>
     <string name="preferences_calendar_synchronize">Synchronize this calendar</string>

--- a/src/com/android/calendar/persistence/CalendarRepository.kt
+++ b/src/com/android/calendar/persistence/CalendarRepository.kt
@@ -186,9 +186,19 @@ internal class CalendarRepository(val application: Application) {
         val calendarUri = ContentUris.withAppendedId(CalendarContract.Calendars.CONTENT_URI, calendarId)
         contentResolver.query(calendarUri, ACCOUNT_PROJECTION, null, null, null)?.use {
             if (it.moveToFirst()) {
-                val accountName = it.getString(ACCOUNT_INDEX_NAME)
-                val accountType = it.getString(ACCOUNT_INDEX_TYPE)
+                val accountName = it.getString(PROJECTION_ACCOUNT_INDEX_NAME)
+                val accountType = it.getString(PROJECTION_ACCOUNT_INDEX_TYPE)
                 return Account(accountName, accountType)
+            }
+        }
+        return null
+    }
+
+    fun queryNumberOfEvents(calendarId: Long): Long? {
+        val args = arrayOf(calendarId.toString())
+        contentResolver.query(CalendarContract.Events.CONTENT_URI, PROJECTION_COUNT_EVENTS, WHERE_COUNT_EVENTS, args, null)?.use {
+            if (it.moveToFirst()) {
+                return it.getLong(PROJECTION_COUNT_EVENTS_INDEX_COUNT)
             }
         }
         return null
@@ -199,8 +209,14 @@ internal class CalendarRepository(val application: Application) {
                 CalendarContract.Calendars.ACCOUNT_NAME,
                 CalendarContract.Calendars.ACCOUNT_TYPE
         )
-        const val ACCOUNT_INDEX_NAME = 0
-        const val ACCOUNT_INDEX_TYPE = 1
+        const val PROJECTION_ACCOUNT_INDEX_NAME = 0
+        const val PROJECTION_ACCOUNT_INDEX_TYPE = 1
+
+        private val PROJECTION_COUNT_EVENTS = arrayOf(
+                CalendarContract.Events._COUNT
+        )
+        const val PROJECTION_COUNT_EVENTS_INDEX_COUNT = 0
+        const val WHERE_COUNT_EVENTS = CalendarContract.Events.CALENDAR_ID + "=?"
 
         const val DEFAULT_COLOR_KEY = "1"
 

--- a/src/com/android/calendar/settings/CalendarPreferences.kt
+++ b/src/com/android/calendar/settings/CalendarPreferences.kt
@@ -53,6 +53,12 @@ class CalendarPreferences : PreferenceFragmentCompat() {
         populatePreferences()
     }
 
+    override fun onActivityCreated(savedInstanceState: Bundle?) {
+        super.onActivityCreated(savedInstanceState)
+        val displayName = preferenceManager.preferenceDataStore!!.getString(DISPLAY_NAME_KEY, null)
+        activity?.title = if (displayName.isNullOrBlank()) getString(R.string.preferences_calendar_no_display_name) else displayName
+    }
+
     private fun populatePreferences() {
         val context = preferenceManager.context
         val screen = preferenceManager.createPreferenceScreen(context)

--- a/src/com/android/calendar/settings/GeneralPreferences.kt
+++ b/src/com/android/calendar/settings/GeneralPreferences.kt
@@ -84,6 +84,11 @@ class GeneralPreferences : PreferenceFragmentCompat(),
         setPreferencesFromResource(R.xml.general_preferences, rootKey)
     }
 
+    override fun onActivityCreated(savedInstanceState: Bundle?) {
+        super.onActivityCreated(savedInstanceState)
+        activity?.title = getString(R.string.preferences_list_general)
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 

--- a/src/com/android/calendar/settings/MainListPreferences.kt
+++ b/src/com/android/calendar/settings/MainListPreferences.kt
@@ -51,6 +51,7 @@ class MainListPreferences : PreferenceFragmentCompat() {
 
     override fun onActivityCreated(savedInstanceState: Bundle?) {
         super.onActivityCreated(savedInstanceState)
+        activity?.title = getString(R.string.preferences_title)
 
         val factory = MainListViewModelFactory(activity!!.application)
         mainListViewModel = ViewModelProvider(this, factory).get(MainListViewModel::class.java)

--- a/src/com/android/calendar/settings/SettingsActivity.kt
+++ b/src/com/android/calendar/settings/SettingsActivity.kt
@@ -26,7 +26,6 @@ import com.android.calendar.DynamicTheme
 import ws.xsoh.etar.R
 
 
-private const val TITLE_TAG = "settingsActivityTitle"
 
 const val EXTRA_SHOW_FRAGMENT = "settingsShowFragment"
 
@@ -34,7 +33,8 @@ const val EXTRA_SHOW_FRAGMENT = "settingsShowFragment"
  * Based on the official Kotlin example for AndroidX preferences:
  * https://github.com/android/user-interface-samples/blob/master/PreferencesKotlin/app/src/main/java/com/example/androidx/preference/sample/MainActivity.kt
  *
- * Extended by EXTRA_SHOW_FRAGMENT
+ * - Added EXTRA_SHOW_FRAGMENT
+ * - Don't assume title from setting, instead set it in each fragment individually
  */
 class SettingsActivity : AppCompatActivity(),
         PreferenceFragmentCompat.OnPreferenceStartFragmentCallback {
@@ -63,21 +63,8 @@ class SettingsActivity : AppCompatActivity(),
                     .beginTransaction()
                     .replace(R.id.body_frame, fragment)
                     .commit()
-        } else {
-            title = savedInstanceState.getCharSequence(TITLE_TAG)
-        }
-        supportFragmentManager.addOnBackStackChangedListener {
-            if (supportFragmentManager.backStackEntryCount == 0) {
-                setTitle(R.string.preferences_title)
-            }
         }
         supportActionBar?.setDisplayHomeAsUpEnabled(true)
-    }
-
-    override fun onSaveInstanceState(outState: Bundle) {
-        super.onSaveInstanceState(outState)
-        // Save current activity title so we can set it again after a configuration change
-        outState.putCharSequence(TITLE_TAG, title)
     }
 
     override fun onSupportNavigateUp(): Boolean {
@@ -105,7 +92,6 @@ class SettingsActivity : AppCompatActivity(),
                 .replace(R.id.body_frame, fragment)
                 .addToBackStack(null)
                 .commit()
-        title = pref.title
         return true
     }
 

--- a/src/com/android/calendar/settings/ViewDetailsPreferences.kt
+++ b/src/com/android/calendar/settings/ViewDetailsPreferences.kt
@@ -51,6 +51,11 @@ class ViewDetailsPreferences : PreferenceFragmentCompat() {
         portraitConf.onCreate(preferenceScreen, activity)
     }
 
+    override fun onActivityCreated(savedInstanceState: Bundle?) {
+        super.onActivityCreated(savedInstanceState)
+        activity?.title = getString(R.string.display_options)
+    }
+
     private class PreferenceKeys internal constructor(val KEY_DISPLAY_TIME: String,
                                                       val KEY_DISPLAY_LOCATION: String,
                                                       val KEY_MAX_NUMBER_OF_LINES: String)


### PR DESCRIPTION
Now shows the number of events in this calendar. This information could be helpful to decide if someone wants to delete a calendar or keep it.

Also reorders some elements.

New design for offline calendars:
![Screenshot_20200209-184603](https://user-images.githubusercontent.com/321888/74107207-00323e80-4b6e-11ea-92a5-848391f14025.png)

Other calendars:
![Screenshot_20200209-184553](https://user-images.githubusercontent.com/321888/74107211-058f8900-4b6e-11ea-9f7f-feb4921ad0b2.png)
