### PR TITLE
Fix warning in app_copyright string resource

### DIFF
--- a/res/values-ca/strings.xml
+++ b/res/values-ca/strings.xml
@@ -334,5 +334,5 @@
     <string name="license">Llicència</string>
     <string name="changelog">Registre de canvis</string>
     <string name="authors">Autors</string>
-    <string name="app_copyright">© 2015-<xliff:g>%s</xliff:g> The Etar Project. Porcions © 2005-<xliff:g>%s</xliff:g> The Android Open Source Project.</string>
+    <string name="app_copyright">© 2015-<xliff:g>%1$s</xliff:g> The Etar Project. Porcions © 2005-<xliff:g>%1$s</xliff:g> The Android Open Source Project.</string>
 </resources>

--- a/res/values-da/strings.xml
+++ b/res/values-da/strings.xml
@@ -316,7 +316,7 @@
     <string name="preferences_calendar_delete_cancel">Annuller</string>
     <string name="preferences_menu_about">Om Etar</string>
     <string name="offline_account_name">Offlinekalender</string>
-    <string name="app_copyright">© 2015-<xliff:g>%s</xliff:g> Etar Projektet. Portions © 2005-<xliff:g>%s</xliff:g> The Android Open Source Project.</string>
+    <string name="app_copyright">© 2015-<xliff:g>%1$s</xliff:g> Etar Projektet. Portions © 2005-<xliff:g>%1$s</xliff:g> The Android Open Source Project.</string>
     <string name="authors">Forfattere</string>
     <string name="changelog">Ændringslog</string>
     <string name="license">Licens</string>

--- a/res/values-de/strings.xml
+++ b/res/values-de/strings.xml
@@ -326,7 +326,7 @@
 \n
 \nIn DAVx⁵ kann \'Kalenderfarben verwalten\' deaktiviert werden, um dies zu verhindern.</string>
     <string name="preferences_list_add_remote">Kalender hinzufügen (CalDAV)</string>
-    <string name="app_copyright">© 2015-<xliff:g>%s</xliff:g> The Etar Project. Teile davon © 2005-<xliff:g>%s</xliff:g> The Android Open Source Project.</string>
+    <string name="app_copyright">© 2015-<xliff:g>%1$s</xliff:g> The Etar Project. Teile davon © 2005-<xliff:g>%1$s</xliff:g> The Android Open Source Project.</string>
     <string name="authors">Autoren</string>
     <string name="changelog">Änderungsübersicht</string>
     <string name="license">Lizenz</string>

--- a/res/values-en-rGB/strings.xml
+++ b/res/values-en-rGB/strings.xml
@@ -304,7 +304,7 @@
     <string name="license">License</string>
     <string name="changelog">Changelog</string>
     <string name="authors">Authors</string>
-    <string name="app_copyright">© 2015-<xliff:g>%s</xliff:g> The Etar Project. Portions © 2005-<xliff:g>%s</xliff:g> The Android Open Source Project.</string>
+    <string name="app_copyright">© 2015-<xliff:g>%1$s</xliff:g> The Etar Project. Portions © 2005-<xliff:g>%1$s</xliff:g> The Android Open Source Project.</string>
     <string name="preferences_default_snooze_delay_dialog">Default snooze delay</string>
     <string name="preferences_default_snooze_delay_title">Default snooze delay time</string>
     <string name="snooze_delay_dialog_title">Set snooze delay</string>

--- a/res/values-es/strings.xml
+++ b/res/values-es/strings.xml
@@ -330,7 +330,7 @@
     <string name="changelog">Registro de cambios</string>
     <string name="license">Licencia</string>
     <string name="source_code">Fuente</string>
-    <string name="app_copyright">© 2015-<xliff:g>%s</xliff:g> The Etar Project. Porciones © 2005-<xliff:g>%s</xliff:g> The Android Open Source Project.</string>
+    <string name="app_copyright">© 2015-<xliff:g>%1$s</xliff:g> The Etar Project. Porciones © 2005-<xliff:g>%1$s</xliff:g> The Android Open Source Project.</string>
     <string name="preferences_calendar_no_display_name">Calendario sin nombre</string>
     <string name="preferences_calendar_configure_account">Configurar calendario en %1$s</string>
     <string name="preferences_calendar_number_of_events">%1$d eventos</string>

