### PR TITLE
Accept "application/ics" in ImportActivity's intent-filter

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -174,6 +174,7 @@
                 <data android:scheme="file" />
                 <data android:mimeType="text/x-vcalendar" />
                 <data android:mimeType="text/calendar" />
+                <data android:mimeType="application/ics" />
             </intent-filter>
         </activity>
 


### PR DESCRIPTION
While text/calendar is the correct mime type for .ics files, there are
some non standard-compliant implementations out there, such as Gmail's
invitations that use application/ics as the mime type and thus don't
work with Etar.

Way to reproduce:
1. Get someone that uses Gmail to send you an invitation to an event.
2. Try opening the event directly from a mail app that just uses the sent
    mime type as sent in the email.

Before this patch:
1. Etar won't be opened.

After this patch:
1. Etar is opened.


Note: I haven't been able to build Etar with the changes as I don't currently have access to a suitable build environment. Though it should be very easy to test and the change is straightforward.
This is has been driving me mad for years now, and I can't wait to get it solved.

Thanks!