### PR TITLE
Settings: add a button to add remote EteSync accounts.

### DIFF
--- a/res/values-ca/strings.xml
+++ b/res/values-ca/strings.xml
@@ -311,6 +311,7 @@
     <string name="preferences_list_add_offline_title">Afegeix un calendari fora de línia</string>
     <string name="preferences_list_add_offline">Afegeix un calendari fora de línia</string>
     <string name="preferences_list_add_remote">Afegeix un calendari remot (CalDAV)</string>
+    <string name="preferences_list_add_remote_etesync">Afegeix un calendari remot (EteSync)</string>
     <string name="preferences_list_general">Configuració general</string>
     <string name="preferences_list_calendar_summary_invisible">No es mostren els esdeveniments</string>
     <string name="preferences_list_calendar_summary_sync_off">No sincronitzat</string>

--- a/res/values-ca/strings.xml
+++ b/res/values-ca/strings.xml
@@ -310,8 +310,6 @@
     <string name="preferences_list_add_offline_error_empty">Introdueix un nom de calendari!</string>
     <string name="preferences_list_add_offline_title">Afegeix un calendari fora de línia</string>
     <string name="preferences_list_add_offline">Afegeix un calendari fora de línia</string>
-    <string name="preferences_list_add_remote">Afegeix un calendari remot (CalDAV)</string>
-    <string name="preferences_list_add_remote_etesync">Afegeix un calendari remot (EteSync)</string>
     <string name="preferences_list_general">Configuració general</string>
     <string name="preferences_list_calendar_summary_invisible">No es mostren els esdeveniments</string>
     <string name="preferences_list_calendar_summary_sync_off">No sincronitzat</string>

--- a/res/values-da/strings.xml
+++ b/res/values-da/strings.xml
@@ -303,6 +303,7 @@
     <string name="preferences_list_calendar_summary_invisible">Begivenheder vises ikke</string>
     <string name="preferences_list_general">Generel opsætning</string>
     <string name="preferences_list_add_remote">Tilføj fjernkalender (CalDAV)</string>
+    <string name="preferences_list_add_remote_etesync">Tilføj fjernkalender (EteSync)</string>
     <string name="preferences_list_add_offline">Tilføj offlinekalender</string>
     <string name="preferences_list_add_offline_title">Tilføj offlinekalender</string>
     <string name="preferences_list_add_offline_error_empty">Indtast kalendernavn!</string>

--- a/res/values-da/strings.xml
+++ b/res/values-da/strings.xml
@@ -302,8 +302,6 @@
     <string name="preferences_list_calendar_summary_sync_off">Ikke synkroniseret</string>
     <string name="preferences_list_calendar_summary_invisible">Begivenheder vises ikke</string>
     <string name="preferences_list_general">Generel opsætning</string>
-    <string name="preferences_list_add_remote">Tilføj fjernkalender (CalDAV)</string>
-    <string name="preferences_list_add_remote_etesync">Tilføj fjernkalender (EteSync)</string>
     <string name="preferences_list_add_offline">Tilføj offlinekalender</string>
     <string name="preferences_list_add_offline_title">Tilføj offlinekalender</string>
     <string name="preferences_list_add_offline_error_empty">Indtast kalendernavn!</string>

--- a/res/values-de/strings.xml
+++ b/res/values-de/strings.xml
@@ -325,8 +325,6 @@
     <string name="preferences_calendar_color_warning_message">Die Änderung der Farbe kann zurückgesetzt werden, wenn der Kalender erneut synchronisiert wird.
 \n
 \nIn DAVx⁵ kann \'Kalenderfarben verwalten\' deaktiviert werden, um dies zu verhindern.</string>
-    <string name="preferences_list_add_remote">Kalender hinzufügen (CalDAV)</string>
-    <string name="preferences_list_add_remote_etesync">Kalender hinzufügen (EteSync)</string>
     <string name="app_copyright">© 2015-<xliff:g>%1$s</xliff:g> The Etar Project. Teile davon © 2005-<xliff:g>%1$s</xliff:g> The Android Open Source Project.</string>
     <string name="authors">Autoren</string>
     <string name="changelog">Änderungsübersicht</string>

