### PR TITLE
Misc fixes

### DIFF
--- a/proguard.flags
+++ b/proguard.flags
@@ -35,6 +35,10 @@
  *** extractDomain(...);
 }
 
+-keep public class * extends android.app.Fragment {
+  public <init>();
+}
+
 -keepclassmembers class * implements android.content.SharedPreferences$Editor {
   public *** apply();
 }

--- a/proguard.flags
+++ b/proguard.flags
@@ -1,6 +1,7 @@
 -keep class com.android.calendar.selectcalendars.SelectCalendarsSyncFragment
 -keep class com.android.calendar.OtherPreferences
 -keep class com.android.calendar.AboutPreferences
+-keep class com.android.calendar.settings.QuickResponsePreferences
 -keepclassmembers class com.android.calendar.AllInOneActivity {
   *** setControlsOffset(...);
 }

--- a/res/values/arrays.xml
+++ b/res/values/arrays.xml
@@ -14,7 +14,7 @@
      limitations under the License.
 -->
 <resources>
-    <string-array name="pref_theme_entries">
+    <string-array name="pref_theme_entries" translatable="false">
         <item>@string/preferences_light_theme</item>
         <item>@string/preferences_dark_theme</item>
         <item>@string/preferences_black_theme</item>
@@ -27,7 +27,7 @@
     </string-array>
 
     <!--Entries for the primary color-->
-    <string-array name="pref_color_entries">
+    <string-array name="pref_color_entries" translatable="false">
         <item>@string/preferences_color_teal</item>
         <item>@string/preferences_color_blue</item>
         <item>@string/preferences_color_orange</item>
@@ -199,13 +199,13 @@
         <item>"2"</item>
     </string-array>
 
-    <string-array name="preferences_days_per_week_labels">
-        <item>2 days</item>
-        <item>3 days</item>
-        <item>4 days</item>
-        <item>5 days</item>
-        <item>6 days</item>
-        <item>7 days</item>
+    <string-array name="preferences_days_per_week_labels" translatable="false">
+        <item>@string/two_days</item>
+        <item>@string/three_days</item>
+        <item>@string/four_days</item>
+        <item>@string/five_days</item>
+        <item>@string/six_days</item>
+        <item>@string/seven_days</item>
     </string-array>
 
     <string-array name="preferences_days_per_week_values" translatable="false">
@@ -217,7 +217,7 @@
         <item>"7"</item>
     </string-array>
 
-    <string-array name="preferences_default_duration_labels">
+    <string-array name="preferences_default_duration_labels" translatable="false">
         <item>@string/zero_minutes</item>
         <item>@string/fifteen_minutes</item>
         <item>@string/thirty_minutes</item>
@@ -248,13 +248,12 @@
         <item>2</item>  <!-- Tentative -->
     </integer-array>
 
-    <string-array name="visibility">
+    <string-array name="visibility" translatable="false">
         <item>@string/visibility_default</item>
         <item>@string/visibility_confidential</item>
         <item>@string/visibility_private</item>
         <item>@string/visibility_public</item>
     </string-array>
-
 
     <!-- Invitation responses -->
     <string-array name="response_labels1">
@@ -277,7 +276,7 @@
 
     <!-- DO NOT TRANSLATE These values need to correspond to the indices
          defined in DeleteEventHelper.java-->
-    <integer-array name="delete_repeating_values">
+    <integer-array name="delete_repeating_values" translatable="false">
         <item>0</item>
         <item>1</item>
         <item>2</item>
@@ -393,8 +392,8 @@
         <item >on every fourth Saturday</item>
         <item >on every last Saturday</item>
     </string-array>
-    
-    <string-array name="show_time">
+
+    <string-array name="show_time" translatable="false">
         <item>@string/show_time_no</item>
         <item>@string/show_time_start</item>
         <item>@string/show_time_start_end</item>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -732,6 +732,14 @@
     <string name="visibility_private">Private</string>
     <string name="visibility_public">Public</string>
 
+    <!-- Strings to describe per week labels array -->
+    <string name="two_days">2 days</string>
+    <string name="three_days">3 days</string>
+    <string name="four_days">4 days</string>
+    <string name="five_days">5 days</string>
+    <string name="six_days">6 days</string>
+    <string name="seven_days">7 days</string>
+
     <!-- Strings to describe default duration array -->
     <string name="zero_minutes">0 minutes</string>
     <string name="fifteen_minutes">15 minutes</string>

--- a/res/xml-v26/general_preferences.xml
+++ b/res/xml-v26/general_preferences.xml
@@ -92,7 +92,6 @@
 
         <CheckBoxPreference
             app:key="preferences_alerts_popup"
-            app:layout="?android:attr/preferenceLayoutChild"
             app:defaultValue="false"
             app:title="@string/preferences_alerts_popup_title" />
 

--- a/res/xml/general_preferences.xml
+++ b/res/xml/general_preferences.xml
@@ -92,7 +92,6 @@
             app:title="@string/preferences_alerts_title" />
 
         <Preference
-            app:layout="?android:attr/preferenceLayoutChild"
             app:key="preferences_alerts_ringtone"
             app:title="@string/preferences_alerts_ringtone_title"
             app:defaultValue="content://settings/system/notification_sound"
@@ -106,7 +105,6 @@
             app:dependency="preferences_alerts" />
 
         <CheckBoxPreference
-            app:layout="?android:attr/preferenceLayoutChild"
             app:key="preferences_alerts_popup"
             app:defaultValue="false"
             app:title="@string/preferences_alerts_popup_title"


### PR DESCRIPTION
Misc proguard crash fixes for AOSP build environment and mark some arrays as untranslatable. Also converted preferences_days_per_week_labels to string references to avoid issues with translations mismatched arrays.