--- a/res/values-eu/strings.xml
+++ b/res/values-eu/strings.xml
@@ -321,7 +321,7 @@
     <string name="preferences_calendar_delete_cancel">Utzi</string>
     <string name="preferences_menu_about">Etar-i buruz</string>
     <string name="offline_account_name">Lineaz kanpoko egutegia</string>
-    <string name="app_copyright">© 2015-<xliff:g>%s</xliff:g> The Etar Project. Portions © 2005-<xliff:g>%s</xliff:g> The Android Open Source Project.</string>
+    <string name="app_copyright">© 2015-<xliff:g>%1$s</xliff:g> The Etar Project. Portions © 2005-<xliff:g>%1$s</xliff:g> The Android Open Source Project.</string>
     <string name="authors">Egileak</string>
     <string name="changelog">Aldaketa egunkaria</string>
     <string name="license">Lizentzia</string>

--- a/res/values-fr/strings.xml
+++ b/res/values-fr/strings.xml
@@ -326,7 +326,7 @@
     <string name="preferences_calendar_delete_cancel">Annuler</string>
     <string name="preferences_menu_about">À propos d’Etar</string>
     <string name="offline_account_name">Calendrier hors-ligne</string>
-    <string name="app_copyright">© 2015-<xliff:g>%s</xliff:g> The Etar Project. Portions © 2005-<xliff:g>%s</xliff:g> The Android Open Source Project.</string>
+    <string name="app_copyright">© 2015-<xliff:g>%1$s</xliff:g> The Etar Project. Portions © 2005-<xliff:g>%1$s</xliff:g> The Android Open Source Project.</string>
     <string name="authors">Auteurs</string>
     <string name="changelog">Journal des modifications</string>
     <string name="license">Licence</string>

--- a/res/values-hr/strings.xml
+++ b/res/values-hr/strings.xml
@@ -342,7 +342,7 @@
     <string name="preferences_calendar_delete_cancel">Odustani</string>
     <string name="preferences_menu_about">Informacije o Etaru</string>
     <string name="offline_account_name">Izvanmrežni kalendar</string>
-    <string name="app_copyright">© 2015. – <xliff:g>%s</xliff:g>. The Etar Project. Dijelovi © 2005. – <xliff:g>%s</xliff:g>. The Android Open Source Project.</string>
+    <string name="app_copyright">© 2015. – <xliff:g>%1$s</xliff:g>. The Etar Project. Dijelovi © 2005. – <xliff:g>%1$s</xliff:g>. The Android Open Source Project.</string>
     <string name="authors">Autori</string>
     <string name="changelog">Zapis promjena</string>
     <string name="license">Licenca</string>

--- a/res/values-in/strings.xml
+++ b/res/values-in/strings.xml
@@ -316,7 +316,7 @@
     <string name="preferences_calendar_account_local">Kalender luring</string>
     <string name="preferences_calendar_number_of_events">%1$d acara</string>
     <string name="preferences_calendar_info_category">Informasi kalender</string>
-    <string name="app_copyright">© 2015-<xliff:g>%s</xliff:g> The Etar Project. Sebagian © 2005-<xliff:g>%s</xliff:g> The Android Open Source Project.</string>
+    <string name="app_copyright">© 2015-<xliff:g>%1$s</xliff:g> The Etar Project. Sebagian © 2005-<xliff:g>%1$s</xliff:g> The Android Open Source Project.</string>
     <string name="preferences_calendar_configure_account">Konfigurasi kalender dalam %1$s</string>
     <string name="seven_days">7 hari</string>
     <string name="six_days">6 hari</string>

--- a/res/values-it/strings.xml
+++ b/res/values-it/strings.xml
@@ -331,7 +331,7 @@
     <string name="preferences_calendar_delete_delete">Elimina calendario</string>
     <string name="preferences_calendar_delete_cancel">Annulla</string>
     <string name="preferences_menu_about">Altro su Etar</string>