--- a/res/values-de/strings.xml
+++ b/res/values-de/strings.xml
@@ -326,6 +326,7 @@
 \n
 \nIn DAVx⁵ kann \'Kalenderfarben verwalten\' deaktiviert werden, um dies zu verhindern.</string>
     <string name="preferences_list_add_remote">Kalender hinzufügen (CalDAV)</string>
+    <string name="preferences_list_add_remote_etesync">Kalender hinzufügen (EteSync)</string>
     <string name="app_copyright">© 2015-<xliff:g>%1$s</xliff:g> The Etar Project. Teile davon © 2005-<xliff:g>%1$s</xliff:g> The Android Open Source Project.</string>
     <string name="authors">Autoren</string>
     <string name="changelog">Änderungsübersicht</string>

--- a/res/values-en-rGB/strings.xml
+++ b/res/values-en-rGB/strings.xml
@@ -244,8 +244,8 @@
     <string name="visibility_private">Private</string>
     <string name="visibility_public">Public</string>
     <string name="share_label">Partilhar</string>
-    <string name="preferences_list_add_remote">Add remote calendar (CalDAV)</string>
-    <string name="preferences_list_add_remote_etesync">Add remote calendar (EteSync)</string>
+    <string name="preferences_list_add_remote">Add CalDAV calendar</string>
+    <string name="preferences_list_add_remote_etesync">Add EteSync calendar</string>
     <string name="preferences_list_add_offline">Add offline calendar</string>
     <string name="preferences_list_add_offline_title">Add offline calendar</string>
     <string name="preferences_list_add_offline_error_empty">Enter a calendar name!</string>

--- a/res/values-en-rGB/strings.xml
+++ b/res/values-en-rGB/strings.xml
@@ -245,6 +245,7 @@
     <string name="visibility_public">Public</string>
     <string name="share_label">Partilhar</string>
     <string name="preferences_list_add_remote">Add remote calendar (CalDAV)</string>
+    <string name="preferences_list_add_remote_etesync">Add remote calendar (EteSync)</string>
     <string name="preferences_list_add_offline">Add offline calendar</string>
     <string name="preferences_list_add_offline_title">Add offline calendar</string>
     <string name="preferences_list_add_offline_error_empty">Enter a calendar name!</string>

--- a/res/values-es/strings.xml
+++ b/res/values-es/strings.xml
@@ -309,6 +309,7 @@
     <string name="preferences_list_calendar_summary_invisible">No se están mostrando los eventos</string>
     <string name="preferences_list_general">Configuración general</string>
     <string name="preferences_list_add_remote">Añadir calendario remoto (CalDAV)</string>
+    <string name="preferences_list_add_remote_etesync">Añadir calendario remoto (EteSync)</string>
     <string name="preferences_list_add_offline">Añadir calendario fuera de línea</string>
     <string name="preferences_list_add_offline_title">Añadir calendario fuera de línea</string>
     <string name="preferences_list_add_offline_error_empty">¡Entrar nombre de calendario!</string>

--- a/res/values-es/strings.xml
+++ b/res/values-es/strings.xml
@@ -308,8 +308,6 @@
     <string name="preferences_list_calendar_summary_sync_off">No sincronizado</string>
     <string name="preferences_list_calendar_summary_invisible">No se están mostrando los eventos</string>
     <string name="preferences_list_general">Configuración general</string>
-    <string name="preferences_list_add_remote">Añadir calendario remoto (CalDAV)</string>
-    <string name="preferences_list_add_remote_etesync">Añadir calendario remoto (EteSync)</string>
     <string name="preferences_list_add_offline">Añadir calendario fuera de línea</string>
     <string name="preferences_list_add_offline_title">Añadir calendario fuera de línea</string>
     <string name="preferences_list_add_offline_error_empty">¡Entrar nombre de calendario!</string>

--- a/res/values-eu/strings.xml
+++ b/res/values-eu/strings.xml
@@ -304,6 +304,7 @@
     <string name="preferences_list_calendar_summary_invisible">Gertaerak ez dira bistaratzen</string>
     <string name="preferences_list_general">Ezarpen orokorrak</string>
     <string name="preferences_list_add_remote">Gehitu urruneko egutegia (CalDAV)</string>
