### PR TITLE
Fix dayview glitches (rebase of #692)

### DIFF
--- a/src/com/android/calendar/DayView.java
+++ b/src/com/android/calendar/DayView.java
@@ -554,7 +554,6 @@ public class DayView extends View implements View.OnCreateContextMenuListener,
                 @Override
                 public void onAnimationEnd(Animator animation) {
                     mScrolling = false;
-            resetSelectedHour();
             invalidate();
         }
     };
@@ -1874,22 +1873,6 @@ public class DayView extends View implements View.OnCreateContextMenuListener,
         view.restartCurrentTimeUpdates();
 
         return view;
-    }
-
-    // This is called after scrolling stops to move the selected hour
-    // to the visible part of the screen.
-    private void resetSelectedHour() {
-        if (mSelectionHour < mFirstHour + 1) {
-            setSelectedHour(mFirstHour + 1);
-            setSelectedEvent(null);
-            mSelectedEvents.clear();
-            mComputeSelectedEvents = true;
-        } else if (mSelectionHour > mFirstHour + mNumHours - 3) {
-            setSelectedHour(mFirstHour + mNumHours - 3);
-            setSelectedEvent(null);
-            mSelectedEvents.clear();
-            mComputeSelectedEvents = true;
-        }
     }
 
             private void initFirstHour() {
@@ -4040,7 +4023,6 @@ public class DayView extends View implements View.OnCreateContextMenuListener,
 
         mScrolling = true;
 
-        mSelectionMode = SELECTION_HIDDEN;
         invalidate();
     }
 
@@ -4070,7 +4052,6 @@ public class DayView extends View implements View.OnCreateContextMenuListener,
     private void doFling(MotionEvent e1, MotionEvent e2, float velocityX, float velocityY) {
         cancelAnimation();
 
-        mSelectionMode = SELECTION_HIDDEN;
         eventClickCleanup();
 
         mOnFlingCalled = true;
@@ -4278,7 +4259,6 @@ public class DayView extends View implements View.OnCreateContextMenuListener,
                 // is visible.
                 if (mScrolling) {
                     mScrolling = false;
-                    resetSelectedHour();
                     invalidate();
                 }
 
@@ -4308,7 +4288,6 @@ public class DayView extends View implements View.OnCreateContextMenuListener,
                 if (DEBUG) Log.e(TAG, "ACTION_CANCEL");
                 mGestureDetector.onTouchEvent(ev);
                 mScrolling = false;
-                resetSelectedHour();
                 return true;
 
             default:
@@ -4905,7 +4884,6 @@ public class DayView extends View implements View.OnCreateContextMenuListener,
                 public void run() {
                     mScrolling = mScrolling && mScroller.computeScrollOffset();
                     if (!mScrolling || mPaused) {
-                        resetSelectedHour();
                         invalidate();
                         return;
                     }

--- a/src/com/android/calendar/DayView.java
+++ b/src/com/android/calendar/DayView.java
@@ -2149,6 +2149,8 @@ public class DayView extends View implements View.OnCreateContextMenuListener,
         doDraw(canvas);
         // restore to having no clip
         canvas.restore();
+        // save again for doing drawHours() later
+        canvas.save();
 
         if ((mTouchMode & TOUCH_MODE_HSCROLL) != 0) {
             float xTranslate;
@@ -2202,6 +2204,8 @@ public class DayView extends View implements View.OnCreateContextMenuListener,
                 invalidate();
             }
         }
+        canvas.restore();
+        drawHours(mRect, canvas, mPaint);
         canvas.restore();
     }
 
@@ -2386,7 +2390,6 @@ public class DayView extends View implements View.OnCreateContextMenuListener,
             drawBgColors(r, canvas, p);
         }
         drawGridBackground(r, canvas, p);
-        drawHours(r, canvas, p);
 
         // Draw each day
         int cell = mFirstJulianDay;