-    <string name="app_copyright">Progetto Etar © 2015-<xliff:g>%s</xliff:g>. Parte del progetto Android Open Source © 2005-<xliff:g>%s</xliff:g>.</string>
+    <string name="app_copyright">Progetto Etar © 2015-<xliff:g>%1$s</xliff:g>. Parte del progetto Android Open Source © 2005-<xliff:g>%1$s</xliff:g>.</string>
     <string name="preferences_calendar_no_display_name">Calendario senza nome</string>
     <string name="preferences_calendar_account_local">Calendario non in linea</string>
     <string name="preferences_calendar_configure_account">Configura calendario in %1$s</string>

--- a/res/values-nb/strings.xml
+++ b/res/values-nb/strings.xml
@@ -327,7 +327,7 @@
     <string name="preferences_calendar_delete_cancel">Avbryt</string>
     <string name="preferences_menu_about">Om Etar</string>
     <string name="offline_account_name">Frakoblet kalender</string>
-    <string name="app_copyright">© 2015-<xliff:g>%s</xliff:g> Etar-prosjektet. Portions © 2005-<xliff:g>%s</xliff:g> Android Open Source-prosjektet.</string>
+    <string name="app_copyright">© 2015-<xliff:g>%1$s</xliff:g> Etar-prosjektet. Portions © 2005-<xliff:g>%1$s</xliff:g> Android Open Source-prosjektet.</string>
     <string name="authors">Utviklere</string>
     <string name="changelog">Endringslogg</string>
     <string name="license">Lisens</string>

--- a/res/values-pt-rPT/strings.xml
+++ b/res/values-pt-rPT/strings.xml
@@ -317,7 +317,7 @@
     <string name="preferences_calendar_configure_account">Configurar calendário em %1$s</string>
     <string name="offline_account_name">Calendário local</string>
     <string name="preferences_calendar_synchronize">Sincronizar este calendário</string>
-    <string name="app_copyright">© 2015-<xliff:g>%s</xliff:g> The Etar Project. Portions © 2005-<xliff:g>%s</xliff:g> The Android Open Source Project.</string>
+    <string name="app_copyright">© 2015-<xliff:g>%1$s</xliff:g> The Etar Project. Portions © 2005-<xliff:g>%1$s</xliff:g> The Android Open Source Project.</string>
     <string name="preferences_list_add_offline_cancel">Cancelar</string>
     <string name="preferences_calendar_info_category">Informação do calendário</string>
     <string name="preferences_calendar_account">Conta %1$s</string>

--- a/res/values-pt/strings.xml
+++ b/res/values-pt/strings.xml
@@ -317,7 +317,7 @@
     <string name="preferences_calendar_delete_cancel">Cancelar</string>
     <string name="preferences_menu_about">Acerca de Etar</string>
     <string name="offline_account_name">Calendário local</string>
-    <string name="app_copyright">© 2015-<xliff:g>%s</xliff:g> The Etar Project. Portions © 2005-<xliff:g>%s</xliff:g> The Android Open Source Project.</string>
+    <string name="app_copyright">© 2015-<xliff:g>%1$s</xliff:g> The Etar Project. Portions © 2005-<xliff:g>%1$s</xliff:g> The Android Open Source Project.</string>
     <string name="authors">Autores</string>
     <string name="changelog">Alterações</string>
     <string name="license">Licença</string>

--- a/res/values-ru/strings.xml
+++ b/res/values-ru/strings.xml
@@ -342,7 +342,7 @@
     <string name="preferences_calendar_delete_cancel">Отмена</string>
     <string name="preferences_menu_about">Об Etar</string>
     <string name="offline_account_name">Локальный календарь</string>
-    <string name="app_copyright">© 2015-<xliff:g>%s</xliff:g> Проект Etar. Частично © 2005-<xliff:g>%s</xliff:g> The Android Open Source Project.</string>
+    <string name="app_copyright">© 2015-<xliff:g>%1$s</xliff:g> Проект Etar. Частично © 2005-<xliff:g>%1$s</xliff:g> The Android Open Source Project.</string>
     <string name="authors">Авторы</string>
     <string name="changelog">История изменений</string>
     <string name="license">Лицензия</string>

--- a/res/values-tr/strings.xml
+++ b/res/values-tr/strings.xml
@@ -325,7 +325,7 @@
     <string name="preferences_calendar_delete_cancel">İptal</string>
     <string name="preferences_menu_about">Etar Hakkında</string>
     <string name="offline_account_name">Çevrimdışı Takvim</string>