+    <string name="preferences_list_add_remote_etesync">Gehitu urruneko egutegia (EteSync)</string>
     <string name="preferences_list_add_offline">Gehitu lineaz kanpoko egutegia</string>
     <string name="preferences_list_add_offline_title">Gehitu lineaz kanpoko egutegia</string>
     <string name="preferences_list_add_offline_error_empty">Idatzi egutegiaren izena!</string>

--- a/res/values-eu/strings.xml
+++ b/res/values-eu/strings.xml
@@ -303,8 +303,6 @@
     <string name="preferences_list_calendar_summary_sync_off">Ez sinkronizatuta</string>
     <string name="preferences_list_calendar_summary_invisible">Gertaerak ez dira bistaratzen</string>
     <string name="preferences_list_general">Ezarpen orokorrak</string>
-    <string name="preferences_list_add_remote">Gehitu urruneko egutegia (CalDAV)</string>
-    <string name="preferences_list_add_remote_etesync">Gehitu urruneko egutegia (EteSync)</string>
     <string name="preferences_list_add_offline">Gehitu lineaz kanpoko egutegia</string>
     <string name="preferences_list_add_offline_title">Gehitu lineaz kanpoko egutegia</string>
     <string name="preferences_list_add_offline_error_empty">Idatzi egutegiaren izena!</string>

--- a/res/values-fr/strings.xml
+++ b/res/values-fr/strings.xml
@@ -309,6 +309,7 @@
     <string name="preferences_list_calendar_summary_invisible">Les évènements ne sont pas affichés</string>
     <string name="preferences_list_general">Paramètres généraux</string>
     <string name="preferences_list_add_remote">Ajouter un calendrier distant (CalDAV)</string>
+    <string name="preferences_list_add_remote_etesync">Ajouter un calendrier distant (EteSync)</string>
     <string name="preferences_list_add_offline">Ajouter un calendrier hors-ligne</string>
     <string name="preferences_list_add_offline_title">Ajouter un calendrier hors-ligne</string>
     <string name="preferences_list_add_offline_error_empty">Veuillez saisir le nom du calendrier !</string>

--- a/res/values-fr/strings.xml
+++ b/res/values-fr/strings.xml
@@ -308,8 +308,6 @@
     <string name="preferences_list_calendar_summary_sync_off">Non synchronisé</string>
     <string name="preferences_list_calendar_summary_invisible">Les évènements ne sont pas affichés</string>
     <string name="preferences_list_general">Paramètres généraux</string>
-    <string name="preferences_list_add_remote">Ajouter un calendrier distant (CalDAV)</string>
-    <string name="preferences_list_add_remote_etesync">Ajouter un calendrier distant (EteSync)</string>
     <string name="preferences_list_add_offline">Ajouter un calendrier hors-ligne</string>
     <string name="preferences_list_add_offline_title">Ajouter un calendrier hors-ligne</string>
     <string name="preferences_list_add_offline_error_empty">Veuillez saisir le nom du calendrier !</string>

--- a/res/values-hr/strings.xml
+++ b/res/values-hr/strings.xml
@@ -325,6 +325,7 @@
     <string name="preferences_list_calendar_summary_invisible">Događaji se ne prikazuju</string>
     <string name="preferences_list_general">Opće postavke</string>
     <string name="preferences_list_add_remote">Dodaj udaljeni kalendar (CalDAV)</string>
+    <string name="preferences_list_add_remote_etesync">Dodaj udaljeni kalendar (EteSync)</string>
     <string name="preferences_list_add_offline">Dodaj izvanmrežni kalendar</string>
     <string name="preferences_list_add_offline_title">Dodaj izvanmrežni kalendar</string>
     <string name="preferences_list_add_offline_error_empty">Upiši ime kalendara!</string>

--- a/res/values-hr/strings.xml
+++ b/res/values-hr/strings.xml
@@ -324,8 +324,6 @@
     <string name="preferences_list_calendar_summary_sync_off">Nije sinkronizirano</string>
     <string name="preferences_list_calendar_summary_invisible">Događaji se ne prikazuju</string>
     <string name="preferences_list_general">Opće postavke</string>