@@ -2460,13 +2463,18 @@ public class DayView extends View implements View.OnCreateContextMenuListener,
 
     private void drawHours(Rect r, Canvas canvas, Paint p) {
         setupHourTextPaint(p);
-
         int totCellHeight =  mCellHeight + HOUR_GAP;
         int hourStep = (mHoursTextHeight + totCellHeight - 1)/ totCellHeight;
+        int i = mFirstHour;
+        if (   (mFirstHourOffset < mHoursTextHeight / 2)
+            && (mAlldayHeight == 0)
+            && (mNumDays == 1))
+        {
+            i += hourStep;
+        }
         int deltaY = hourStep * totCellHeight;
-        int y = deltaY + mHoursTextHeight / 2 - HOUR_GAP;
-        //Draw only from 1:00 to 23:00
-        for (int i = hourStep; i < 24; i += hourStep) {
+        int y = i * totCellHeight + mHoursTextHeight / 2 - HOUR_GAP;
+        for (; i < 24; i += hourStep) {
             String time = mHourStrs[i];
             canvas.drawText(time, HOURS_LEFT_MARGIN, y, p);
             y += deltaY;


### PR DESCRIPTION
Fixes #457. #693 
Merges #692 
TODO: The commit messages might discard too much information and do not link original commits.

This is a PR from what has been my current master branch.  
It enables code review while still being the most verbose and true to history, i.e. no commits have been melded yet, it's just the cherry-picks.  
My suggestion is to go from here. Whatever will be decided for the final squash that should be merged, i would definitely change the commit messages a bit to reflect on the squashed changes which, as i know now, are quite intertwined.

## Summary of my squashing considerations

In my opinion, https://github.com/SebiderSushi/Etar-Calendar/commits/squashed is actually the least clean of my branches and definitely not atomic. I also squashed `Fix problem with selecting hour 23` into `Fix issue #457 and remove other bounces` while keeping `Don't mess with selected hour when scrolling`. As i found out until now, doing so is incorrect:

> I did some testing and apparently,
> `dbfed92215570932c7acb4d2d2b4aa7b4e255e3a Fix problem with selecting hour 23`
> only works if applied together with
> `8f59dc15ed7fc97edcac7d1167696e9aa8dc27b0 Don't mess with selected hour when scrolling`
> 
> Now i am very confused as to how to squash of retain the commits of this PR.

Concerning this issue, @rparkins999 [stated](https://github.com/Etar-Group/Etar-Calendar/issues/693#issuecomment-627263825_) in #693:
> The problem with setting hour 23 only occurs when the display is squeezed so that all hours are visible. It is present both before and after my recent changes, but it is worse after.

I was not able to reproduce this on my device. During my tests, i could easily reproduce the issue after applying `Fix issue #457 and remove other bounces`, but never reproduced it without this commit.  
If others are able to reproduce this as stated by @rparkins999 then i don't know, but according to my tests this issue is heavily linked to `Fix issue #457 and remove other bounces` so i'd suggest squashing the 3 commits together along with a descriptive commit description.

The only commit that i would possibly preserve as an individual commit is `Display hour 00 label if there is room for it.` as it can be seen to resemble one distinct feature, is atomic and could (in theory) stand on its own (which i didn't test practically).

## Original commits used on this branch
Right now, this branch contains the following, cherry-picked and unchanged commits from https://github.com/rparkins999/Etar-Calendar:
```
dbfed92215570932c7acb4d2d2b4aa7b4e255e3a Fix problem with selecting hour 23
8f59dc15ed7fc97edcac7d1167696e9aa8dc27b0 Don't mess with selected hour when scrolling
cd1ecb86bba786d5d7905319298dad1af0990375 Display hour 00 label if there is room for it.
b043785f79d46e6f24035ad0b6a51c5216bae41d Remove DEBUG_SCROLLING, left in branch DEBUG_SCROLLING
36f1e6609eea42a4a8c5ea942983e577dea4a484 Fix issue #457 and remove other bounces
```
Cherry-picking command line to reproduce:
`git cherry-pick 36f1e66 b043785 cd1ecb8 8f59dc1 dbfed92`