-    <string name="app_copyright">© 2015-<xliff:g>%s</xliff:g> Etar Projsi. Portions © 2005-<xliff:g>%s</xliff:g> Android Açık Kaynak Projesi.</string>
+    <string name="app_copyright">© 2015-<xliff:g>%1$s</xliff:g> Etar Projsi. Portions © 2005-<xliff:g>%1$s</xliff:g> Android Açık Kaynak Projesi.</string>
     <string name="authors">Yazarlar</string>
     <string name="changelog">Değişiklikler</string>
     <string name="license">Lisans</string>

--- a/res/values-uk/strings.xml
+++ b/res/values-uk/strings.xml
@@ -345,7 +345,7 @@
     <string name="preferences_calendar_delete_cancel">Скасувати</string>
     <string name="preferences_menu_about">Про Etar</string>
     <string name="offline_account_name">Автономний календар</string>
-    <string name="app_copyright">© 2015-<xliff:g>%s</xliff:g> Проєкт Etar. Частково © 2005-<xliff:g>%s</xliff:g> The Android Open Source Project.</string>
+    <string name="app_copyright">© 2015-<xliff:g>%1$s</xliff:g> Проєкт Etar. Частково © 2005-<xliff:g>%1$s</xliff:g> The Android Open Source Project.</string>
     <string name="authors">Автори</string>
     <string name="changelog">Перелік змін</string>
     <string name="license">Ліцензія</string>

--- a/res/values-zh-rCN/strings.xml
+++ b/res/values-zh-rCN/strings.xml
@@ -327,7 +327,7 @@
     <string name="preferences_calendar_delete_cancel">取消</string>
     <string name="preferences_menu_about">关于 Etar</string>
     <string name="offline_account_name">离线日历</string>
-    <string name="app_copyright">© 2015-<xliff:g>%s</xliff:g> The Etar Project. Portions © 2005-<xliff:g>%s</xliff:g> The Android Open Source Project.</string>
+    <string name="app_copyright">© 2015-<xliff:g>%1$s</xliff:g> The Etar Project. Portions © 2005-<xliff:g>%1$s</xliff:g> The Android Open Source Project.</string>
     <string name="authors">作者</string>
     <string name="changelog">更新日志</string>
     <string name="license">许可证</string>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -555,7 +555,7 @@
     <string name="app_authors" translatable="false">The Etar Project</string>
     <string name="app_authors_url" translatable="false">https://github.com/Etar-Group/Etar-Calendar/graphs/contributors</string>
     <string name="app_changelog" translatable="false">https://github.com/Etar-Group/Etar-Calendar/releases</string>
-    <string name="app_copyright">\u00a9 2015-<xliff:g>%s</xliff:g> The Etar Project. Portions \u00a9 2005-<xliff:g>%s</xliff:g> The Android Open Source Project.</string>
+    <string name="app_copyright">\u00a9 2015-<xliff:g>%1$s</xliff:g> The Etar Project. Portions \u00a9 2005-<xliff:g>%1$s</xliff:g> The Android Open Source Project.</string>
     <string name="app_issues_url" translatable="false">https://github.com/Etar-Group/Etar-Calendar/issues</string>
     <string name="app_license" translatable="false">GPLv3</string>
     <string name="app_license_url" translatable="false">https://www.gnu.org/licenses/gpl-3.0.html</string>

--- a/src/com/android/calendar/AboutFragment.kt
+++ b/src/com/android/calendar/AboutFragment.kt
@@ -43,7 +43,7 @@ class AboutFragment : Fragment() {
         view.findViewById<TextView>(R.id.version).text = getVersionNumber()
 
         val year = Calendar.getInstance().get(Calendar.YEAR).toString()
-        view.findViewById<TextView>(R.id.copyright).text = getString(R.string.app_copyright, year, year)
+        view.findViewById<TextView>(R.id.copyright).text = getString(R.string.app_copyright, year)
 
         view.findViewById<LinearLayout>(R.id.authorsLayout).setOnClickListener {
             startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(getString(R.string.app_authors_url))))


### PR DESCRIPTION
Fixes: packages/apps/Etar/res/values/strings.xml:556: warn: multiple substitutions specified in non-positional format; did you mean to add the formatted="false" attribute?.
Change-Id: Iab287d6fa945c7db539e91c8b2f322d40e7167d8