-    <string name="preferences_list_add_remote">Dodaj udaljeni kalendar (CalDAV)</string>
-    <string name="preferences_list_add_remote_etesync">Dodaj udaljeni kalendar (EteSync)</string>
     <string name="preferences_list_add_offline">Dodaj izvanmrežni kalendar</string>
     <string name="preferences_list_add_offline_title">Dodaj izvanmrežni kalendar</string>
     <string name="preferences_list_add_offline_error_empty">Upiši ime kalendara!</string>

--- a/res/values-it/strings.xml
+++ b/res/values-it/strings.xml
@@ -303,6 +303,7 @@
     <string name="preferences_list_calendar_summary_sync_off">Non sincronizzato</string>
     <string name="preferences_list_general">Impostazioni generali</string>
     <string name="preferences_list_add_remote">Aggiungi calendario remoto (CalDAV)</string>
+    <string name="preferences_list_add_remote_etesync">Aggiungi calendario remoto (EteSync)</string>
     <string name="preferences_list_add_offline">Aggiungi calendario offline</string>
     <string name="offline_account_name">Calendario offline</string>
     <string name="authors">Autori</string>

--- a/res/values-it/strings.xml
+++ b/res/values-it/strings.xml
@@ -302,8 +302,6 @@
     <string name="preferences_calendar_synchronize">Sincronizza questo calendario</string>
     <string name="preferences_list_calendar_summary_sync_off">Non sincronizzato</string>
     <string name="preferences_list_general">Impostazioni generali</string>
-    <string name="preferences_list_add_remote">Aggiungi calendario remoto (CalDAV)</string>
-    <string name="preferences_list_add_remote_etesync">Aggiungi calendario remoto (EteSync)</string>
     <string name="preferences_list_add_offline">Aggiungi calendario offline</string>
     <string name="offline_account_name">Calendario offline</string>
     <string name="authors">Autori</string>

--- a/res/values-nb/strings.xml
+++ b/res/values-nb/strings.xml
@@ -309,8 +309,6 @@
     <string name="preferences_list_calendar_summary_sync_off">Ikke synkronisert</string>
     <string name="preferences_list_calendar_summary_invisible">Aktiviteter vises ikke</string>
     <string name="preferences_list_general">Hovedinnstillinger</string>
-    <string name="preferences_list_add_remote">Legg til kalender annensteds fra (CalDAV)</string>
-    <string name="preferences_list_add_remote_etesync">Legg til kalender annensteds fra (EteSync)</string>
     <string name="preferences_list_add_offline">Legg til frakoblet kalender</string>
     <string name="preferences_list_add_offline_title">Legg til frakoblet kalender</string>
     <string name="preferences_list_add_offline_error_empty">Skriv inn kalendernavn!</string>

--- a/res/values-nb/strings.xml
+++ b/res/values-nb/strings.xml
@@ -310,6 +310,7 @@
     <string name="preferences_list_calendar_summary_invisible">Aktiviteter vises ikke</string>
     <string name="preferences_list_general">Hovedinnstillinger</string>
     <string name="preferences_list_add_remote">Legg til kalender annensteds fra (CalDAV)</string>
+    <string name="preferences_list_add_remote_etesync">Legg til kalender annensteds fra (EteSync)</string>
     <string name="preferences_list_add_offline">Legg til frakoblet kalender</string>
     <string name="preferences_list_add_offline_title">Legg til frakoblet kalender</string>
     <string name="preferences_list_add_offline_error_empty">Skriv inn kalendernavn!</string>

--- a/res/values-pt-rPT/strings.xml
+++ b/res/values-pt-rPT/strings.xml
@@ -329,8 +329,6 @@
     <string name="preferences_calendar_color_warning_button">Percebi</string>
     <string name="preferences_list_add_offline_button">Adicionar calendário</string>
     <string name="preferences_list_calendar_summary_sync_off">Não sincronizado</string>
-    <string name="preferences_list_add_remote">Adicionar calendário remoto (CalDAV)</string>
-    <string name="preferences_list_add_remote_etesync">Adicionar calendário remoto (EteSync)</string>
     <string name="six_days">6 dias</string>
     <string name="authors">Autores</string>
     <string name="two_days">2 dias</string>

--- a/res/values-pt-rPT/strings.xml
+++ b/res/values-pt-rPT/strings.xml
@@ -330,6 +330,7 @@
     <string name="preferences_list_add_offline_button">Adicionar calendário</string>
     <string name="preferences_list_calendar_summary_sync_off">Não sincronizado</string>
     <string name="preferences_list_add_remote">Adicionar calendário remoto (CalDAV)</string>
+    <string name="preferences_list_add_remote_etesync">Adicionar calendário remoto (EteSync)</string>
     <string name="six_days">6 dias</string>
     <string name="authors">Autores</string>
     <string name="two_days">2 dias</string>

--- a/res/values-pt/strings.xml
+++ b/res/values-pt/strings.xml
@@ -325,6 +325,7 @@
     <string name="preferences_calendar_no_display_name">Calendário sem nome</string>
     <string name="cal_import_error_time_zone_msg">Incapaz de entender o fuso horário: %s</string>
     <string name="preferences_list_add_remote">Adicionar calendário remoto (CalDAV)</string>
+    <string name="preferences_list_add_remote_etesync">Adicionar calendário remoto (EteSync)</string>
     <string name="preferences_list_add_offline">Adicionar calendário local</string>
     <string name="preferences_list_add_offline_title">Adicionar calendário local</string>
     <string name="preferences_list_add_offline_error_empty">Introduza um nome!</string>

--- a/res/values-pt/strings.xml
+++ b/res/values-pt/strings.xml
@@ -324,8 +324,6 @@
     <string name="source_code">Código fonte</string>
     <string name="preferences_calendar_no_display_name">Calendário sem nome</string>
     <string name="cal_import_error_time_zone_msg">Incapaz de entender o fuso horário: %s</string>
-    <string name="preferences_list_add_remote">Adicionar calendário remoto (CalDAV)</string>
-    <string name="preferences_list_add_remote_etesync">Adicionar calendário remoto (EteSync)</string>
     <string name="preferences_list_add_offline">Adicionar calendário local</string>
     <string name="preferences_list_add_offline_title">Adicionar calendário local</string>
     <string name="preferences_list_add_offline_error_empty">Introduza um nome!</string>

--- a/res/values-ru/strings.xml
+++ b/res/values-ru/strings.xml
@@ -324,8 +324,6 @@
     <string name="preferences_list_calendar_summary_sync_off">Не синхронизирован</string>
     <string name="preferences_list_calendar_summary_invisible">События не отображаются</string>
     <string name="preferences_list_general">Общие настройки</string>
-    <string name="preferences_list_add_remote">Добавить удалённый календарь (CalDAV)</string>
-    <string name="preferences_list_add_remote_etesync">Добавить удалённый календарь (EteSync)</string>
     <string name="preferences_list_add_offline">Добавить локальный календарь</string>
     <string name="preferences_list_add_offline_title">Добавить локальный календарь</string>
     <string name="preferences_list_add_offline_error_empty">Введите название календаря!</string>

--- a/res/values-ru/strings.xml
+++ b/res/values-ru/strings.xml
@@ -325,6 +325,7 @@
     <string name="preferences_list_calendar_summary_invisible">События не отображаются</string>
     <string name="preferences_list_general">Общие настройки</string>
     <string name="preferences_list_add_remote">Добавить удалённый календарь (CalDAV)</string>
+    <string name="preferences_list_add_remote_etesync">Добавить удалённый календарь (EteSync)</string>
     <string name="preferences_list_add_offline">Добавить локальный календарь</string>
     <string name="preferences_list_add_offline_title">Добавить локальный календарь</string>
     <string name="preferences_list_add_offline_error_empty">Введите название календаря!</string>

--- a/res/values-tr/strings.xml
+++ b/res/values-tr/strings.xml
@@ -307,8 +307,6 @@
     <string name="preferences_list_calendar_summary_sync_off">Senkronize değil</string>
     <string name="preferences_list_calendar_summary_invisible">Olaylar gösterilmiyor</string>
     <string name="preferences_list_general">Genel ayarlar</string>
-    <string name="preferences_list_add_remote">Uzak takvim ekle (CalDAV)</string>
-    <string name="preferences_list_add_remote_etesync">Uzak takvim ekle (EteSync)</string>
     <string name="preferences_list_add_offline">Çevrimdışı takvim ekle</string>
     <string name="preferences_list_add_offline_title">Çevrimdışı takvim ekle</string>
     <string name="preferences_list_add_offline_error_empty">Bir takvim adı girin!</string>

--- a/res/values-tr/strings.xml
+++ b/res/values-tr/strings.xml
@@ -308,6 +308,7 @@
     <string name="preferences_list_calendar_summary_invisible">Olaylar gösterilmiyor</string>
     <string name="preferences_list_general">Genel ayarlar</string>
     <string name="preferences_list_add_remote">Uzak takvim ekle (CalDAV)</string>
+    <string name="preferences_list_add_remote_etesync">Uzak takvim ekle (EteSync)</string>
     <string name="preferences_list_add_offline">Çevrimdışı takvim ekle</string>
     <string name="preferences_list_add_offline_title">Çevrimdışı takvim ekle</string>
     <string name="preferences_list_add_offline_error_empty">Bir takvim adı girin!</string>

--- a/res/values-uk/strings.xml
+++ b/res/values-uk/strings.xml
@@ -328,6 +328,7 @@
     <string name="preferences_list_calendar_summary_invisible">Події не показуються</string>
     <string name="preferences_list_general">Загальні налаштування</string>
     <string name="preferences_list_add_remote">Додати віддалений календар (CalDAV)</string>
+    <string name="preferences_list_add_remote_etesync">Додати віддалений календар (CalDAV)</string>
     <string name="preferences_list_add_offline">Додати автономний календар</string>
     <string name="preferences_list_add_offline_title">Додати автономний календар</string>
     <string name="preferences_list_add_offline_error_empty">Введіть назву календаря!</string>

--- a/res/values-uk/strings.xml
+++ b/res/values-uk/strings.xml
@@ -327,8 +327,6 @@
     <string name="preferences_list_calendar_summary_sync_off">Не синхронізовано</string>
     <string name="preferences_list_calendar_summary_invisible">Події не показуються</string>
     <string name="preferences_list_general">Загальні налаштування</string>
-    <string name="preferences_list_add_remote">Додати віддалений календар (CalDAV)</string>
-    <string name="preferences_list_add_remote_etesync">Додати віддалений календар (CalDAV)</string>
     <string name="preferences_list_add_offline">Додати автономний календар</string>
     <string name="preferences_list_add_offline_title">Додати автономний календар</string>
     <string name="preferences_list_add_offline_error_empty">Введіть назву календаря!</string>

--- a/res/values-zh-rCN/strings.xml
+++ b/res/values-zh-rCN/strings.xml
@@ -310,6 +310,7 @@
     <string name="preferences_list_calendar_summary_invisible">事件未显示</string>
     <string name="preferences_list_general">通用设置</string>
     <string name="preferences_list_add_remote">添加远程日历 (CalDAV)</string>
+    <string name="preferences_list_add_remote_etesync">添加远程日历 (EteSync)</string>
     <string name="preferences_list_add_offline">添加离线日历</string>
     <string name="preferences_list_add_offline_title">添加离线日历</string>
     <string name="preferences_list_add_offline_error_empty">输入日历名称！</string>

--- a/res/values-zh-rCN/strings.xml
+++ b/res/values-zh-rCN/strings.xml
@@ -309,8 +309,6 @@
     <string name="preferences_list_calendar_summary_sync_off">未同步</string>
     <string name="preferences_list_calendar_summary_invisible">事件未显示</string>
     <string name="preferences_list_general">通用设置</string>
-    <string name="preferences_list_add_remote">添加远程日历 (CalDAV)</string>
-    <string name="preferences_list_add_remote_etesync">添加远程日历 (EteSync)</string>
     <string name="preferences_list_add_offline">添加离线日历</string>
     <string name="preferences_list_add_offline_title">添加离线日历</string>
     <string name="preferences_list_add_offline_error_empty">输入日历名称！</string>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -789,8 +789,8 @@
     <string name="preferences_list_calendar_summary_sync_off">Not synchronized</string>
     <string name="preferences_list_calendar_summary_invisible">Events are not displayed</string>
     <string name="preferences_list_general">General settings</string>
-    <string name="preferences_list_add_remote">Add remote calendar (CalDAV)</string>
-    <string name="preferences_list_add_remote_etesync">Add remote calendar (EteSync)</string>
+    <string name="preferences_list_add_remote">Add CalDAV calendar</string>
+    <string name="preferences_list_add_remote_etesync">Add EteSync calendar</string>
     <string name="preferences_list_add_offline">Add offline calendar</string>
     <string name="preferences_list_add_offline_title">Add offline calendar</string>
     <string name="preferences_list_add_offline_error_empty">Enter a calendar name!</string>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -790,6 +790,7 @@
     <string name="preferences_list_calendar_summary_invisible">Events are not displayed</string>
     <string name="preferences_list_general">General settings</string>
     <string name="preferences_list_add_remote">Add remote calendar (CalDAV)</string>
+    <string name="preferences_list_add_remote_etesync">Add remote calendar (EteSync)</string>
     <string name="preferences_list_add_offline">Add offline calendar</string>
     <string name="preferences_list_add_offline_title">Add offline calendar</string>
     <string name="preferences_list_add_offline_error_empty">Enter a calendar name!</string>

--- a/src/com/android/calendar/settings/MainListPreferences.kt
+++ b/src/com/android/calendar/settings/MainListPreferences.kt
@@ -161,6 +161,13 @@ class MainListPreferences : PreferenceFragmentCompat() {
             launchDavX5Login()
             true
         }
+        val addEtesyncPreference = Preference(context).apply {
+            title = getString(R.string.preferences_list_add_remote_etesync)
+        }
+        addEtesyncPreference.setOnPreferenceClickListener {
+            launchAddEtesync()
+            true
+        }
         val addOfflinePreference = Preference(context).apply {
             title = getString(R.string.preferences_list_add_offline)
         }
@@ -170,6 +177,7 @@ class MainListPreferences : PreferenceFragmentCompat() {
         }
         screen.addPreference(generalPreference)
         screen.addPreference(addCaldavPreference)
+        screen.addPreference(addEtesyncPreference)
         screen.addPreference(addOfflinePreference)
     }
 
@@ -199,6 +207,33 @@ class MainListPreferences : PreferenceFragmentCompat() {
                 val downloadIntent = Intent(Intent.ACTION_VIEW,
                         Uri.parse("https://f-droid.org/repository/browse/?fdid=at.bitfire.davdroid"))
                 if (downloadIntent.resolveActivity(activity!!.packageManager) != null) {
+                    startActivity(downloadIntent)
+                } else {
+                    Toast.makeText(activity, "No browser available!", Toast.LENGTH_LONG).show()
+                }
+            }
+        }
+    }
+
+    private fun launchAddEtesync() {
+        val packageManager = requireActivity().packageManager
+        val etesyncPackage = "com.etesync.syncadapter"
+        val etesyncIntent = packageManager.getLaunchIntentForPackage(etesyncPackage)
+
+        if (etesyncIntent != null) {
+            startActivity(etesyncIntent)
+        } else {
+            // EteSync is not installed
+            val installIntent = Intent(Intent.ACTION_VIEW, Uri.parse("market://details?id=${etesyncPackage}"))
+
+            // launch market
+            if (installIntent.resolveActivity(packageManager) != null) {
+                startActivity(installIntent)
+            } else {
+                // no f-droid market app or Play store installed -> launch browser for f-droid url
+                val downloadIntent = Intent(Intent.ACTION_VIEW,
+                        Uri.parse("https://f-droid.org/repository/browse/?fdid=${etesyncPackage}"))
+                if (downloadIntent.resolveActivity(packageManager) != null) {
                     startActivity(downloadIntent)
                 } else {
                     Toast.makeText(activity, "No browser available!", Toast.LENGTH_LONG).show()


### PR DESCRIPTION
EteSync is a fully open-source (clients and server), end-to-end encrypted,
and privacy respecting sync for your contacts, calendars and tasks.

This change was kept as close as possible to the existing CalDAV/DAVx5 button
so it made it possible for me to easily add translations for all languages that
already had the CalDAV button translated.