### PR TITLE
add more options for reminders, refactor reminder labels

### DIFF
--- a/res/layout/edit_reminder_item.xml
+++ b/res/layout/edit_reminder_item.xml
@@ -25,7 +25,6 @@
         android:layout_height="wrap_content"
         android:layout_marginTop="4dp"
         android:contentDescription="@string/accessibility_reminder_time"
-        android:entries="@array/reminder_minutes_labels"
         android:gravity="top|start"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />

--- a/res/values-af/arrays.xml
+++ b/res/values-af/arrays.xml
@@ -22,27 +22,6 @@
     <item msgid="2658001219380695677">"SMS"</item>
     <item msgid="7926918288165444873">"Alarm"</item>
   </string-array>
-  <string-array name="preferences_default_reminder_labels">
-    <item msgid="7495163916242649023">"Geen"</item>
-    <item msgid="5883344836499335043">"0 minute"</item>
-    <item msgid="4354350447805231188">"1 minuut"</item>
-    <item msgid="265674592625309858">"5 minute"</item>
-    <item msgid="8011089417728419666">"10 minute"</item>
-    <item msgid="6177098581805412986">"15 minute"</item>
-    <item msgid="356346660503078923">"20 minute"</item>
-    <item msgid="992592434377054063">"25 minute"</item>
-    <item msgid="9191353668596201944">"30 minute"</item>
-    <item msgid="1192985682962908244">"45 minute"</item>
-    <item msgid="1694315499429259938">"1 uur"</item>
-    <item msgid="8281019320591769635">"2 uur"</item>
-    <item msgid="2062931719019287773">"3 uur"</item>
-    <item msgid="4086495711621133006">"12 uur"</item>
-    <item msgid="3172669681920709561">"24 uur"</item>
-    <item msgid="5557836606782821910">"2 dae"</item>
-    <item msgid="8336577387266744930">"1 week"</item>
-    <item>2 weeks</item>
-    <item>4 weeks</item>
-  </string-array>
   <string-array name="preferences_week_start_day_labels">
     <item msgid="986150274035512339">"Locale-verstek"</item>
     <item msgid="134027225275475280">"Saterdag"</item>

--- a/res/values-af/arrays.xml
+++ b/res/values-af/arrays.xml
@@ -22,24 +22,6 @@
     <item msgid="2658001219380695677">"SMS"</item>
     <item msgid="7926918288165444873">"Alarm"</item>
   </string-array>
-  <string-array name="reminder_minutes_labels">
-    <item msgid="2416970002377237011">"0 minute"</item>
-    <item msgid="6681865010714743948">"1 minuut"</item>
-    <item msgid="2327505114623595779">"5 minute"</item>
-    <item msgid="1657410063332547113">"10 minute"</item>
-    <item msgid="366087535181197780">"15 minute"</item>
-    <item msgid="6252612791145061929">"20 minute"</item>
-    <item msgid="7896694531989090700">"25 minute"</item>
-    <item msgid="8754510169374808607">"30 minute"</item>
-    <item msgid="3113380274218454394">"45 minute"</item>
-    <item msgid="8546646645868526283">"1 uur"</item>
-    <item msgid="6467845211024768872">"2 uur"</item>
-    <item msgid="8201677619511076575">"3 uur"</item>
-    <item msgid="7172504281650128893">"12 uur"</item>
-    <item msgid="9114286702181482496">"24 uur"</item>
-    <item msgid="3107009344872997366">"2 dae"</item>
-    <item msgid="6135563708172153696">"1 week"</item>
-  </string-array>
   <string-array name="preferences_default_reminder_labels">
     <item msgid="7495163916242649023">"Geen"</item>
     <item msgid="5883344836499335043">"0 minute"</item>
@@ -58,6 +40,8 @@
     <item msgid="3172669681920709561">"24 uur"</item>
     <item msgid="5557836606782821910">"2 dae"</item>
     <item msgid="8336577387266744930">"1 week"</item>
+    <item>2 weeks</item>
+    <item>4 weeks</item>
   </string-array>
   <string-array name="preferences_week_start_day_labels">
     <item msgid="986150274035512339">"Locale-verstek"</item>

--- a/res/values-af/strings.xml
+++ b/res/values-af/strings.xml
@@ -242,4 +242,5 @@
     <string name="snooze_delay_dialog_title">Stel sluimer vertraging</string>
     <string name="preferences_default_snooze_delay_title">Standaard sluimer vertragings tyd</string>
     <string name="preferences_default_snooze_delay_dialog">Standaard sluimer vertraging</string>
+    <string name="no_reminder_label">Geen</string>
 </resources>

--- a/res/values-am/arrays.xml
+++ b/res/values-am/arrays.xml
@@ -22,24 +22,6 @@
     <item msgid="2658001219380695677">"አጭር የፅሁፍ መልዕክት"</item>
     <item msgid="7926918288165444873">"ማንቂያ ደውል"</item>
   </string-array>
-  <string-array name="reminder_minutes_labels">
-    <item msgid="2416970002377237011">"0 ደቂቃዎች"</item>
-    <item msgid="6681865010714743948">"1 ደቂቃ"</item>
-    <item msgid="2327505114623595779">"5 ደቂቃዎች"</item>
-    <item msgid="1657410063332547113">"10 ደቂቃዎች"</item>
-    <item msgid="366087535181197780">"15 ደቂቃዎች"</item>
-    <item msgid="6252612791145061929">"20 ደቂቃዎች"</item>
-    <item msgid="7896694531989090700">"25 ደቂቃዎች"</item>
-    <item msgid="8754510169374808607">"30 ደቂቃዎች"</item>
-    <item msgid="3113380274218454394">"45 ደቂቃዎች"</item>
-    <item msgid="8546646645868526283">"1 ሰዓት"</item>
-    <item msgid="6467845211024768872">"2 ሰዓቶች"</item>
-    <item msgid="8201677619511076575">"3 ሰዓቶች"</item>
-    <item msgid="7172504281650128893">"12 ሰዓቶች"</item>
-    <item msgid="9114286702181482496">"24 ሰዓቶች"</item>
-    <item msgid="3107009344872997366">"2 ቀኖች"</item>
-    <item msgid="6135563708172153696">"1 ሳምንት"</item>
-  </string-array>
   <string-array name="preferences_default_reminder_labels">
     <item msgid="7495163916242649023">"የለም"</item>
     <item msgid="5883344836499335043">"0 ደቂቃዎች"</item>
@@ -58,6 +40,8 @@
     <item msgid="3172669681920709561">"24 ሰዓቶች"</item>
     <item msgid="5557836606782821910">"2 ቀኖች"</item>
     <item msgid="8336577387266744930">"1 ሳምንት"</item>
+    <item>2 weeks</item>
+    <item>4 weeks</item>
   </string-array>
   <string-array name="preferences_week_start_day_labels">
     <item msgid="986150274035512339">"የአካባቢ ነባሪ"</item>

--- a/res/values-am/arrays.xml
+++ b/res/values-am/arrays.xml
@@ -22,27 +22,6 @@
     <item msgid="2658001219380695677">"አጭር የፅሁፍ መልዕክት"</item>
     <item msgid="7926918288165444873">"ማንቂያ ደውል"</item>
   </string-array>
-  <string-array name="preferences_default_reminder_labels">
-    <item msgid="7495163916242649023">"የለም"</item>
-    <item msgid="5883344836499335043">"0 ደቂቃዎች"</item>
-    <item msgid="4354350447805231188">"1 ደቂቃ"</item>
-    <item msgid="265674592625309858">"5 ደቂቃዎች"</item>
-    <item msgid="8011089417728419666">"10 ደቂቃዎች"</item>
-    <item msgid="6177098581805412986">"15 ደቂቃዎች"</item>
-    <item msgid="356346660503078923">"20 ደቂቃዎች"</item>
-    <item msgid="992592434377054063">"25 ደቂቃዎች"</item>
-    <item msgid="9191353668596201944">"30 ደቂቃዎች"</item>
-    <item msgid="1192985682962908244">"45 ደቂቃዎች"</item>
-    <item msgid="1694315499429259938">"1 ሰዓት"</item>
-    <item msgid="8281019320591769635">"2 ሰዓቶች"</item>
-    <item msgid="2062931719019287773">"3 ሰዓቶች"</item>
-    <item msgid="4086495711621133006">"12 ሰዓቶች"</item>
-    <item msgid="3172669681920709561">"24 ሰዓቶች"</item>
-    <item msgid="5557836606782821910">"2 ቀኖች"</item>
-    <item msgid="8336577387266744930">"1 ሳምንት"</item>
-    <item>2 weeks</item>
-    <item>4 weeks</item>
-  </string-array>
   <string-array name="preferences_week_start_day_labels">
     <item msgid="986150274035512339">"የአካባቢ ነባሪ"</item>
     <item msgid="134027225275475280">"ቅዳሜ"</item>

--- a/res/values-am/strings.xml
+++ b/res/values-am/strings.xml
@@ -236,4 +236,5 @@
     <string name="visibility_default">ነባሪ</string>
     <string name="visibility_private">የግል</string>
     <string name="visibility_public">ሕዝብ</string>
+    <string name="no_reminder_label">የለም</string>
 </resources>

--- a/res/values-ar/arrays.xml
+++ b/res/values-ar/arrays.xml
@@ -22,24 +22,6 @@
     <item msgid="2658001219380695677">"رسائل SMS"</item>
     <item msgid="7926918288165444873">"المنبه"</item>
   </string-array>
-  <string-array name="reminder_minutes_labels">
-    <item msgid="2416970002377237011">"0 دقائق"</item>
-    <item msgid="6681865010714743948">"دقيقة واحدة"</item>
-    <item msgid="2327505114623595779">"5 دقائق"</item>
-    <item msgid="1657410063332547113">"10 دقائق"</item>
-    <item msgid="366087535181197780">"15 دقيقة"</item>
-    <item msgid="6252612791145061929">"20 دقيقة"</item>
-    <item msgid="7896694531989090700">"25 دقيقة"</item>
-    <item msgid="8754510169374808607">"30 دقيقة"</item>
-    <item msgid="3113380274218454394">"45 دقيقة"</item>
-    <item msgid="8546646645868526283">"ساعة واحدة"</item>
-    <item msgid="6467845211024768872">"ساعتان"</item>
-    <item msgid="8201677619511076575">"3 ساعات"</item>
-    <item msgid="7172504281650128893">"12 ساعة"</item>
-    <item msgid="9114286702181482496">"24 ساعة"</item>
-    <item msgid="3107009344872997366">"يومان"</item>
-    <item msgid="6135563708172153696">"أسبوع واحد"</item>
-  </string-array>
   <string-array name="preferences_default_reminder_labels">
     <item msgid="7495163916242649023">"لا شيء"</item>
     <item msgid="5883344836499335043">"0 دقائق"</item>
@@ -58,6 +40,8 @@
     <item msgid="3172669681920709561">"24 ساعة"</item>
     <item msgid="5557836606782821910">"يومان"</item>
     <item msgid="8336577387266744930">"أسبوع واحد"</item>
+    <item>2 weeks</item>
+    <item>4 weeks</item>
   </string-array>
   <string-array name="preferences_week_start_day_labels">
     <item msgid="986150274035512339">"اللغة الافتراضية"</item>

--- a/res/values-ar/arrays.xml
+++ b/res/values-ar/arrays.xml
@@ -22,27 +22,6 @@
     <item msgid="2658001219380695677">"رسائل SMS"</item>
     <item msgid="7926918288165444873">"المنبه"</item>
   </string-array>
-  <string-array name="preferences_default_reminder_labels">
-    <item msgid="7495163916242649023">"لا شيء"</item>
-    <item msgid="5883344836499335043">"0 دقائق"</item>
-    <item msgid="4354350447805231188">"دقيقة واحدة"</item>
-    <item msgid="265674592625309858">"5 دقائق"</item>
-    <item msgid="8011089417728419666">"10 دقائق"</item>
-    <item msgid="6177098581805412986">"15 دقيقة"</item>
-    <item msgid="356346660503078923">"20 دقيقة"</item>
-    <item msgid="992592434377054063">"25 دقيقة"</item>
-    <item msgid="9191353668596201944">"30 دقيقة"</item>
-    <item msgid="1192985682962908244">"45 دقيقة"</item>
-    <item msgid="1694315499429259938">"ساعة واحدة"</item>
-    <item msgid="8281019320591769635">"ساعتان"</item>
-    <item msgid="2062931719019287773">"3 ساعات"</item>
-    <item msgid="4086495711621133006">"12 ساعة"</item>
-    <item msgid="3172669681920709561">"24 ساعة"</item>
-    <item msgid="5557836606782821910">"يومان"</item>
-    <item msgid="8336577387266744930">"أسبوع واحد"</item>
-    <item>2 weeks</item>
-    <item>4 weeks</item>
-  </string-array>
   <string-array name="preferences_week_start_day_labels">
     <item msgid="986150274035512339">"اللغة الافتراضية"</item>
     <item msgid="134027225275475280">"السبت"</item>

--- a/res/values-ar/strings.xml
+++ b/res/values-ar/strings.xml
@@ -342,4 +342,5 @@
     <string name="foreground_notification_channel_name">تنبيه التزامن</string>
     <string name="rsvp_declined">تمت الإجابة بلا.</string>
     <string name="rsvp_tentative">تمت الإحابة بمحتمل.</string>
+    <string name="no_reminder_label">لا شيء</string>
 </resources>

--- a/res/values-be/arrays.xml
+++ b/res/values-be/arrays.xml
@@ -22,24 +22,6 @@
     <item msgid="2658001219380695677">"SMS"</item>
     <item msgid="7926918288165444873">"Будзільнік"</item>
   </string-array>
-  <string-array name="reminder_minutes_labels">
-    <item msgid="2416970002377237011">"0 хвілін"</item>
-    <item msgid="6681865010714743948">"1 хвіліна"</item>
-    <item msgid="2327505114623595779">"5 хвілін"</item>
-    <item msgid="1657410063332547113">"10 хвілін"</item>
-    <item msgid="366087535181197780">"15 хвілін"</item>
-    <item msgid="6252612791145061929">"20 хвілін"</item>
-    <item msgid="7896694531989090700">"25 хвілін"</item>
-    <item msgid="8754510169374808607">"30 хвілін"</item>
-    <item msgid="3113380274218454394">"45 хвілін"</item>
-    <item msgid="8546646645868526283">"1 гадзіна"</item>
-    <item msgid="6467845211024768872">"2 гадзіны"</item>
-    <item msgid="8201677619511076575">"3 гадзіны"</item>
-    <item msgid="7172504281650128893">"12 гадзін"</item>
-    <item msgid="9114286702181482496">"24 гадзіны"</item>
-    <item msgid="3107009344872997366">"2 дні"</item>
-    <item msgid="6135563708172153696">"1 тыдзень"</item>
-  </string-array>
   <string-array name="preferences_default_reminder_labels">
     <item msgid="7495163916242649023">"Няма"</item>
     <item msgid="5883344836499335043">"0 хвілін"</item>
@@ -58,6 +40,8 @@
     <item msgid="3172669681920709561">"24 гадзіны"</item>
     <item msgid="5557836606782821910">"2 дні"</item>
     <item msgid="8336577387266744930">"1 тыдзень"</item>
+    <item>2 weeks</item>
+    <item>4 weeks</item>
   </string-array>
   <string-array name="preferences_week_start_day_labels">
     <item msgid="986150274035512339">"Рэгiянальная налада па змаўчанні"</item>

--- a/res/values-be/arrays.xml
+++ b/res/values-be/arrays.xml
@@ -22,27 +22,6 @@
     <item msgid="2658001219380695677">"SMS"</item>
     <item msgid="7926918288165444873">"Будзільнік"</item>
   </string-array>
-  <string-array name="preferences_default_reminder_labels">
-    <item msgid="7495163916242649023">"Няма"</item>
-    <item msgid="5883344836499335043">"0 хвілін"</item>
-    <item msgid="4354350447805231188">"1 хвіліна"</item>
-    <item msgid="265674592625309858">"5 хвілін"</item>
-    <item msgid="8011089417728419666">"10 хвілін"</item>
-    <item msgid="6177098581805412986">"15 хвілін"</item>
-    <item msgid="356346660503078923">"20 хвілін"</item>
-    <item msgid="992592434377054063">"25 хвілін"</item>
-    <item msgid="9191353668596201944">"30 хвілін"</item>
-    <item msgid="1192985682962908244">"45 хвілін"</item>
-    <item msgid="1694315499429259938">"1 гадзіна"</item>
-    <item msgid="8281019320591769635">"2 гадзіны"</item>
-    <item msgid="2062931719019287773">"3 гадзіны"</item>
-    <item msgid="4086495711621133006">"12 гадзін"</item>
-    <item msgid="3172669681920709561">"24 гадзіны"</item>
-    <item msgid="5557836606782821910">"2 дні"</item>
-    <item msgid="8336577387266744930">"1 тыдзень"</item>
-    <item>2 weeks</item>
-    <item>4 weeks</item>
-  </string-array>
   <string-array name="preferences_week_start_day_labels">
     <item msgid="986150274035512339">"Рэгiянальная налада па змаўчанні"</item>
     <item msgid="134027225275475280">"Субота"</item>

--- a/res/values-be/strings.xml
+++ b/res/values-be/strings.xml
@@ -291,4 +291,5 @@
     <string name="one_hour">1 гадзіна</string>
     <string name="one_and_a_half_hours">1.5 гадзіны</string>
     <string name="two_hours">2 гадзіны</string>
+    <string name="no_reminder_label">Няма</string>
 </resources>

--- a/res/values-bg/arrays.xml
+++ b/res/values-bg/arrays.xml
@@ -22,27 +22,6 @@
     <item msgid="2658001219380695677">"SMS"</item>
     <item msgid="7926918288165444873">"Будилник"</item>
   </string-array>
-  <string-array name="preferences_default_reminder_labels">
-    <item msgid="7495163916242649023">"Няма"</item>
-    <item msgid="5883344836499335043">"0 минути"</item>
-    <item msgid="4354350447805231188">"1 минута"</item>
-    <item msgid="265674592625309858">"5 минути"</item>
-    <item msgid="8011089417728419666">"10 минути"</item>
-    <item msgid="6177098581805412986">"15 минути"</item>
-    <item msgid="356346660503078923">"20 минути"</item>
-    <item msgid="992592434377054063">"25 минути"</item>
-    <item msgid="9191353668596201944">"30 минути"</item>
-    <item msgid="1192985682962908244">"45 минути"</item>
-    <item msgid="1694315499429259938">"1 час"</item>
-    <item msgid="8281019320591769635">"2 часа"</item>
-    <item msgid="2062931719019287773">"3 часа"</item>
-    <item msgid="4086495711621133006">"12 часа"</item>
-    <item msgid="3172669681920709561">"24 часа"</item>
-    <item msgid="5557836606782821910">"2 дни"</item>
-    <item msgid="8336577387266744930">"1 седмица"</item>
-    <item>2 weeks</item>
-    <item>4 weeks</item>
-  </string-array>
   <string-array name="preferences_week_start_day_labels">
     <item msgid="986150274035512339">"Стандартно за локала"</item>
     <item msgid="134027225275475280">"събота"</item>

--- a/res/values-bg/arrays.xml
+++ b/res/values-bg/arrays.xml
@@ -22,24 +22,6 @@
     <item msgid="2658001219380695677">"SMS"</item>
     <item msgid="7926918288165444873">"Будилник"</item>
   </string-array>
-  <string-array name="reminder_minutes_labels">
-    <item msgid="2416970002377237011">"0 минути"</item>
-    <item msgid="6681865010714743948">"1 минута"</item>
-    <item msgid="2327505114623595779">"5 минути"</item>
-    <item msgid="1657410063332547113">"10 минути"</item>
-    <item msgid="366087535181197780">"15 минути"</item>
-    <item msgid="6252612791145061929">"20 минути"</item>
-    <item msgid="7896694531989090700">"25 минути"</item>
-    <item msgid="8754510169374808607">"30 минути"</item>
-    <item msgid="3113380274218454394">"45 минути"</item>
-    <item msgid="8546646645868526283">"1 час"</item>
-    <item msgid="6467845211024768872">"2 часа"</item>
-    <item msgid="8201677619511076575">"3 часа"</item>
-    <item msgid="7172504281650128893">"12 часа"</item>
-    <item msgid="9114286702181482496">"24 часа"</item>
-    <item msgid="3107009344872997366">"2 дни"</item>
-    <item msgid="6135563708172153696">"1 седмица"</item>
-  </string-array>
   <string-array name="preferences_default_reminder_labels">
     <item msgid="7495163916242649023">"Няма"</item>
     <item msgid="5883344836499335043">"0 минути"</item>
@@ -58,6 +40,8 @@
     <item msgid="3172669681920709561">"24 часа"</item>
     <item msgid="5557836606782821910">"2 дни"</item>
     <item msgid="8336577387266744930">"1 седмица"</item>
+    <item>2 weeks</item>
+    <item>4 weeks</item>
   </string-array>
   <string-array name="preferences_week_start_day_labels">
     <item msgid="986150274035512339">"Стандартно за локала"</item>

--- a/res/values-bg/strings.xml
+++ b/res/values-bg/strings.xml
@@ -236,4 +236,5 @@
     <string name="visibility_default">Стандартно</string>
     <string name="visibility_private">Частно</string>
     <string name="visibility_public">Обществено</string>
+    <string name="no_reminder_label">Няма</string>
 </resources>

--- a/res/values-ca/arrays.xml
+++ b/res/values-ca/arrays.xml
@@ -22,27 +22,6 @@
     <item msgid="2658001219380695677">"SMS"</item>
     <item msgid="7926918288165444873">"Alarma"</item>
   </string-array>
-  <string-array name="preferences_default_reminder_labels">
-    <item msgid="7495163916242649023">"Cap"</item>
-    <item msgid="5883344836499335043">"0 minuts"</item>
-    <item msgid="4354350447805231188">"1 minut"</item>
-    <item msgid="265674592625309858">"5 minuts"</item>
-    <item msgid="8011089417728419666">"10 minuts"</item>
-    <item msgid="6177098581805412986">"15 minuts"</item>
-    <item msgid="356346660503078923">"20 minuts"</item>
-    <item msgid="992592434377054063">"25 minuts"</item>
-    <item msgid="9191353668596201944">"30 minuts"</item>
-    <item msgid="1192985682962908244">"45 minuts"</item>
-    <item msgid="1694315499429259938">"1 hora"</item>
-    <item msgid="8281019320591769635">"2 hores"</item>
-    <item msgid="2062931719019287773">"3 hores"</item>
-    <item msgid="4086495711621133006">"12 hores"</item>
-    <item msgid="3172669681920709561">"24 hores"</item>
-    <item msgid="5557836606782821910">"2 dies"</item>
-    <item msgid="8336577387266744930">"1 setmana"</item>
-    <item>2 weeks</item>
-    <item>4 weeks</item>
-  </string-array>
   <string-array name="preferences_week_start_day_labels">
     <item msgid="986150274035512339">"Regió predeterminada"</item>
     <item msgid="134027225275475280">"Dissabte"</item>

--- a/res/values-ca/arrays.xml
+++ b/res/values-ca/arrays.xml
@@ -22,24 +22,6 @@
     <item msgid="2658001219380695677">"SMS"</item>
     <item msgid="7926918288165444873">"Alarma"</item>
   </string-array>
-  <string-array name="reminder_minutes_labels">
-    <item msgid="2416970002377237011">"0 minuts"</item>
-    <item msgid="6681865010714743948">"1 minut"</item>
-    <item msgid="2327505114623595779">"5 minuts"</item>
-    <item msgid="1657410063332547113">"10 minuts"</item>
-    <item msgid="366087535181197780">"15 minuts"</item>
-    <item msgid="6252612791145061929">"20 minuts"</item>
-    <item msgid="7896694531989090700">"25 minuts"</item>
-    <item msgid="8754510169374808607">"30 minuts"</item>
-    <item msgid="3113380274218454394">"45 minuts"</item>
-    <item msgid="8546646645868526283">"1 hora"</item>
-    <item msgid="6467845211024768872">"2 hores"</item>
-    <item msgid="8201677619511076575">"3 hores"</item>
-    <item msgid="7172504281650128893">"12 hores"</item>
-    <item msgid="9114286702181482496">"24 hores"</item>
-    <item msgid="3107009344872997366">"2 dies"</item>
-    <item msgid="6135563708172153696">"1 setmana"</item>
-  </string-array>
   <string-array name="preferences_default_reminder_labels">
     <item msgid="7495163916242649023">"Cap"</item>
     <item msgid="5883344836499335043">"0 minuts"</item>
@@ -58,6 +40,8 @@
     <item msgid="3172669681920709561">"24 hores"</item>
     <item msgid="5557836606782821910">"2 dies"</item>
     <item msgid="8336577387266744930">"1 setmana"</item>
+    <item>2 weeks</item>
+    <item>4 weeks</item>
   </string-array>
   <string-array name="preferences_week_start_day_labels">
     <item msgid="986150274035512339">"Regió predeterminada"</item>

--- a/res/values-ca/strings.xml
+++ b/res/values-ca/strings.xml
@@ -337,4 +337,5 @@
     <string name="preferences_pure_black_night_mode">Mode negra nit pura</string>
     <string name="preferences_system_theme">Sistema</string>
     <string name="preferences_list_add_remote">Afegeix un calendari CalDAV</string>
+    <string name="no_reminder_label">Cap</string>
 </resources>

--- a/res/values-cs/arrays.xml
+++ b/res/values-cs/arrays.xml
@@ -22,24 +22,6 @@
     <item msgid="2658001219380695677">"SMS"</item>
     <item msgid="7926918288165444873">"Budík"</item>
   </string-array>
-  <string-array name="reminder_minutes_labels">
-    <item msgid="2416970002377237011">"0 minut"</item>
-    <item msgid="6681865010714743948">"1 minuta"</item>
-    <item msgid="2327505114623595779">"5 minut"</item>
-    <item msgid="1657410063332547113">"10 minut"</item>
-    <item msgid="366087535181197780">"15 minut"</item>
-    <item msgid="6252612791145061929">"20 minut"</item>
-    <item msgid="7896694531989090700">"25 minut"</item>
-    <item msgid="8754510169374808607">"30 minut"</item>
-    <item msgid="3113380274218454394">"45 minut"</item>
-    <item msgid="8546646645868526283">"1 hodina"</item>
-    <item msgid="6467845211024768872">"2 hodiny"</item>
-    <item msgid="8201677619511076575">"3 hodiny"</item>
-    <item msgid="7172504281650128893">"12 hodin"</item>
-    <item msgid="9114286702181482496">"24 hodin"</item>
-    <item msgid="3107009344872997366">"2 dny"</item>
-    <item msgid="6135563708172153696">"1 týden"</item>
-  </string-array>
   <string-array name="preferences_default_reminder_labels">
     <item msgid="7495163916242649023">"Žádný"</item>
     <item msgid="5883344836499335043">"0 minut"</item>
@@ -58,6 +40,8 @@
     <item msgid="3172669681920709561">"24 hodin"</item>
     <item msgid="5557836606782821910">"2 dny"</item>
     <item msgid="8336577387266744930">"1 týden"</item>
+    <item>2 weeks</item>
+    <item>4 weeks</item>
   </string-array>
   <string-array name="preferences_week_start_day_labels">
     <item msgid="986150274035512339">"Výchozí hodnota regionálního nastavení"</item>

--- a/res/values-cs/arrays.xml
+++ b/res/values-cs/arrays.xml
@@ -22,27 +22,6 @@
     <item msgid="2658001219380695677">"SMS"</item>
     <item msgid="7926918288165444873">"Budík"</item>
   </string-array>
-  <string-array name="preferences_default_reminder_labels">
-    <item msgid="7495163916242649023">"Žádný"</item>
-    <item msgid="5883344836499335043">"0 minut"</item>
-    <item msgid="4354350447805231188">"1 minuta"</item>
-    <item msgid="265674592625309858">"5 minut"</item>
-    <item msgid="8011089417728419666">"10 minut"</item>
-    <item msgid="6177098581805412986">"15 minut"</item>
-    <item msgid="356346660503078923">"20 minut"</item>
-    <item msgid="992592434377054063">"25 minut"</item>
-    <item msgid="9191353668596201944">"30 minut"</item>
-    <item msgid="1192985682962908244">"45 minut"</item>
-    <item msgid="1694315499429259938">"1 hodina"</item>
-    <item msgid="8281019320591769635">"2 hodiny"</item>
-    <item msgid="2062931719019287773">"3 hodiny"</item>
-    <item msgid="4086495711621133006">"12 hodin"</item>
-    <item msgid="3172669681920709561">"24 hodin"</item>
-    <item msgid="5557836606782821910">"2 dny"</item>
-    <item msgid="8336577387266744930">"1 týden"</item>
-    <item>2 weeks</item>
-    <item>4 weeks</item>
-  </string-array>
   <string-array name="preferences_week_start_day_labels">
     <item msgid="986150274035512339">"Výchozí hodnota regionálního nastavení"</item>
     <item msgid="134027225275475280">"Sobota"</item>

--- a/res/values-cs/strings.xml
+++ b/res/values-cs/strings.xml
@@ -242,4 +242,5 @@
     <string name="snooze_delay_dialog_title">Nastavit délku odložení</string>
     <string name="preferences_default_snooze_delay_title">Výchozí délka odložení</string>
     <string name="preferences_default_snooze_delay_dialog">Výchozí délka odložení</string>
+    <string name="no_reminder_label">Žádný</string>
 </resources>

--- a/res/values-da/arrays.xml
+++ b/res/values-da/arrays.xml
@@ -22,24 +22,6 @@
     <item msgid="2658001219380695677">"Sms"</item>
     <item msgid="7926918288165444873">"Påmindelse"</item>
   </string-array>
-  <string-array name="reminder_minutes_labels">
-    <item msgid="2416970002377237011">"0 minutter"</item>
-    <item msgid="6681865010714743948">"1 minut"</item>
-    <item msgid="2327505114623595779">"5 minutter"</item>
-    <item msgid="1657410063332547113">"10 minutter"</item>
-    <item msgid="366087535181197780">"15 minutter"</item>
-    <item msgid="6252612791145061929">"20 minutter"</item>
-    <item msgid="7896694531989090700">"25 minutter"</item>
-    <item msgid="8754510169374808607">"30 minutter"</item>
-    <item msgid="3113380274218454394">"45 minutter"</item>
-    <item msgid="8546646645868526283">"1 time"</item>
-    <item msgid="6467845211024768872">"2 timer"</item>
-    <item msgid="8201677619511076575">"3 timer"</item>
-    <item msgid="7172504281650128893">"12 timer"</item>
-    <item msgid="9114286702181482496">"24 timer"</item>
-    <item msgid="3107009344872997366">"2 dage"</item>
-    <item msgid="6135563708172153696">"1 uge"</item>
-  </string-array>
   <string-array name="preferences_default_reminder_labels">
     <item msgid="7495163916242649023">"Ingen"</item>
     <item msgid="5883344836499335043">"0 minutter"</item>
@@ -58,6 +40,8 @@
     <item msgid="3172669681920709561">"24 timer"</item>
     <item msgid="5557836606782821910">"2 dage"</item>
     <item msgid="8336577387266744930">"1 uge"</item>
+    <item>2 weeks</item>
+    <item>4 weeks</item>
   </string-array>
   <string-array name="preferences_week_start_day_labels">
     <item msgid="986150274035512339">"Landestandard"</item>

--- a/res/values-da/arrays.xml
+++ b/res/values-da/arrays.xml
@@ -22,27 +22,6 @@
     <item msgid="2658001219380695677">"Sms"</item>
     <item msgid="7926918288165444873">"Påmindelse"</item>
   </string-array>
-  <string-array name="preferences_default_reminder_labels">
-    <item msgid="7495163916242649023">"Ingen"</item>
-    <item msgid="5883344836499335043">"0 minutter"</item>
-    <item msgid="4354350447805231188">"1 minut"</item>
-    <item msgid="265674592625309858">"5 minutter"</item>
-    <item msgid="8011089417728419666">"10 minutter"</item>
-    <item msgid="6177098581805412986">"15 minutter"</item>
-    <item msgid="356346660503078923">"20 minutter"</item>
-    <item msgid="992592434377054063">"25 minutter"</item>
-    <item msgid="9191353668596201944">"30 minutter"</item>
-    <item msgid="1192985682962908244">"45 minutter"</item>
-    <item msgid="1694315499429259938">"1 time"</item>
-    <item msgid="8281019320591769635">"2 timer"</item>
-    <item msgid="2062931719019287773">"3 timer"</item>
-    <item msgid="4086495711621133006">"12 timer"</item>
-    <item msgid="3172669681920709561">"24 timer"</item>
-    <item msgid="5557836606782821910">"2 dage"</item>
-    <item msgid="8336577387266744930">"1 uge"</item>
-    <item>2 weeks</item>
-    <item>4 weeks</item>
-  </string-array>
   <string-array name="preferences_week_start_day_labels">
     <item msgid="986150274035512339">"Landestandard"</item>
     <item msgid="134027225275475280">"lørdag"</item>

--- a/res/values-da/strings.xml
+++ b/res/values-da/strings.xml
@@ -318,4 +318,5 @@
     <string name="preferences_calendar_configure_account">Indstille kalender i %1$s</string>
     <string name="preferences_calendar_number_of_events">%1d begivenheder</string>
     <string name="preferences_calendar_info_category">Kalendar information</string>
+    <string name="no_reminder_label">Ingen</string>
 </resources>

--- a/res/values-de/arrays.xml
+++ b/res/values-de/arrays.xml
@@ -22,27 +22,6 @@
     <item msgid="2658001219380695677">"SMS"</item>
     <item msgid="7926918288165444873">"Wecker"</item>
   </string-array>
-  <string-array name="preferences_default_reminder_labels">
-    <item msgid="7495163916242649023">"Keine"</item>
-    <item msgid="5883344836499335043">"0 Minuten"</item>
-    <item msgid="4354350447805231188">"1 Minute"</item>
-    <item msgid="265674592625309858">"5 Minuten"</item>
-    <item msgid="8011089417728419666">"10 Minuten"</item>
-    <item msgid="6177098581805412986">"15 Minuten"</item>
-    <item msgid="356346660503078923">"20 Minuten"</item>
-    <item msgid="992592434377054063">"25 Minuten"</item>
-    <item msgid="9191353668596201944">"30 Minuten"</item>
-    <item msgid="1192985682962908244">"45 Minuten"</item>
-    <item msgid="1694315499429259938">"1 Stunde"</item>
-    <item msgid="8281019320591769635">"2 Stunden"</item>
-    <item msgid="2062931719019287773">"3 Stunden"</item>
-    <item msgid="4086495711621133006">"12 Stunden"</item>
-    <item msgid="3172669681920709561">"24 Stunden"</item>
-    <item msgid="5557836606782821910">"2 Tage"</item>
-    <item msgid="8336577387266744930">"1 Woche"</item>
-    <item>2 Wochen</item>
-    <item>4 Wochen</item>
-  </string-array>
   <string-array name="preferences_week_start_day_labels">
     <item msgid="986150274035512339">"Gebietsschema - Standard"</item>
     <item msgid="134027225275475280">"Samstag"</item>

--- a/res/values-de/arrays.xml
+++ b/res/values-de/arrays.xml
@@ -22,24 +22,6 @@
     <item msgid="2658001219380695677">"SMS"</item>
     <item msgid="7926918288165444873">"Wecker"</item>
   </string-array>
-  <string-array name="reminder_minutes_labels">
-    <item msgid="2416970002377237011">"0 Minuten"</item>
-    <item msgid="6681865010714743948">"1 Minute"</item>
-    <item msgid="2327505114623595779">"5 Minuten"</item>
-    <item msgid="1657410063332547113">"10 Minuten"</item>
-    <item msgid="366087535181197780">"15 Minuten"</item>
-    <item msgid="6252612791145061929">"20 Minuten"</item>
-    <item msgid="7896694531989090700">"25 Minuten"</item>
-    <item msgid="8754510169374808607">"30 Minuten"</item>
-    <item msgid="3113380274218454394">"45 Minuten"</item>
-    <item msgid="8546646645868526283">"1 Stunde"</item>
-    <item msgid="6467845211024768872">"2 Stunden"</item>
-    <item msgid="8201677619511076575">"3 Stunden"</item>
-    <item msgid="7172504281650128893">"12 Stunden"</item>
-    <item msgid="9114286702181482496">"24 Stunden"</item>
-    <item msgid="3107009344872997366">"2 Tage"</item>
-    <item msgid="6135563708172153696">"1 Woche"</item>
-  </string-array>
   <string-array name="preferences_default_reminder_labels">
     <item msgid="7495163916242649023">"Keine"</item>
     <item msgid="5883344836499335043">"0 Minuten"</item>
@@ -58,6 +40,8 @@
     <item msgid="3172669681920709561">"24 Stunden"</item>
     <item msgid="5557836606782821910">"2 Tage"</item>
     <item msgid="8336577387266744930">"1 Woche"</item>
+    <item>2 Wochen</item>
+    <item>4 Wochen</item>
   </string-array>
   <string-array name="preferences_week_start_day_labels">
     <item msgid="986150274035512339">"Gebietsschema - Standard"</item>

--- a/res/values-de/strings.xml
+++ b/res/values-de/strings.xml
@@ -341,4 +341,5 @@
     <string name="preferences_list_add_remote_etesync">Füge EteSync Kalender hinzu</string>
     <string name="preferences_list_add_remote">Füge CalDAV Kalender hinzu</string>
     <string name="preferences_pure_black_night_mode">Rein schwarzer Nachtmodus</string>
+    <string name="no_reminder_label">Keine</string>
 </resources>

--- a/res/values-de/strings.xml
+++ b/res/values-de/strings.xml
@@ -22,20 +22,24 @@
     <string name="date_time_fmt" msgid="1642972650061946484"><xliff:g id="date">%1$s</xliff:g>, <xliff:g id="time_interval">%2$s</xliff:g></string>
     <string name="no_title_label" msgid="302177118061368042">"(Kein Titel)"</string>
     <plurals name="Nminutes">
-        <item quantity="one">Eine Minute</item>
+        <item quantity="one">1 Minute</item>
         <item quantity="other"><xliff:g id="count">%d</xliff:g> Minuten</item>
     </plurals>
     <plurals name="Nmins">
-        <item quantity="one">Eine Minute</item>
+        <item quantity="one">1 Minute</item>
         <item quantity="other"><xliff:g id="count">%d</xliff:g> Minuten</item>
     </plurals>
     <plurals name="Nhours">
-        <item quantity="one">Eine Stunde</item>
+        <item quantity="one">1 Stunde</item>
         <item quantity="other"><xliff:g id="count">%d</xliff:g> Stunden</item>
     </plurals>
     <plurals name="Ndays">
-        <item quantity="one">Ein Tag</item>
+        <item quantity="one">1 Tag</item>
         <item quantity="other"><xliff:g id="count">%d</xliff:g> Tage</item>
+    </plurals>
+    <plurals name="Nweeks">
+        <item quantity="one">1 Woche</item>
+        <item quantity="other"><xliff:g id="count">%d</xliff:g> Wochen</item>
     </plurals>
     <plurals name="weekN">
         <item quantity="one">Eine Woche <xliff:g id="count">%d</xliff:g></item>

--- a/res/values-el/arrays.xml
+++ b/res/values-el/arrays.xml
@@ -22,27 +22,6 @@
     <item msgid="2658001219380695677">"SMS"</item>
     <item msgid="7926918288165444873">"Ξυπνητήρι"</item>
   </string-array>
-  <string-array name="preferences_default_reminder_labels">
-    <item msgid="7495163916242649023">"Κανένα"</item>
-    <item msgid="5883344836499335043">"0 λεπτά"</item>
-    <item msgid="4354350447805231188">"1 λεπτό"</item>
-    <item msgid="265674592625309858">"5 λεπτά"</item>
-    <item msgid="8011089417728419666">"10 λεπτά"</item>
-    <item msgid="6177098581805412986">"15 λεπτά"</item>
-    <item msgid="356346660503078923">"20 λεπτά"</item>
-    <item msgid="992592434377054063">"25 λεπτά"</item>
-    <item msgid="9191353668596201944">"30 λεπτά"</item>
-    <item msgid="1192985682962908244">"45 λεπτά"</item>
-    <item msgid="1694315499429259938">"1 ώρα"</item>
-    <item msgid="8281019320591769635">"2 ώρες"</item>
-    <item msgid="2062931719019287773">"3 ώρες"</item>
-    <item msgid="4086495711621133006">"12 ώρες"</item>
-    <item msgid="3172669681920709561">"24 ώρες"</item>
-    <item msgid="5557836606782821910">"2 ημέρες"</item>
-    <item msgid="8336577387266744930">"1 εβδομάδα"</item>
-    <item>2 weeks</item>
-    <item>4 weeks</item>
-  </string-array>
   <string-array name="preferences_week_start_day_labels">
     <item msgid="986150274035512339">"Προεπιλογή τοπικών ρυθμίσεων"</item>
     <item msgid="134027225275475280">"Σάββατο"</item>

--- a/res/values-el/arrays.xml
+++ b/res/values-el/arrays.xml
@@ -22,24 +22,6 @@
     <item msgid="2658001219380695677">"SMS"</item>
     <item msgid="7926918288165444873">"Ξυπνητήρι"</item>
   </string-array>
-  <string-array name="reminder_minutes_labels">
-    <item msgid="2416970002377237011">"0 λεπτά"</item>
-    <item msgid="6681865010714743948">"1 λεπτό"</item>
-    <item msgid="2327505114623595779">"5 λεπτά"</item>
-    <item msgid="1657410063332547113">"10 λεπτά"</item>
-    <item msgid="366087535181197780">"15 λεπτά"</item>
-    <item msgid="6252612791145061929">"20 λεπτά"</item>
-    <item msgid="7896694531989090700">"25 λεπτά"</item>
-    <item msgid="8754510169374808607">"30 λεπτά"</item>
-    <item msgid="3113380274218454394">"45 λεπτά"</item>
-    <item msgid="8546646645868526283">"1 ώρα"</item>
-    <item msgid="6467845211024768872">"2 ώρες"</item>
-    <item msgid="8201677619511076575">"3 ώρες"</item>
-    <item msgid="7172504281650128893">"12 ώρες"</item>
-    <item msgid="9114286702181482496">"24 ώρες"</item>
-    <item msgid="3107009344872997366">"2 ημέρες"</item>
-    <item msgid="6135563708172153696">"1 εβδομάδα"</item>
-  </string-array>
   <string-array name="preferences_default_reminder_labels">
     <item msgid="7495163916242649023">"Κανένα"</item>
     <item msgid="5883344836499335043">"0 λεπτά"</item>
@@ -58,6 +40,8 @@
     <item msgid="3172669681920709561">"24 ώρες"</item>
     <item msgid="5557836606782821910">"2 ημέρες"</item>
     <item msgid="8336577387266744930">"1 εβδομάδα"</item>
+    <item>2 weeks</item>
+    <item>4 weeks</item>
   </string-array>
   <string-array name="preferences_week_start_day_labels">
     <item msgid="986150274035512339">"Προεπιλογή τοπικών ρυθμίσεων"</item>

--- a/res/values-el/strings.xml
+++ b/res/values-el/strings.xml
@@ -336,4 +336,5 @@
     <string name="view_settings">Ρυθμίσεις</string>
     <string name="goto_date">Μετάβαση…</string>
     <string name="share_label">Μοιράσου</string>
+    <string name="no_reminder_label">Κανένα</string>
 </resources>

--- a/res/values-en-rGB/arrays.xml
+++ b/res/values-en-rGB/arrays.xml
@@ -22,24 +22,6 @@
     <item msgid="2658001219380695677">"SMS"</item>
     <item msgid="7926918288165444873">"Alarm"</item>
   </string-array>
-  <string-array name="reminder_minutes_labels">
-    <item msgid="2416970002377237011">"0 minutes"</item>
-    <item msgid="6681865010714743948">"1 minute"</item>
-    <item msgid="2327505114623595779">"5 minutes"</item>
-    <item msgid="1657410063332547113">"10 minutes"</item>
-    <item msgid="366087535181197780">"15 minutes"</item>
-    <item msgid="6252612791145061929">"20 minutes"</item>
-    <item msgid="7896694531989090700">"25 minutes"</item>
-    <item msgid="8754510169374808607">"30 minutes"</item>
-    <item msgid="3113380274218454394">"45 minutes"</item>
-    <item msgid="8546646645868526283">"1 hour"</item>
-    <item msgid="6467845211024768872">"2 hours"</item>
-    <item msgid="8201677619511076575">"3 hours"</item>
-    <item msgid="7172504281650128893">"12 hours"</item>
-    <item msgid="9114286702181482496">"24 hours"</item>
-    <item msgid="3107009344872997366">"2 days"</item>
-    <item msgid="6135563708172153696">"1 week"</item>
-  </string-array>
   <string-array name="preferences_default_reminder_labels">
     <item msgid="7495163916242649023">"None"</item>
     <item msgid="5883344836499335043">"0 minutes"</item>
@@ -58,6 +40,8 @@
     <item msgid="3172669681920709561">"24 hours"</item>
     <item msgid="5557836606782821910">"2 days"</item>
     <item msgid="8336577387266744930">"1 week"</item>
+    <item>2 weeks</item>
+    <item>4 weeks</item>
   </string-array>
   <string-array name="preferences_week_start_day_labels">
     <item msgid="986150274035512339">"Locale default"</item>

--- a/res/values-en-rGB/arrays.xml
+++ b/res/values-en-rGB/arrays.xml
@@ -22,27 +22,6 @@
     <item msgid="2658001219380695677">"SMS"</item>
     <item msgid="7926918288165444873">"Alarm"</item>
   </string-array>
-  <string-array name="preferences_default_reminder_labels">
-    <item msgid="7495163916242649023">"None"</item>
-    <item msgid="5883344836499335043">"0 minutes"</item>
-    <item msgid="4354350447805231188">"1 minute"</item>
-    <item msgid="265674592625309858">"5 minutes"</item>
-    <item msgid="8011089417728419666">"10 minutes"</item>
-    <item msgid="6177098581805412986">"15 minutes"</item>
-    <item msgid="356346660503078923">"20 minutes"</item>
-    <item msgid="992592434377054063">"25 minutes"</item>
-    <item msgid="9191353668596201944">"30 minutes"</item>
-    <item msgid="1192985682962908244">"45 minutes"</item>
-    <item msgid="1694315499429259938">"1 hour"</item>
-    <item msgid="8281019320591769635">"2 hours"</item>
-    <item msgid="2062931719019287773">"3 hours"</item>
-    <item msgid="4086495711621133006">"12 hours"</item>
-    <item msgid="3172669681920709561">"24 hours"</item>
-    <item msgid="5557836606782821910">"2 days"</item>
-    <item msgid="8336577387266744930">"1 week"</item>
-    <item>2 weeks</item>
-    <item>4 weeks</item>
-  </string-array>
   <string-array name="preferences_week_start_day_labels">
     <item msgid="986150274035512339">"Locale default"</item>
     <item msgid="134027225275475280">"Saturday"</item>

--- a/res/values-en-rGB/strings.xml
+++ b/res/values-en-rGB/strings.xml
@@ -337,4 +337,5 @@
     <string name="two_days">2 days</string>
     <string name="preferences_system_theme">System default</string>
     <string name="preferences_pure_black_night_mode">Pure black night mode</string>
+    <string name="no_reminder_label">None</string>
 </resources>

--- a/res/values-es-rUS/arrays.xml
+++ b/res/values-es-rUS/arrays.xml
@@ -22,24 +22,6 @@
     <item msgid="2658001219380695677">"SMS"</item>
     <item msgid="7926918288165444873">"Alarma"</item>
   </string-array>
-  <string-array name="reminder_minutes_labels">
-    <item msgid="2416970002377237011">"0 minutos"</item>
-    <item msgid="6681865010714743948">"1 minuto"</item>
-    <item msgid="2327505114623595779">"5 minutos"</item>
-    <item msgid="1657410063332547113">"10 minutos"</item>
-    <item msgid="366087535181197780">"15 minutos"</item>
-    <item msgid="6252612791145061929">"20 minutos"</item>
-    <item msgid="7896694531989090700">"25 minutos"</item>
-    <item msgid="8754510169374808607">"30 minutos"</item>
-    <item msgid="3113380274218454394">"45 minutos"</item>
-    <item msgid="8546646645868526283">"1 hora"</item>
-    <item msgid="6467845211024768872">"2 horas"</item>
-    <item msgid="8201677619511076575">"3 horas"</item>
-    <item msgid="7172504281650128893">"12 horas"</item>
-    <item msgid="9114286702181482496">"24 horas"</item>
-    <item msgid="3107009344872997366">"2 días"</item>
-    <item msgid="6135563708172153696">"1 semana"</item>
-  </string-array>
   <string-array name="preferences_default_reminder_labels">
     <item msgid="7495163916242649023">"Ninguno"</item>
     <item msgid="5883344836499335043">"0 minutos"</item>
@@ -58,6 +40,8 @@
     <item msgid="3172669681920709561">"24 horas"</item>
     <item msgid="5557836606782821910">"2 días"</item>
     <item msgid="8336577387266744930">"1 semana"</item>
+    <item>2 weeks</item>
+    <item>4 weeks</item>
   </string-array>
   <string-array name="preferences_week_start_day_labels">
     <item msgid="986150274035512339">"Configuración regional predeterminada"</item>

--- a/res/values-es-rUS/arrays.xml
+++ b/res/values-es-rUS/arrays.xml
@@ -22,27 +22,6 @@
     <item msgid="2658001219380695677">"SMS"</item>
     <item msgid="7926918288165444873">"Alarma"</item>
   </string-array>
-  <string-array name="preferences_default_reminder_labels">
-    <item msgid="7495163916242649023">"Ninguno"</item>
-    <item msgid="5883344836499335043">"0 minutos"</item>
-    <item msgid="4354350447805231188">"1 minuto"</item>
-    <item msgid="265674592625309858">"5 minutos"</item>
-    <item msgid="8011089417728419666">"10 minutos"</item>
-    <item msgid="6177098581805412986">"15 minutos"</item>
-    <item msgid="356346660503078923">"20 minutos"</item>
-    <item msgid="992592434377054063">"25 minutos"</item>
-    <item msgid="9191353668596201944">"30 minutos"</item>
-    <item msgid="1192985682962908244">"45 minutos"</item>
-    <item msgid="1694315499429259938">"1 hora"</item>
-    <item msgid="8281019320591769635">"2 horas"</item>
-    <item msgid="2062931719019287773">"3 horas"</item>
-    <item msgid="4086495711621133006">"12 horas"</item>
-    <item msgid="3172669681920709561">"24 horas"</item>
-    <item msgid="5557836606782821910">"2 días"</item>
-    <item msgid="8336577387266744930">"1 semana"</item>
-    <item>2 weeks</item>
-    <item>4 weeks</item>
-  </string-array>
   <string-array name="preferences_week_start_day_labels">
     <item msgid="986150274035512339">"Configuración regional predeterminada"</item>
     <item msgid="134027225275475280">"Sábado"</item>

--- a/res/values-es-rUS/strings.xml
+++ b/res/values-es-rUS/strings.xml
@@ -259,4 +259,5 @@
     <string name="display_options">Ver detalles</string>
     <string name="display_time">Mostrar horario</string>
     <string name="display_location">Mostrar ubicación</string>
+    <string name="no_reminder_label">Ninguno</string>
 </resources>

--- a/res/values-es/arrays.xml
+++ b/res/values-es/arrays.xml
@@ -22,27 +22,6 @@
     <item msgid="2658001219380695677">"SMS"</item>
     <item msgid="7926918288165444873">"Alarma"</item>
   </string-array>
-  <string-array name="preferences_default_reminder_labels">
-    <item msgid="7495163916242649023">"Ninguno"</item>
-    <item msgid="5883344836499335043">"0 minutos"</item>
-    <item msgid="4354350447805231188">"1 minuto"</item>
-    <item msgid="265674592625309858">"5 minutos"</item>
-    <item msgid="8011089417728419666">"10 minutos"</item>
-    <item msgid="6177098581805412986">"15 minutos"</item>
-    <item msgid="356346660503078923">"20 minutos"</item>
-    <item msgid="992592434377054063">"25 minutos"</item>
-    <item msgid="9191353668596201944">"30 minutos"</item>
-    <item msgid="1192985682962908244">"45 minutos"</item>
-    <item msgid="1694315499429259938">"1 hora"</item>
-    <item msgid="8281019320591769635">"2 horas"</item>
-    <item msgid="2062931719019287773">"3 horas"</item>
-    <item msgid="4086495711621133006">"12 horas"</item>
-    <item msgid="3172669681920709561">"24 horas"</item>
-    <item msgid="5557836606782821910">"2 días"</item>
-    <item msgid="8336577387266744930">"1 semana"</item>
-    <item>2 weeks</item>
-    <item>4 weeks</item>
-  </string-array>
   <string-array name="preferences_week_start_day_labels">
     <item msgid="986150274035512339">"Región predeterminada"</item>
     <item msgid="134027225275475280">"Sábado"</item>

--- a/res/values-es/arrays.xml
+++ b/res/values-es/arrays.xml
@@ -22,24 +22,6 @@
     <item msgid="2658001219380695677">"SMS"</item>
     <item msgid="7926918288165444873">"Alarma"</item>
   </string-array>
-  <string-array name="reminder_minutes_labels">
-    <item msgid="2416970002377237011">"0 minutos"</item>
-    <item msgid="6681865010714743948">"1 minuto"</item>
-    <item msgid="2327505114623595779">"5 minutos"</item>
-    <item msgid="1657410063332547113">"10 minutos"</item>
-    <item msgid="366087535181197780">"15 minutos"</item>
-    <item msgid="6252612791145061929">"20 minutos"</item>
-    <item msgid="7896694531989090700">"25 minutos"</item>
-    <item msgid="8754510169374808607">"30 minutos"</item>
-    <item msgid="3113380274218454394">"45 minutos"</item>
-    <item msgid="8546646645868526283">"1 hora"</item>
-    <item msgid="6467845211024768872">"2 horas"</item>
-    <item msgid="8201677619511076575">"3 horas"</item>
-    <item msgid="7172504281650128893">"12 horas"</item>
-    <item msgid="9114286702181482496">"24 horas"</item>
-    <item msgid="3107009344872997366">"2 días"</item>
-    <item msgid="6135563708172153696">"1 semana"</item>
-  </string-array>
   <string-array name="preferences_default_reminder_labels">
     <item msgid="7495163916242649023">"Ninguno"</item>
     <item msgid="5883344836499335043">"0 minutos"</item>
@@ -58,6 +40,8 @@
     <item msgid="3172669681920709561">"24 horas"</item>
     <item msgid="5557836606782821910">"2 días"</item>
     <item msgid="8336577387266744930">"1 semana"</item>
+    <item>2 weeks</item>
+    <item>4 weeks</item>
   </string-array>
   <string-array name="preferences_week_start_day_labels">
     <item msgid="986150274035512339">"Región predeterminada"</item>

--- a/res/values-es/strings.xml
+++ b/res/values-es/strings.xml
@@ -337,4 +337,5 @@
     <string name="preferences_list_add_remote_etesync">Añadir calendario EteSync</string>
     <string name="preferences_list_add_remote">Añadir calendario CalDAV</string>
     <string name="preferences_pure_black_night_mode">Modo noche negro puro</string>
+    <string name="no_reminder_label">Ninguno</string>
 </resources>

--- a/res/values-et/arrays.xml
+++ b/res/values-et/arrays.xml
@@ -22,27 +22,6 @@
     <item msgid="2658001219380695677">"SMS"</item>
     <item msgid="7926918288165444873">"Alarm"</item>
   </string-array>
-  <string-array name="preferences_default_reminder_labels">
-    <item msgid="7495163916242649023">"Puudub"</item>
-    <item msgid="5883344836499335043">"0 minutit"</item>
-    <item msgid="4354350447805231188">"1 minut"</item>
-    <item msgid="265674592625309858">"5 minutit"</item>
-    <item msgid="8011089417728419666">"10 minutit"</item>
-    <item msgid="6177098581805412986">"15 minutit"</item>
-    <item msgid="356346660503078923">"20 minutit"</item>
-    <item msgid="992592434377054063">"25 minutit"</item>
-    <item msgid="9191353668596201944">"30 minutit"</item>
-    <item msgid="1192985682962908244">"45 minutit"</item>
-    <item msgid="1694315499429259938">"1 tund"</item>
-    <item msgid="8281019320591769635">"2 tundi"</item>
-    <item msgid="2062931719019287773">"3 tundi"</item>
-    <item msgid="4086495711621133006">"12 tundi"</item>
-    <item msgid="3172669681920709561">"24 tundi"</item>
-    <item msgid="5557836606782821910">"2 päeva"</item>
-    <item msgid="8336577387266744930">"1 nädal"</item>
-    <item>2 weeks</item>
-    <item>4 weeks</item>
-  </string-array>
   <string-array name="preferences_week_start_day_labels">
     <item msgid="986150274035512339">"Lokaadi vaikeseade"</item>
     <item msgid="134027225275475280">"Laupäev"</item>

--- a/res/values-et/arrays.xml
+++ b/res/values-et/arrays.xml
@@ -22,24 +22,6 @@
     <item msgid="2658001219380695677">"SMS"</item>
     <item msgid="7926918288165444873">"Alarm"</item>
   </string-array>
-  <string-array name="reminder_minutes_labels">
-    <item msgid="2416970002377237011">"0 minutit"</item>
-    <item msgid="6681865010714743948">"1 minut"</item>
-    <item msgid="2327505114623595779">"5 minutit"</item>
-    <item msgid="1657410063332547113">"10 minutit"</item>
-    <item msgid="366087535181197780">"15 minutit"</item>
-    <item msgid="6252612791145061929">"20 minutit"</item>
-    <item msgid="7896694531989090700">"25 minutit"</item>
-    <item msgid="8754510169374808607">"30 minutit"</item>
-    <item msgid="3113380274218454394">"45 minutit"</item>
-    <item msgid="8546646645868526283">"1 tund"</item>
-    <item msgid="6467845211024768872">"2 tundi"</item>
-    <item msgid="8201677619511076575">"3 tundi"</item>
-    <item msgid="7172504281650128893">"12 tundi"</item>
-    <item msgid="9114286702181482496">"24 tundi"</item>
-    <item msgid="3107009344872997366">"2 päeva"</item>
-    <item msgid="6135563708172153696">"1 nädal"</item>
-  </string-array>
   <string-array name="preferences_default_reminder_labels">
     <item msgid="7495163916242649023">"Puudub"</item>
     <item msgid="5883344836499335043">"0 minutit"</item>
@@ -58,6 +40,8 @@
     <item msgid="3172669681920709561">"24 tundi"</item>
     <item msgid="5557836606782821910">"2 päeva"</item>
     <item msgid="8336577387266744930">"1 nädal"</item>
+    <item>2 weeks</item>
+    <item>4 weeks</item>
   </string-array>
   <string-array name="preferences_week_start_day_labels">
     <item msgid="986150274035512339">"Lokaadi vaikeseade"</item>

--- a/res/values-et/strings.xml
+++ b/res/values-et/strings.xml
@@ -236,4 +236,5 @@
     <string name="visibility_default">Vaikeseade</string>
     <string name="visibility_private">Privaatne</string>
     <string name="visibility_public">Avalik</string>
+    <string name="no_reminder_label">Puudub</string>
 </resources>

--- a/res/values-fa/arrays.xml
+++ b/res/values-fa/arrays.xml
@@ -22,27 +22,6 @@
     <item msgid="2658001219380695677">"پیامک"</item>
     <item msgid="7926918288165444873">"زنگ هشدار"</item>
   </string-array>
-  <string-array name="preferences_default_reminder_labels">
-    <item msgid="7495163916242649023">"هیچکدام"</item>
-    <item msgid="5883344836499335043">"0 دقیقه"</item>
-    <item msgid="4354350447805231188">"۱ دقیقه"</item>
-    <item msgid="265674592625309858">"۵ دقیقه"</item>
-    <item msgid="8011089417728419666">"۱۰ دقیقه"</item>
-    <item msgid="6177098581805412986">"۱۵ دقیقه"</item>
-    <item msgid="356346660503078923">"۲۰ دقیقه"</item>
-    <item msgid="992592434377054063">"۲۵ دقیقه"</item>
-    <item msgid="9191353668596201944">"۳۰ دقیقه"</item>
-    <item msgid="1192985682962908244">"۴۵ دقیقه"</item>
-    <item msgid="1694315499429259938">"۱ ساعت"</item>
-    <item msgid="8281019320591769635">"۲ ساعت"</item>
-    <item msgid="2062931719019287773">"۳ ساعت"</item>
-    <item msgid="4086495711621133006">"۱۲ ساعت"</item>
-    <item msgid="3172669681920709561">"۲۴ ساعت"</item>
-    <item msgid="5557836606782821910">"۲ روز"</item>
-    <item msgid="8336577387266744930">"۱ هفته"</item>
-    <item>2 weeks</item>
-    <item>4 weeks</item>
-  </string-array>
   <string-array name="preferences_week_start_day_labels">
     <item msgid="986150274035512339">"پیش‌فرض محلی"</item>
     <item msgid="134027225275475280">"شنبه"</item>

--- a/res/values-fa/arrays.xml
+++ b/res/values-fa/arrays.xml
@@ -22,24 +22,6 @@
     <item msgid="2658001219380695677">"پیامک"</item>
     <item msgid="7926918288165444873">"زنگ هشدار"</item>
   </string-array>
-  <string-array name="reminder_minutes_labels">
-    <item msgid="2416970002377237011">"0 دقیقه"</item>
-    <item msgid="6681865010714743948">"۱ دقیقه"</item>
-    <item msgid="2327505114623595779">"۵ دقیقه"</item>
-    <item msgid="1657410063332547113">"۱۰ دقیقه"</item>
-    <item msgid="366087535181197780">"۱۵ دقیقه"</item>
-    <item msgid="6252612791145061929">"۲۰ دقیقه"</item>
-    <item msgid="7896694531989090700">"۲۵ دقیقه"</item>
-    <item msgid="8754510169374808607">"۳۰ دقیقه"</item>
-    <item msgid="3113380274218454394">"۴۵ دقیقه"</item>
-    <item msgid="8546646645868526283">"۱ ساعت"</item>
-    <item msgid="6467845211024768872">"۲ ساعت"</item>
-    <item msgid="8201677619511076575">"۳ ساعت"</item>
-    <item msgid="7172504281650128893">"۱۲ ساعت"</item>
-    <item msgid="9114286702181482496">"۲۴ ساعت"</item>
-    <item msgid="3107009344872997366">"۲ روز"</item>
-    <item msgid="6135563708172153696">"۱ هفته"</item>
-  </string-array>
   <string-array name="preferences_default_reminder_labels">
     <item msgid="7495163916242649023">"هیچکدام"</item>
     <item msgid="5883344836499335043">"0 دقیقه"</item>
@@ -58,6 +40,8 @@
     <item msgid="3172669681920709561">"۲۴ ساعت"</item>
     <item msgid="5557836606782821910">"۲ روز"</item>
     <item msgid="8336577387266744930">"۱ هفته"</item>
+    <item>2 weeks</item>
+    <item>4 weeks</item>
   </string-array>
   <string-array name="preferences_week_start_day_labels">
     <item msgid="986150274035512339">"پیش‌فرض محلی"</item>

--- a/res/values-fa/strings.xml
+++ b/res/values-fa/strings.xml
@@ -236,4 +236,5 @@
     <string name="visibility_default">پیش‌فرض</string>
     <string name="visibility_private">خصوصی</string>
     <string name="visibility_public">عمومی</string>
+    <string name="no_reminder_label">هیچکدام</string>
 </resources>

--- a/res/values-fi/arrays.xml
+++ b/res/values-fi/arrays.xml
@@ -22,27 +22,6 @@
     <item msgid="2658001219380695677">"Tekstiviesti"</item>
     <item msgid="7926918288165444873">"Hälytys"</item>
   </string-array>
-  <string-array name="preferences_default_reminder_labels">
-    <item msgid="7495163916242649023">"Ei mitään"</item>
-    <item msgid="5883344836499335043">"0 minuuttia"</item>
-    <item msgid="4354350447805231188">"1 minuutti"</item>
-    <item msgid="265674592625309858">"5 minuuttia"</item>
-    <item msgid="8011089417728419666">"10 minuuttia"</item>
-    <item msgid="6177098581805412986">"15 minuuttia"</item>
-    <item msgid="356346660503078923">"20 minuuttia"</item>
-    <item msgid="992592434377054063">"25 minuuttia"</item>
-    <item msgid="9191353668596201944">"30 minuuttia"</item>
-    <item msgid="1192985682962908244">"45 minuuttia"</item>
-    <item msgid="1694315499429259938">"1 tunti"</item>
-    <item msgid="8281019320591769635">"2 tuntia"</item>
-    <item msgid="2062931719019287773">"3 tuntia"</item>
-    <item msgid="4086495711621133006">"12 tuntia"</item>
-    <item msgid="3172669681920709561">"24 tuntia"</item>
-    <item msgid="5557836606782821910">"2 päivää"</item>
-    <item msgid="8336577387266744930">"1 viikko"</item>
-    <item>2 weeks</item>
-    <item>4 weeks</item>
-  </string-array>
   <string-array name="preferences_week_start_day_labels">
     <item msgid="986150274035512339">"Oletussijainti"</item>
     <item msgid="134027225275475280">"lauantai"</item>

--- a/res/values-fi/arrays.xml
+++ b/res/values-fi/arrays.xml
@@ -22,24 +22,6 @@
     <item msgid="2658001219380695677">"Tekstiviesti"</item>
     <item msgid="7926918288165444873">"Hälytys"</item>
   </string-array>
-  <string-array name="reminder_minutes_labels">
-    <item msgid="2416970002377237011">"0 minuuttia"</item>
-    <item msgid="6681865010714743948">"1 minuutti"</item>
-    <item msgid="2327505114623595779">"5 minuuttia"</item>
-    <item msgid="1657410063332547113">"10 minuuttia"</item>
-    <item msgid="366087535181197780">"15 minuuttia"</item>
-    <item msgid="6252612791145061929">"20 minuuttia"</item>
-    <item msgid="7896694531989090700">"25 minuuttia"</item>
-    <item msgid="8754510169374808607">"30 minuuttia"</item>
-    <item msgid="3113380274218454394">"45 minuuttia"</item>
-    <item msgid="8546646645868526283">"1 tunti"</item>
-    <item msgid="6467845211024768872">"2 tuntia"</item>
-    <item msgid="8201677619511076575">"3 tuntia"</item>
-    <item msgid="7172504281650128893">"12 tuntia"</item>
-    <item msgid="9114286702181482496">"24 tuntia"</item>
-    <item msgid="3107009344872997366">"2 päivää"</item>
-    <item msgid="6135563708172153696">"1 viikko"</item>
-  </string-array>
   <string-array name="preferences_default_reminder_labels">
     <item msgid="7495163916242649023">"Ei mitään"</item>
     <item msgid="5883344836499335043">"0 minuuttia"</item>
@@ -58,6 +40,8 @@
     <item msgid="3172669681920709561">"24 tuntia"</item>
     <item msgid="5557836606782821910">"2 päivää"</item>
     <item msgid="8336577387266744930">"1 viikko"</item>
+    <item>2 weeks</item>
+    <item>4 weeks</item>
   </string-array>
   <string-array name="preferences_week_start_day_labels">
     <item msgid="986150274035512339">"Oletussijainti"</item>

--- a/res/values-fi/strings.xml
+++ b/res/values-fi/strings.xml
@@ -330,4 +330,5 @@
     <string name="preferences_system_theme">Järjestelmän oletusasetus</string>
     <string name="foreground_notification_channel_description">Sisäisen hälytyksen synkronointiin tarvitaan tulosilmoitus.</string>
     <string name="foreground_notification_channel_name">Hälytyksen synkronointi</string>
+    <string name="no_reminder_label">Ei mitään</string>
 </resources>

--- a/res/values-fr/arrays.xml
+++ b/res/values-fr/arrays.xml
@@ -22,24 +22,6 @@
     <item msgid="2658001219380695677">"SMS"</item>
     <item msgid="7926918288165444873">"Alarme"</item>
   </string-array>
-  <string-array name="reminder_minutes_labels">
-    <item msgid="2416970002377237011">"0 minute"</item>
-    <item msgid="6681865010714743948">"1 minute"</item>
-    <item msgid="2327505114623595779">"5 minutes"</item>
-    <item msgid="1657410063332547113">"10 minutes"</item>
-    <item msgid="366087535181197780">"15 minutes"</item>
-    <item msgid="6252612791145061929">"20 minutes"</item>
-    <item msgid="7896694531989090700">"25 minutes"</item>
-    <item msgid="8754510169374808607">"30 minutes"</item>
-    <item msgid="3113380274218454394">"45 minutes"</item>
-    <item msgid="8546646645868526283">"1 heure"</item>
-    <item msgid="6467845211024768872">"2 heures"</item>
-    <item msgid="8201677619511076575">"3 heures"</item>
-    <item msgid="7172504281650128893">"12 heures"</item>
-    <item msgid="9114286702181482496">"24 heures"</item>
-    <item msgid="3107009344872997366">"2 jours"</item>
-    <item msgid="6135563708172153696">"1 semaine"</item>
-  </string-array>
   <string-array name="preferences_default_reminder_labels">
     <item msgid="7495163916242649023">"Aucun"</item>
     <item msgid="5883344836499335043">"0 minute"</item>
@@ -58,6 +40,8 @@
     <item msgid="3172669681920709561">"24 heures"</item>
     <item msgid="5557836606782821910">"2 jours"</item>
     <item msgid="8336577387266744930">"1 semaine"</item>
+    <item>2 weeks</item>
+    <item>4 weeks</item>
   </string-array>
   <string-array name="preferences_week_start_day_labels">
     <item msgid="986150274035512339">"Paramètres régionaux par défaut"</item>

--- a/res/values-fr/arrays.xml
+++ b/res/values-fr/arrays.xml
@@ -22,27 +22,6 @@
     <item msgid="2658001219380695677">"SMS"</item>
     <item msgid="7926918288165444873">"Alarme"</item>
   </string-array>
-  <string-array name="preferences_default_reminder_labels">
-    <item msgid="7495163916242649023">"Aucun"</item>
-    <item msgid="5883344836499335043">"0 minute"</item>
-    <item msgid="4354350447805231188">"1 minute"</item>
-    <item msgid="265674592625309858">"5 minutes"</item>
-    <item msgid="8011089417728419666">"10 minutes"</item>
-    <item msgid="6177098581805412986">"15 minutes"</item>
-    <item msgid="356346660503078923">"20 minutes"</item>
-    <item msgid="992592434377054063">"25 minutes"</item>
-    <item msgid="9191353668596201944">"30 minutes"</item>
-    <item msgid="1192985682962908244">"45 minutes"</item>
-    <item msgid="1694315499429259938">"1 heure"</item>
-    <item msgid="8281019320591769635">"2 heures"</item>
-    <item msgid="2062931719019287773">"3 heures"</item>
-    <item msgid="4086495711621133006">"12 heures"</item>
-    <item msgid="3172669681920709561">"24 heures"</item>
-    <item msgid="5557836606782821910">"2 jours"</item>
-    <item msgid="8336577387266744930">"1 semaine"</item>
-    <item>2 weeks</item>
-    <item>4 weeks</item>
-  </string-array>
   <string-array name="preferences_week_start_day_labels">
     <item msgid="986150274035512339">"Paramètres régionaux par défaut"</item>
     <item msgid="134027225275475280">"Samedi"</item>

--- a/res/values-fr/strings.xml
+++ b/res/values-fr/strings.xml
@@ -337,4 +337,5 @@
     <string name="preferences_list_add_remote_etesync">Ajouter un calendrier EteSync</string>
     <string name="preferences_list_add_remote">Ajouter un calendrier CalDAV</string>
     <string name="preferences_pure_black_night_mode">Mode pure nuit noire</string>
+    <string name="no_reminder_label">Aucun</string>
 </resources>

--- a/res/values-hi/arrays.xml
+++ b/res/values-hi/arrays.xml
@@ -22,27 +22,6 @@
     <item msgid="2658001219380695677">"SMS"</item>
     <item msgid="7926918288165444873">"अलार्म"</item>
   </string-array>
-  <string-array name="preferences_default_reminder_labels">
-    <item msgid="7495163916242649023">"कोई नहीं"</item>
-    <item msgid="5883344836499335043">"0 मिनट"</item>
-    <item msgid="4354350447805231188">"1 मिनट"</item>
-    <item msgid="265674592625309858">"5 मिनट"</item>
-    <item msgid="8011089417728419666">"10 मिनट"</item>
-    <item msgid="6177098581805412986">"15 मिनट"</item>
-    <item msgid="356346660503078923">"20 मिनट"</item>
-    <item msgid="992592434377054063">"25 मिनट"</item>
-    <item msgid="9191353668596201944">"30 मिनट"</item>
-    <item msgid="1192985682962908244">"45 मिनट"</item>
-    <item msgid="1694315499429259938">"1 घंटा"</item>
-    <item msgid="8281019320591769635">"2 घंटे"</item>
-    <item msgid="2062931719019287773">"3 घंटे"</item>
-    <item msgid="4086495711621133006">"12 घंटे"</item>
-    <item msgid="3172669681920709561">"24 घंटे"</item>
-    <item msgid="5557836606782821910">"2 दिन"</item>
-    <item msgid="8336577387266744930">"1 सप्ताह"</item>
-    <item>2 weeks</item>
-    <item>4 weeks</item>
-  </string-array>
   <string-array name="preferences_week_start_day_labels">
     <item msgid="986150274035512339">"स्थान डिफ़ॉल्ट"</item>
     <item msgid="134027225275475280">"शनिवार"</item>

--- a/res/values-hi/arrays.xml
+++ b/res/values-hi/arrays.xml
@@ -22,24 +22,6 @@
     <item msgid="2658001219380695677">"SMS"</item>
     <item msgid="7926918288165444873">"अलार्म"</item>
   </string-array>
-  <string-array name="reminder_minutes_labels">
-    <item msgid="2416970002377237011">"0 मिनट"</item>
-    <item msgid="6681865010714743948">"1 मिनट"</item>
-    <item msgid="2327505114623595779">"5 मिनट"</item>
-    <item msgid="1657410063332547113">"10 मिनट"</item>
-    <item msgid="366087535181197780">"15 मिनट"</item>
-    <item msgid="6252612791145061929">"20 मिनट"</item>
-    <item msgid="7896694531989090700">"25 मिनट"</item>
-    <item msgid="8754510169374808607">"30 मिनट"</item>
-    <item msgid="3113380274218454394">"45 मिनट"</item>
-    <item msgid="8546646645868526283">"1 घंटा"</item>
-    <item msgid="6467845211024768872">"2 घंटे"</item>
-    <item msgid="8201677619511076575">"3 घंटे"</item>
-    <item msgid="7172504281650128893">"12 घंटे"</item>
-    <item msgid="9114286702181482496">"24 घंटे"</item>
-    <item msgid="3107009344872997366">"2 दिन"</item>
-    <item msgid="6135563708172153696">"1 सप्ताह"</item>
-  </string-array>
   <string-array name="preferences_default_reminder_labels">
     <item msgid="7495163916242649023">"कोई नहीं"</item>
     <item msgid="5883344836499335043">"0 मिनट"</item>
@@ -58,6 +40,8 @@
     <item msgid="3172669681920709561">"24 घंटे"</item>
     <item msgid="5557836606782821910">"2 दिन"</item>
     <item msgid="8336577387266744930">"1 सप्ताह"</item>
+    <item>2 weeks</item>
+    <item>4 weeks</item>
   </string-array>
   <string-array name="preferences_week_start_day_labels">
     <item msgid="986150274035512339">"स्थान डिफ़ॉल्ट"</item>

--- a/res/values-hi/strings.xml
+++ b/res/values-hi/strings.xml
@@ -237,4 +237,5 @@
     <string name="visibility_default">डिफ़ॉल्ट</string>
     <string name="visibility_private">निजी</string>
     <string name="visibility_public">सार्वजनिक</string>
+    <string name="no_reminder_label">कोई नहीं</string>
 </resources>

--- a/res/values-hr/arrays.xml
+++ b/res/values-hr/arrays.xml
@@ -22,27 +22,6 @@
     <item msgid="2658001219380695677">"SMS"</item>
     <item msgid="7926918288165444873">"Alarm"</item>
   </string-array>
-  <string-array name="preferences_default_reminder_labels">
-    <item msgid="7495163916242649023">"Ništa"</item>
-    <item msgid="5883344836499335043">"0 minuta"</item>
-    <item msgid="4354350447805231188">"1 minuta"</item>
-    <item msgid="265674592625309858">"5 minuta"</item>
-    <item msgid="8011089417728419666">"10 minuta"</item>
-    <item msgid="6177098581805412986">"15 minuta"</item>
-    <item msgid="356346660503078923">"20 minuta"</item>
-    <item msgid="992592434377054063">"25 minuta"</item>
-    <item msgid="9191353668596201944">"30 minuta"</item>
-    <item msgid="1192985682962908244">"45 minuta"</item>
-    <item msgid="1694315499429259938">"1 sat"</item>
-    <item msgid="8281019320591769635">"2 sata"</item>
-    <item msgid="2062931719019287773">"3 sata"</item>
-    <item msgid="4086495711621133006">"12 sati"</item>
-    <item msgid="3172669681920709561">"24 sata"</item>
-    <item msgid="5557836606782821910">"2 dana"</item>
-    <item msgid="8336577387266744930">"1 tjedan"</item>
-    <item>2 weeks</item>
-    <item>4 weeks</item>
-  </string-array>
   <string-array name="preferences_week_start_day_labels">
     <item msgid="986150274035512339">"Zadana oznaka zemlje"</item>
     <item msgid="134027225275475280">"Subota"</item>

--- a/res/values-hr/arrays.xml
+++ b/res/values-hr/arrays.xml
@@ -22,24 +22,6 @@
     <item msgid="2658001219380695677">"SMS"</item>
     <item msgid="7926918288165444873">"Alarm"</item>
   </string-array>
-  <string-array name="reminder_minutes_labels">
-    <item msgid="2416970002377237011">"0 minuta"</item>
-    <item msgid="6681865010714743948">"1 minuta"</item>
-    <item msgid="2327505114623595779">"5 minuta"</item>
-    <item msgid="1657410063332547113">"10 minuta"</item>
-    <item msgid="366087535181197780">"15 minuta"</item>
-    <item msgid="6252612791145061929">"20 minuta"</item>
-    <item msgid="7896694531989090700">"25 minuta"</item>
-    <item msgid="8754510169374808607">"30 minuta"</item>
-    <item msgid="3113380274218454394">"45 minuta"</item>
-    <item msgid="8546646645868526283">"1 sat"</item>
-    <item msgid="6467845211024768872">"2 sata"</item>
-    <item msgid="8201677619511076575">"3 sata"</item>
-    <item msgid="7172504281650128893">"12 sati"</item>
-    <item msgid="9114286702181482496">"24 sata"</item>
-    <item msgid="3107009344872997366">"2 dana"</item>
-    <item msgid="6135563708172153696">"1 tjedan"</item>
-  </string-array>
   <string-array name="preferences_default_reminder_labels">
     <item msgid="7495163916242649023">"Ništa"</item>
     <item msgid="5883344836499335043">"0 minuta"</item>
@@ -58,6 +40,8 @@
     <item msgid="3172669681920709561">"24 sata"</item>
     <item msgid="5557836606782821910">"2 dana"</item>
     <item msgid="8336577387266744930">"1 tjedan"</item>
+    <item>2 weeks</item>
+    <item>4 weeks</item>
   </string-array>
   <string-array name="preferences_week_start_day_labels">
     <item msgid="986150274035512339">"Zadana oznaka zemlje"</item>

--- a/res/values-hr/strings.xml
+++ b/res/values-hr/strings.xml
@@ -353,4 +353,5 @@
     <string name="preferences_list_add_remote_etesync">Dodaj EteSync kalendar</string>
     <string name="preferences_list_add_remote">Dodaj CalDAV kalendar</string>
     <string name="preferences_pure_black_night_mode">Crni noćni modus</string>
+    <string name="no_reminder_label">Ništa</string>
 </resources>

--- a/res/values-hu/arrays.xml
+++ b/res/values-hu/arrays.xml
@@ -22,27 +22,6 @@
     <item msgid="2658001219380695677">"SMS"</item>
     <item msgid="7926918288165444873">"Ébresztő"</item>
   </string-array>
-  <string-array name="preferences_default_reminder_labels">
-    <item msgid="7495163916242649023">"Semelyik"</item>
-    <item msgid="5883344836499335043">"0 perc"</item>
-    <item msgid="4354350447805231188">"1 perc"</item>
-    <item msgid="265674592625309858">"5 perc"</item>
-    <item msgid="8011089417728419666">"10 perc"</item>
-    <item msgid="6177098581805412986">"15 perc"</item>
-    <item msgid="356346660503078923">"20 perc"</item>
-    <item msgid="992592434377054063">"25 perc"</item>
-    <item msgid="9191353668596201944">"30 perc"</item>
-    <item msgid="1192985682962908244">"45 perc"</item>
-    <item msgid="1694315499429259938">"1 óra"</item>
-    <item msgid="8281019320591769635">"2 óra"</item>
-    <item msgid="2062931719019287773">"3 óra"</item>
-    <item msgid="4086495711621133006">"12 óra"</item>
-    <item msgid="3172669681920709561">"24 óra"</item>
-    <item msgid="5557836606782821910">"2 nap"</item>
-    <item msgid="8336577387266744930">"1 hét"</item>
-    <item>2 weeks</item>
-    <item>4 weeks</item>
-  </string-array>
   <string-array name="preferences_week_start_day_labels">
     <item msgid="986150274035512339">"Helyi alapértelmezett"</item>
     <item msgid="134027225275475280">"Szombat"</item>

--- a/res/values-hu/arrays.xml
+++ b/res/values-hu/arrays.xml
@@ -22,24 +22,6 @@
     <item msgid="2658001219380695677">"SMS"</item>
     <item msgid="7926918288165444873">"Ébresztő"</item>
   </string-array>
-  <string-array name="reminder_minutes_labels">
-    <item msgid="2416970002377237011">"0 perc"</item>
-    <item msgid="6681865010714743948">"1 perc"</item>
-    <item msgid="2327505114623595779">"5 perc"</item>
-    <item msgid="1657410063332547113">"10 perc"</item>
-    <item msgid="366087535181197780">"15 perc"</item>
-    <item msgid="6252612791145061929">"20 perc"</item>
-    <item msgid="7896694531989090700">"25 perc"</item>
-    <item msgid="8754510169374808607">"30 perc"</item>
-    <item msgid="3113380274218454394">"45 perc"</item>
-    <item msgid="8546646645868526283">"1 óra"</item>
-    <item msgid="6467845211024768872">"2 óra"</item>
-    <item msgid="8201677619511076575">"3 óra"</item>
-    <item msgid="7172504281650128893">"12 óra"</item>
-    <item msgid="9114286702181482496">"24 óra"</item>
-    <item msgid="3107009344872997366">"2 nap"</item>
-    <item msgid="6135563708172153696">"1 hét"</item>
-  </string-array>
   <string-array name="preferences_default_reminder_labels">
     <item msgid="7495163916242649023">"Semelyik"</item>
     <item msgid="5883344836499335043">"0 perc"</item>
@@ -58,6 +40,8 @@
     <item msgid="3172669681920709561">"24 óra"</item>
     <item msgid="5557836606782821910">"2 nap"</item>
     <item msgid="8336577387266744930">"1 hét"</item>
+    <item>2 weeks</item>
+    <item>4 weeks</item>
   </string-array>
   <string-array name="preferences_week_start_day_labels">
     <item msgid="986150274035512339">"Helyi alapértelmezett"</item>

--- a/res/values-hu/strings.xml
+++ b/res/values-hu/strings.xml
@@ -337,4 +337,5 @@
     <string name="no_map">Nincs térképalkalmazás telepítve</string>
     <string name="foreground_notification_channel_description">Előtérbeli értesítés szükséges a belső riasztásszinkronizálásához.</string>
     <string name="foreground_notification_channel_name">Riasztások szinkronizálása</string>
+    <string name="no_reminder_label">Semelyik</string>
 </resources>

--- a/res/values-in/arrays.xml
+++ b/res/values-in/arrays.xml
@@ -22,24 +22,6 @@
     <item msgid="2658001219380695677">"SMS"</item>
     <item msgid="7926918288165444873">"Alarm"</item>
   </string-array>
-  <string-array name="reminder_minutes_labels">
-    <item msgid="2416970002377237011">"0 menit"</item>
-    <item msgid="6681865010714743948">"1 menit"</item>
-    <item msgid="2327505114623595779">"5 menit"</item>
-    <item msgid="1657410063332547113">"10 menit"</item>
-    <item msgid="366087535181197780">"15 menit"</item>
-    <item msgid="6252612791145061929">"20 menit"</item>
-    <item msgid="7896694531989090700">"25 menit"</item>
-    <item msgid="8754510169374808607">"30 menit"</item>
-    <item msgid="3113380274218454394">"45 menit"</item>
-    <item msgid="8546646645868526283">"1 jam"</item>
-    <item msgid="6467845211024768872">"2 jam"</item>
-    <item msgid="8201677619511076575">"3 jam"</item>
-    <item msgid="7172504281650128893">"12 jam"</item>
-    <item msgid="9114286702181482496">"24 jam"</item>
-    <item msgid="3107009344872997366">"2 hari"</item>
-    <item msgid="6135563708172153696">"1 minggu"</item>
-  </string-array>
   <string-array name="preferences_default_reminder_labels">
     <item msgid="7495163916242649023">"Tak Satu Pun"</item>
     <item msgid="5883344836499335043">"0 menit"</item>
@@ -58,6 +40,8 @@
     <item msgid="3172669681920709561">"24 jam"</item>
     <item msgid="5557836606782821910">"2 hari"</item>
     <item msgid="8336577387266744930">"1 minggu"</item>
+    <item>2 weeks</item>
+    <item>4 weeks</item>
   </string-array>
   <string-array name="preferences_week_start_day_labels">
     <item msgid="986150274035512339">"Lokal default"</item>

--- a/res/values-in/arrays.xml
+++ b/res/values-in/arrays.xml
@@ -22,27 +22,6 @@
     <item msgid="2658001219380695677">"SMS"</item>
     <item msgid="7926918288165444873">"Alarm"</item>
   </string-array>
-  <string-array name="preferences_default_reminder_labels">
-    <item msgid="7495163916242649023">"Tak Satu Pun"</item>
-    <item msgid="5883344836499335043">"0 menit"</item>
-    <item msgid="4354350447805231188">"1 menit"</item>
-    <item msgid="265674592625309858">"5 menit"</item>
-    <item msgid="8011089417728419666">"10 menit"</item>
-    <item msgid="6177098581805412986">"15 menit"</item>
-    <item msgid="356346660503078923">"20 menit"</item>
-    <item msgid="992592434377054063">"25 menit"</item>
-    <item msgid="9191353668596201944">"30 menit"</item>
-    <item msgid="1192985682962908244">"45 menit"</item>
-    <item msgid="1694315499429259938">"1 jam"</item>
-    <item msgid="8281019320591769635">"2 jam"</item>
-    <item msgid="2062931719019287773">"3 jam"</item>
-    <item msgid="4086495711621133006">"12 jam"</item>
-    <item msgid="3172669681920709561">"24 jam"</item>
-    <item msgid="5557836606782821910">"2 hari"</item>
-    <item msgid="8336577387266744930">"1 minggu"</item>
-    <item>2 weeks</item>
-    <item>4 weeks</item>
-  </string-array>
   <string-array name="preferences_week_start_day_labels">
     <item msgid="986150274035512339">"Lokal default"</item>
     <item msgid="134027225275475280">"Sabtu"</item>

--- a/res/values-in/strings.xml
+++ b/res/values-in/strings.xml
@@ -321,4 +321,5 @@
     <string name="preferences_pure_black_night_mode">Mode malam hitam pekat</string>
     <string name="foreground_notification_channel_name">Sinkronisasi peringatan</string>
     <string name="foreground_notification_channel_description">Notifikasi latar depan dibutuhkan untuk sinkronisasi peringatan internal.</string>
+    <string name="no_reminder_label">Tak Satu Pun</string>
 </resources>

--- a/res/values-it/arrays.xml
+++ b/res/values-it/arrays.xml
@@ -22,24 +22,6 @@
     <item msgid="2658001219380695677">"SMS"</item>
     <item msgid="7926918288165444873">"Allarme"</item>
   </string-array>
-  <string-array name="reminder_minutes_labels">
-    <item msgid="2416970002377237011">"0 minuti"</item>
-    <item msgid="6681865010714743948">"1 minuto"</item>
-    <item msgid="2327505114623595779">"5 minuti"</item>
-    <item msgid="1657410063332547113">"10 minuti"</item>
-    <item msgid="366087535181197780">"15 minuti"</item>
-    <item msgid="6252612791145061929">"20 minuti"</item>
-    <item msgid="7896694531989090700">"25 minuti"</item>
-    <item msgid="8754510169374808607">"30 minuti"</item>
-    <item msgid="3113380274218454394">"45 minuti"</item>
-    <item msgid="8546646645868526283">"1 ora"</item>
-    <item msgid="6467845211024768872">"2 ore"</item>
-    <item msgid="8201677619511076575">"3 ore"</item>
-    <item msgid="7172504281650128893">"12 ore"</item>
-    <item msgid="9114286702181482496">"24 ore"</item>
-    <item msgid="3107009344872997366">"2 giorni"</item>
-    <item msgid="6135563708172153696">"1 settimana"</item>
-  </string-array>
   <string-array name="preferences_default_reminder_labels">
     <item msgid="7495163916242649023">"Nessuno"</item>
     <item msgid="5883344836499335043">"0 minuti"</item>
@@ -58,6 +40,8 @@
     <item msgid="3172669681920709561">"24 ore"</item>
     <item msgid="5557836606782821910">"2 giorni"</item>
     <item msgid="8336577387266744930">"1 settimana"</item>
+    <item>2 weeks</item>
+    <item>4 weeks</item>
   </string-array>
   <string-array name="preferences_week_start_day_labels">
     <item msgid="986150274035512339">"Impostazioni internazionali predefinite"</item>

--- a/res/values-it/arrays.xml
+++ b/res/values-it/arrays.xml
@@ -22,27 +22,6 @@
     <item msgid="2658001219380695677">"SMS"</item>
     <item msgid="7926918288165444873">"Allarme"</item>
   </string-array>
-  <string-array name="preferences_default_reminder_labels">
-    <item msgid="7495163916242649023">"Nessuno"</item>
-    <item msgid="5883344836499335043">"0 minuti"</item>
-    <item msgid="4354350447805231188">"1 minuto"</item>
-    <item msgid="265674592625309858">"5 minuti"</item>
-    <item msgid="8011089417728419666">"10 minuti"</item>
-    <item msgid="6177098581805412986">"15 minuti"</item>
-    <item msgid="356346660503078923">"20 minuti"</item>
-    <item msgid="992592434377054063">"25 minuti"</item>
-    <item msgid="9191353668596201944">"30 minuti"</item>
-    <item msgid="1192985682962908244">"45 minuti"</item>
-    <item msgid="1694315499429259938">"1 ora"</item>
-    <item msgid="8281019320591769635">"2 ore"</item>
-    <item msgid="2062931719019287773">"3 ore"</item>
-    <item msgid="4086495711621133006">"12 ore"</item>
-    <item msgid="3172669681920709561">"24 ore"</item>
-    <item msgid="5557836606782821910">"2 giorni"</item>
-    <item msgid="8336577387266744930">"1 settimana"</item>
-    <item>2 weeks</item>
-    <item>4 weeks</item>
-  </string-array>
   <string-array name="preferences_week_start_day_labels">
     <item msgid="986150274035512339">"Impostazioni internazionali predefinite"</item>
     <item msgid="134027225275475280">"Sabato"</item>

--- a/res/values-it/strings.xml
+++ b/res/values-it/strings.xml
@@ -337,4 +337,5 @@
     <string name="preferences_list_add_remote_etesync">Aggiungi un calendario EteSync</string>
     <string name="preferences_list_add_remote">Aggiungi calendario CalDAV</string>
     <string name="preferences_pure_black_night_mode">Modalità notte nera pura</string>
+    <string name="no_reminder_label">Nessuno</string>
 </resources>

--- a/res/values-iw/arrays.xml
+++ b/res/values-iw/arrays.xml
@@ -22,27 +22,6 @@
     <item msgid="2658001219380695677">"SMS"</item>
     <item msgid="7926918288165444873">"התראה"</item>
   </string-array>
-  <string-array name="preferences_default_reminder_labels">
-    <item msgid="7495163916242649023">"ללא"</item>
-    <item msgid="5883344836499335043">"0 דקות"</item>
-    <item msgid="4354350447805231188">"דקה אחת"</item>
-    <item msgid="265674592625309858">"5 דקות"</item>
-    <item msgid="8011089417728419666">"10 דקות"</item>
-    <item msgid="6177098581805412986">"15 דקות"</item>
-    <item msgid="356346660503078923">"20 דקות"</item>
-    <item msgid="992592434377054063">"25 דקות"</item>
-    <item msgid="9191353668596201944">"30 דקות"</item>
-    <item msgid="1192985682962908244">"45 דקות"</item>
-    <item msgid="1694315499429259938">"שעה אחת"</item>
-    <item msgid="8281019320591769635">"שעתיים"</item>
-    <item msgid="2062931719019287773">"3 שעות"</item>
-    <item msgid="4086495711621133006">"12 שעות"</item>
-    <item msgid="3172669681920709561">"24 שעות"</item>
-    <item msgid="5557836606782821910">"יומיים"</item>
-    <item msgid="8336577387266744930">"שבוע אחד"</item>
-    <item>2 weeks</item>
-    <item>4 weeks</item>
-  </string-array>
   <string-array name="preferences_week_start_day_labels">
     <item msgid="986150274035512339">"ברירת מחדל של מיקום"</item>
     <item msgid="134027225275475280">"יום שבת"</item>

--- a/res/values-iw/arrays.xml
+++ b/res/values-iw/arrays.xml
@@ -22,24 +22,6 @@
     <item msgid="2658001219380695677">"SMS"</item>
     <item msgid="7926918288165444873">"התראה"</item>
   </string-array>
-  <string-array name="reminder_minutes_labels">
-    <item msgid="2416970002377237011">"0 דקות"</item>
-    <item msgid="6681865010714743948">"דקה אחת"</item>
-    <item msgid="2327505114623595779">"5 דקות"</item>
-    <item msgid="1657410063332547113">"10 דקות"</item>
-    <item msgid="366087535181197780">"15 דקות"</item>
-    <item msgid="6252612791145061929">"20 דקות"</item>
-    <item msgid="7896694531989090700">"25 דקות"</item>
-    <item msgid="8754510169374808607">"30 דקות"</item>
-    <item msgid="3113380274218454394">"45 דקות"</item>
-    <item msgid="8546646645868526283">"שעה אחת"</item>
-    <item msgid="6467845211024768872">"שעתיים"</item>
-    <item msgid="8201677619511076575">"3 שעות"</item>
-    <item msgid="7172504281650128893">"12 שעות"</item>
-    <item msgid="9114286702181482496">"24 שעות"</item>
-    <item msgid="3107009344872997366">"יומיים"</item>
-    <item msgid="6135563708172153696">"שבוע אחד"</item>
-  </string-array>
   <string-array name="preferences_default_reminder_labels">
     <item msgid="7495163916242649023">"ללא"</item>
     <item msgid="5883344836499335043">"0 דקות"</item>
@@ -58,6 +40,8 @@
     <item msgid="3172669681920709561">"24 שעות"</item>
     <item msgid="5557836606782821910">"יומיים"</item>
     <item msgid="8336577387266744930">"שבוע אחד"</item>
+    <item>2 weeks</item>
+    <item>4 weeks</item>
   </string-array>
   <string-array name="preferences_week_start_day_labels">
     <item msgid="986150274035512339">"ברירת מחדל של מיקום"</item>

--- a/res/values-iw/strings.xml
+++ b/res/values-iw/strings.xml
@@ -369,4 +369,5 @@
 \n
 \nב־DAVx⁵ ניתן להשבית ‚ניהול צבעי לוח שנה’ כדי למנוע זאת.</string>
     <string name="preferences_pure_black_night_mode">מצב לילה שחור טהור</string>
+    <string name="no_reminder_label">ללא</string>
 </resources>

--- a/res/values-ja/arrays.xml
+++ b/res/values-ja/arrays.xml
@@ -22,24 +22,6 @@
     <item msgid="2658001219380695677">"SMS"</item>
     <item msgid="7926918288165444873">"アラーム"</item>
   </string-array>
-  <string-array name="reminder_minutes_labels">
-    <item msgid="2416970002377237011">"0分"</item>
-    <item msgid="6681865010714743948">"1分"</item>
-    <item msgid="2327505114623595779">"5分"</item>
-    <item msgid="1657410063332547113">"10分"</item>
-    <item msgid="366087535181197780">"15分"</item>
-    <item msgid="6252612791145061929">"20分"</item>
-    <item msgid="7896694531989090700">"25分"</item>
-    <item msgid="8754510169374808607">"30分"</item>
-    <item msgid="3113380274218454394">"45分"</item>
-    <item msgid="8546646645868526283">"1時間"</item>
-    <item msgid="6467845211024768872">"2時間"</item>
-    <item msgid="8201677619511076575">"3時間"</item>
-    <item msgid="7172504281650128893">"12時間"</item>
-    <item msgid="9114286702181482496">"24時間"</item>
-    <item msgid="3107009344872997366">"2日"</item>
-    <item msgid="6135563708172153696">"1週間"</item>
-  </string-array>
   <string-array name="preferences_default_reminder_labels">
     <item msgid="7495163916242649023">"なし"</item>
     <item msgid="5883344836499335043">"0分"</item>
@@ -58,6 +40,8 @@
     <item msgid="3172669681920709561">"24時間"</item>
     <item msgid="5557836606782821910">"2日"</item>
     <item msgid="8336577387266744930">"1週間"</item>
+    <item>2 weeks</item>
+    <item>4 weeks</item>
   </string-array>
   <string-array name="preferences_week_start_day_labels">
     <item msgid="986150274035512339">"ユーザーの言語/地域でのデフォルト設定"</item>

--- a/res/values-ja/arrays.xml
+++ b/res/values-ja/arrays.xml
@@ -22,27 +22,6 @@
     <item msgid="2658001219380695677">"SMS"</item>
     <item msgid="7926918288165444873">"アラーム"</item>
   </string-array>
-  <string-array name="preferences_default_reminder_labels">
-    <item msgid="7495163916242649023">"なし"</item>
-    <item msgid="5883344836499335043">"0分"</item>
-    <item msgid="4354350447805231188">"1分"</item>
-    <item msgid="265674592625309858">"5分"</item>
-    <item msgid="8011089417728419666">"10分"</item>
-    <item msgid="6177098581805412986">"15分"</item>
-    <item msgid="356346660503078923">"20分"</item>
-    <item msgid="992592434377054063">"25分"</item>
-    <item msgid="9191353668596201944">"30分"</item>
-    <item msgid="1192985682962908244">"45分"</item>
-    <item msgid="1694315499429259938">"1時間"</item>
-    <item msgid="8281019320591769635">"2時間"</item>
-    <item msgid="2062931719019287773">"3時間"</item>
-    <item msgid="4086495711621133006">"12時間"</item>
-    <item msgid="3172669681920709561">"24時間"</item>
-    <item msgid="5557836606782821910">"2日"</item>
-    <item msgid="8336577387266744930">"1週間"</item>
-    <item>2 weeks</item>
-    <item>4 weeks</item>
-  </string-array>
   <string-array name="preferences_week_start_day_labels">
     <item msgid="986150274035512339">"ユーザーの言語/地域でのデフォルト設定"</item>
     <item msgid="134027225275475280">"土曜日"</item>

--- a/res/values-ja/strings.xml
+++ b/res/values-ja/strings.xml
@@ -253,4 +253,5 @@
     <string name="view_settings">設定を表示</string>
     <string name="goto_date">移動…</string>
     <string name="share_label">共有する</string>
+    <string name="no_reminder_label">なし</string>
 </resources>

--- a/res/values-ko/arrays.xml
+++ b/res/values-ko/arrays.xml
@@ -22,24 +22,6 @@
     <item msgid="2658001219380695677">"SMS"</item>
     <item msgid="7926918288165444873">"알람"</item>
   </string-array>
-  <string-array name="reminder_minutes_labels">
-    <item msgid="2416970002377237011">"0분"</item>
-    <item msgid="6681865010714743948">"1분"</item>
-    <item msgid="2327505114623595779">"5분"</item>
-    <item msgid="1657410063332547113">"10분"</item>
-    <item msgid="366087535181197780">"15분"</item>
-    <item msgid="6252612791145061929">"20분"</item>
-    <item msgid="7896694531989090700">"25분"</item>
-    <item msgid="8754510169374808607">"30분"</item>
-    <item msgid="3113380274218454394">"45분"</item>
-    <item msgid="8546646645868526283">"1시간"</item>
-    <item msgid="6467845211024768872">"2시간"</item>
-    <item msgid="8201677619511076575">"3시간"</item>
-    <item msgid="7172504281650128893">"12시간"</item>
-    <item msgid="9114286702181482496">"24시간"</item>
-    <item msgid="3107009344872997366">"2일"</item>
-    <item msgid="6135563708172153696">"1주"</item>
-  </string-array>
   <string-array name="preferences_default_reminder_labels">
     <item msgid="7495163916242649023">"없음"</item>
     <item msgid="5883344836499335043">"0분"</item>
@@ -58,6 +40,8 @@
     <item msgid="3172669681920709561">"24시간"</item>
     <item msgid="5557836606782821910">"2일"</item>
     <item msgid="8336577387266744930">"1주"</item>
+    <item>2 weeks</item>
+    <item>4 weeks</item>
   </string-array>
   <string-array name="preferences_week_start_day_labels">
     <item msgid="986150274035512339">"언어 기본값"</item>

--- a/res/values-ko/arrays.xml
+++ b/res/values-ko/arrays.xml
@@ -22,27 +22,6 @@
     <item msgid="2658001219380695677">"SMS"</item>
     <item msgid="7926918288165444873">"알람"</item>
   </string-array>
-  <string-array name="preferences_default_reminder_labels">
-    <item msgid="7495163916242649023">"없음"</item>
-    <item msgid="5883344836499335043">"0분"</item>
-    <item msgid="4354350447805231188">"1분"</item>
-    <item msgid="265674592625309858">"5분"</item>
-    <item msgid="8011089417728419666">"10분"</item>
-    <item msgid="6177098581805412986">"15분"</item>
-    <item msgid="356346660503078923">"20분"</item>
-    <item msgid="992592434377054063">"25분"</item>
-    <item msgid="9191353668596201944">"30분"</item>
-    <item msgid="1192985682962908244">"45분"</item>
-    <item msgid="1694315499429259938">"1시간"</item>
-    <item msgid="8281019320591769635">"2시간"</item>
-    <item msgid="2062931719019287773">"3시간"</item>
-    <item msgid="4086495711621133006">"12시간"</item>
-    <item msgid="3172669681920709561">"24시간"</item>
-    <item msgid="5557836606782821910">"2일"</item>
-    <item msgid="8336577387266744930">"1주"</item>
-    <item>2 weeks</item>
-    <item>4 weeks</item>
-  </string-array>
   <string-array name="preferences_week_start_day_labels">
     <item msgid="986150274035512339">"언어 기본값"</item>
     <item msgid="134027225275475280">"토요일"</item>

--- a/res/values-ko/strings.xml
+++ b/res/values-ko/strings.xml
@@ -289,4 +289,5 @@
     <string name="maximum_number_of_lines">이벤트의 최대 라인 수</string>
     <string name="foreground_notification_channel_name">동기화 경고</string>
     <string name="foreground_notification_channel_description">Foreground 알림 내부 경계 태세를 동기화에 필요하다. 음소거 해달라</string>
+    <string name="no_reminder_label">없음</string>
 </resources>

--- a/res/values-lt/arrays.xml
+++ b/res/values-lt/arrays.xml
@@ -22,24 +22,6 @@
     <item msgid="2658001219380695677">"SMS"</item>
     <item msgid="7926918288165444873">"Signalas"</item>
   </string-array>
-  <string-array name="reminder_minutes_labels">
-    <item msgid="2416970002377237011">"0 min."</item>
-    <item msgid="6681865010714743948">"1 min."</item>
-    <item msgid="2327505114623595779">"5 min."</item>
-    <item msgid="1657410063332547113">"10 min."</item>
-    <item msgid="366087535181197780">"15 min."</item>
-    <item msgid="6252612791145061929">"20 min."</item>
-    <item msgid="7896694531989090700">"25 min."</item>
-    <item msgid="8754510169374808607">"30 min."</item>
-    <item msgid="3113380274218454394">"45 min."</item>
-    <item msgid="8546646645868526283">"1 val."</item>
-    <item msgid="6467845211024768872">"2 val."</item>
-    <item msgid="8201677619511076575">"3 val."</item>
-    <item msgid="7172504281650128893">"12 val."</item>
-    <item msgid="9114286702181482496">"24 val."</item>
-    <item msgid="3107009344872997366">"2 d."</item>
-    <item msgid="6135563708172153696">"1 sav."</item>
-  </string-array>
   <string-array name="preferences_default_reminder_labels">
     <item msgid="7495163916242649023">"Nėra"</item>
     <item msgid="5883344836499335043">"0 min."</item>
@@ -58,6 +40,8 @@
     <item msgid="3172669681920709561">"24 val."</item>
     <item msgid="5557836606782821910">"2 d."</item>
     <item msgid="8336577387266744930">"1 sav."</item>
+    <item>2 weeks</item>
+    <item>4 weeks</item>
   </string-array>
   <string-array name="preferences_week_start_day_labels">
     <item msgid="986150274035512339">"Numatytoji lokalė"</item>

--- a/res/values-lt/arrays.xml
+++ b/res/values-lt/arrays.xml
@@ -22,27 +22,6 @@
     <item msgid="2658001219380695677">"SMS"</item>
     <item msgid="7926918288165444873">"Signalas"</item>
   </string-array>
-  <string-array name="preferences_default_reminder_labels">
-    <item msgid="7495163916242649023">"Nėra"</item>
-    <item msgid="5883344836499335043">"0 min."</item>
-    <item msgid="4354350447805231188">"1 min."</item>
-    <item msgid="265674592625309858">"5 min."</item>
-    <item msgid="8011089417728419666">"10 min."</item>
-    <item msgid="6177098581805412986">"15 min."</item>
-    <item msgid="356346660503078923">"20 min."</item>
-    <item msgid="992592434377054063">"25 min."</item>
-    <item msgid="9191353668596201944">"30 min."</item>
-    <item msgid="1192985682962908244">"45 min."</item>
-    <item msgid="1694315499429259938">"1 val."</item>
-    <item msgid="8281019320591769635">"2 val."</item>
-    <item msgid="2062931719019287773">"3 val."</item>
-    <item msgid="4086495711621133006">"12 val."</item>
-    <item msgid="3172669681920709561">"24 val."</item>
-    <item msgid="5557836606782821910">"2 d."</item>
-    <item msgid="8336577387266744930">"1 sav."</item>
-    <item>2 weeks</item>
-    <item>4 weeks</item>
-  </string-array>
   <string-array name="preferences_week_start_day_labels">
     <item msgid="986150274035512339">"Numatytoji lokalė"</item>
     <item msgid="134027225275475280">"Šeštadienis"</item>

--- a/res/values-lt/strings.xml
+++ b/res/values-lt/strings.xml
@@ -338,4 +338,5 @@
     <string name="rsvp_accepted">Atsakė taip.</string>
     <string name="view_settings">Peržiūrėti nustatymus</string>
     <string name="goto_date">Eiti į…</string>
+    <string name="no_reminder_label">Nėra</string>
 </resources>

--- a/res/values-lv/arrays.xml
+++ b/res/values-lv/arrays.xml
@@ -22,24 +22,6 @@
     <item msgid="2658001219380695677">"Īsziņa"</item>
     <item msgid="7926918288165444873">"Signāls"</item>
   </string-array>
-  <string-array name="reminder_minutes_labels">
-    <item msgid="2416970002377237011">"0 minūšu"</item>
-    <item msgid="6681865010714743948">"1 minūte"</item>
-    <item msgid="2327505114623595779">"5 minūtes"</item>
-    <item msgid="1657410063332547113">"10 minūtes"</item>
-    <item msgid="366087535181197780">"15 minūtes"</item>
-    <item msgid="6252612791145061929">"20 minūtes"</item>
-    <item msgid="7896694531989090700">"25 minūtes"</item>
-    <item msgid="8754510169374808607">"30 minūtes"</item>
-    <item msgid="3113380274218454394">"45 minūtes"</item>
-    <item msgid="8546646645868526283">"1 stunda"</item>
-    <item msgid="6467845211024768872">"2 stundas"</item>
-    <item msgid="8201677619511076575">"3 stundas"</item>
-    <item msgid="7172504281650128893">"12 stundas"</item>
-    <item msgid="9114286702181482496">"24 stundas"</item>
-    <item msgid="3107009344872997366">"2 dienas"</item>
-    <item msgid="6135563708172153696">"1 nedēļa"</item>
-  </string-array>
   <string-array name="preferences_default_reminder_labels">
     <item msgid="7495163916242649023">"Nav"</item>
     <item msgid="5883344836499335043">"0 minūšu"</item>
@@ -58,6 +40,8 @@
     <item msgid="3172669681920709561">"24 stundas"</item>
     <item msgid="5557836606782821910">"2 dienas"</item>
     <item msgid="8336577387266744930">"1 nedēļa"</item>
+    <item>2 weeks</item>
+    <item>4 weeks</item>
   </string-array>
   <string-array name="preferences_week_start_day_labels">
     <item msgid="986150274035512339">"Lokalizācijas noklusējums"</item>

--- a/res/values-lv/arrays.xml
+++ b/res/values-lv/arrays.xml
@@ -22,27 +22,6 @@
     <item msgid="2658001219380695677">"Īsziņa"</item>
     <item msgid="7926918288165444873">"Signāls"</item>
   </string-array>
-  <string-array name="preferences_default_reminder_labels">
-    <item msgid="7495163916242649023">"Nav"</item>
-    <item msgid="5883344836499335043">"0 minūšu"</item>
-    <item msgid="4354350447805231188">"1 minūte"</item>
-    <item msgid="265674592625309858">"5 minūtes"</item>
-    <item msgid="8011089417728419666">"10 minūtes"</item>
-    <item msgid="6177098581805412986">"15 minūtes"</item>
-    <item msgid="356346660503078923">"20 minūtes"</item>
-    <item msgid="992592434377054063">"25 minūtes"</item>
-    <item msgid="9191353668596201944">"30 minūtes"</item>
-    <item msgid="1192985682962908244">"45 minūtes"</item>
-    <item msgid="1694315499429259938">"1 stunda"</item>
-    <item msgid="8281019320591769635">"2 stundas"</item>
-    <item msgid="2062931719019287773">"3 stundas"</item>
-    <item msgid="4086495711621133006">"12 stundas"</item>
-    <item msgid="3172669681920709561">"24 stundas"</item>
-    <item msgid="5557836606782821910">"2 dienas"</item>
-    <item msgid="8336577387266744930">"1 nedēļa"</item>
-    <item>2 weeks</item>
-    <item>4 weeks</item>
-  </string-array>
   <string-array name="preferences_week_start_day_labels">
     <item msgid="986150274035512339">"Lokalizācijas noklusējums"</item>
     <item msgid="134027225275475280">"Sestdiena"</item>

--- a/res/values-lv/strings.xml
+++ b/res/values-lv/strings.xml
@@ -236,4 +236,5 @@
     <string name="visibility_default">Noklusējums</string>
     <string name="visibility_private">Privāts</string>
     <string name="visibility_public">Publisks</string>
+    <string name="no_reminder_label">Nav</string>
 </resources>

--- a/res/values-ms/arrays.xml
+++ b/res/values-ms/arrays.xml
@@ -22,27 +22,6 @@
     <item msgid="2658001219380695677">"SMS"</item>
     <item msgid="7926918288165444873">"Penggera"</item>
   </string-array>
-  <string-array name="preferences_default_reminder_labels">
-    <item msgid="7495163916242649023">"Tiada"</item>
-    <item msgid="5883344836499335043">"0 minit"</item>
-    <item msgid="4354350447805231188">"1 minit"</item>
-    <item msgid="265674592625309858">"5 minit"</item>
-    <item msgid="8011089417728419666">"10 minit"</item>
-    <item msgid="6177098581805412986">"15 minit"</item>
-    <item msgid="356346660503078923">"20 minit"</item>
-    <item msgid="992592434377054063">"25 minit"</item>
-    <item msgid="9191353668596201944">"30 minit"</item>
-    <item msgid="1192985682962908244">"45 minit"</item>
-    <item msgid="1694315499429259938">"1 jam"</item>
-    <item msgid="8281019320591769635">"2 jam"</item>
-    <item msgid="2062931719019287773">"3 jam"</item>
-    <item msgid="4086495711621133006">"12 jam"</item>
-    <item msgid="3172669681920709561">"24 jam"</item>
-    <item msgid="5557836606782821910">"2 hari"</item>
-    <item msgid="8336577387266744930">"1 minggu"</item>
-    <item>2 weeks</item>
-    <item>4 weeks</item>
-  </string-array>
   <string-array name="preferences_week_start_day_labels">
     <item msgid="986150274035512339">"Lalai tempat peristiwa"</item>
     <item msgid="134027225275475280">"Sabtu"</item>

--- a/res/values-ms/arrays.xml
+++ b/res/values-ms/arrays.xml
@@ -22,24 +22,6 @@
     <item msgid="2658001219380695677">"SMS"</item>
     <item msgid="7926918288165444873">"Penggera"</item>
   </string-array>
-  <string-array name="reminder_minutes_labels">
-    <item msgid="2416970002377237011">"0 minit"</item>
-    <item msgid="6681865010714743948">"1 minit"</item>
-    <item msgid="2327505114623595779">"5 minit"</item>
-    <item msgid="1657410063332547113">"10 minit"</item>
-    <item msgid="366087535181197780">"15 minit"</item>
-    <item msgid="6252612791145061929">"20 minit"</item>
-    <item msgid="7896694531989090700">"25 minit"</item>
-    <item msgid="8754510169374808607">"30 minit"</item>
-    <item msgid="3113380274218454394">"45 minit"</item>
-    <item msgid="8546646645868526283">"1 jam"</item>
-    <item msgid="6467845211024768872">"2 jam"</item>
-    <item msgid="8201677619511076575">"3 jam"</item>
-    <item msgid="7172504281650128893">"12 jam"</item>
-    <item msgid="9114286702181482496">"24 jam"</item>
-    <item msgid="3107009344872997366">"2 hari"</item>
-    <item msgid="6135563708172153696">"1 minggu"</item>
-  </string-array>
   <string-array name="preferences_default_reminder_labels">
     <item msgid="7495163916242649023">"Tiada"</item>
     <item msgid="5883344836499335043">"0 minit"</item>
@@ -58,6 +40,8 @@
     <item msgid="3172669681920709561">"24 jam"</item>
     <item msgid="5557836606782821910">"2 hari"</item>
     <item msgid="8336577387266744930">"1 minggu"</item>
+    <item>2 weeks</item>
+    <item>4 weeks</item>
   </string-array>
   <string-array name="preferences_week_start_day_labels">
     <item msgid="986150274035512339">"Lalai tempat peristiwa"</item>

--- a/res/values-ms/strings.xml
+++ b/res/values-ms/strings.xml
@@ -236,4 +236,5 @@
     <string name="visibility_default">Lalai</string>
     <string name="visibility_private">Peribadi</string>
     <string name="visibility_public">Awam</string>
+    <string name="no_reminder_label">Tiada</string>
 </resources>

--- a/res/values-nb/arrays.xml
+++ b/res/values-nb/arrays.xml
@@ -22,27 +22,6 @@
     <item msgid="2658001219380695677">"Tekstmelding"</item>
     <item msgid="7926918288165444873">"Alarm"</item>
   </string-array>
-  <string-array name="preferences_default_reminder_labels">
-    <item msgid="7495163916242649023">"Ingen"</item>
-    <item msgid="5883344836499335043">"0 minutter"</item>
-    <item msgid="4354350447805231188">"1 minutt"</item>
-    <item msgid="265674592625309858">"5 minutter"</item>
-    <item msgid="8011089417728419666">"10 minutter"</item>
-    <item msgid="6177098581805412986">"15 minutter"</item>
-    <item msgid="356346660503078923">"20 minutter"</item>
-    <item msgid="992592434377054063">"25 minutter"</item>
-    <item msgid="9191353668596201944">"30 minutter"</item>
-    <item msgid="1192985682962908244">"45 minutter"</item>
-    <item msgid="1694315499429259938">"1 time"</item>
-    <item msgid="8281019320591769635">"2 timer"</item>
-    <item msgid="2062931719019287773">"3 timer"</item>
-    <item msgid="4086495711621133006">"12 timer"</item>
-    <item msgid="3172669681920709561">"1 døgn"</item>
-    <item msgid="5557836606782821910">"2 dager"</item>
-    <item msgid="8336577387266744930">"1 uke"</item>
-    <item>2 weeks</item>
-    <item>4 weeks</item>
-  </string-array>
   <string-array name="preferences_week_start_day_labels">
     <item msgid="986150274035512339">"Språkstandard"</item>
     <item msgid="134027225275475280">"Lørdag"</item>

--- a/res/values-nb/arrays.xml
+++ b/res/values-nb/arrays.xml
@@ -22,24 +22,6 @@
     <item msgid="2658001219380695677">"Tekstmelding"</item>
     <item msgid="7926918288165444873">"Alarm"</item>
   </string-array>
-  <string-array name="reminder_minutes_labels">
-    <item msgid="2416970002377237011">"0 minutter"</item>
-    <item msgid="6681865010714743948">"1 minutt"</item>
-    <item msgid="2327505114623595779">"5 minutter"</item>
-    <item msgid="1657410063332547113">"10 minutter"</item>
-    <item msgid="366087535181197780">"15 minutter"</item>
-    <item msgid="6252612791145061929">"20 minutter"</item>
-    <item msgid="7896694531989090700">"25 minutter"</item>
-    <item msgid="8754510169374808607">"30 minutter"</item>
-    <item msgid="3113380274218454394">"45 minutter"</item>
-    <item msgid="8546646645868526283">"1 time"</item>
-    <item msgid="6467845211024768872">"To timer"</item>
-    <item msgid="8201677619511076575">"3 timer"</item>
-    <item msgid="7172504281650128893">"12 timer"</item>
-    <item msgid="9114286702181482496">"1 døgn"</item>
-    <item msgid="3107009344872997366">"2 dager"</item>
-    <item msgid="6135563708172153696">"1 uke"</item>
-  </string-array>
   <string-array name="preferences_default_reminder_labels">
     <item msgid="7495163916242649023">"Ingen"</item>
     <item msgid="5883344836499335043">"0 minutter"</item>
@@ -58,6 +40,8 @@
     <item msgid="3172669681920709561">"1 døgn"</item>
     <item msgid="5557836606782821910">"2 dager"</item>
     <item msgid="8336577387266744930">"1 uke"</item>
+    <item>2 weeks</item>
+    <item>4 weeks</item>
   </string-array>
   <string-array name="preferences_week_start_day_labels">
     <item msgid="986150274035512339">"Språkstandard"</item>

--- a/res/values-nb/strings.xml
+++ b/res/values-nb/strings.xml
@@ -337,4 +337,5 @@
     <string name="two_days">2 dager</string>
     <string name="preferences_system_theme">Systemforvalg</string>
     <string name="preferences_pure_black_night_mode">Beksvart nattmodus</string>
+    <string name="no_reminder_label">Ingen</string>
 </resources>

--- a/res/values-nl/arrays.xml
+++ b/res/values-nl/arrays.xml
@@ -22,24 +22,6 @@
     <item msgid="2658001219380695677">"Sms"</item>
     <item msgid="7926918288165444873">"Alarm"</item>
   </string-array>
-  <string-array name="reminder_minutes_labels">
-    <item msgid="2416970002377237011">"0 minuten"</item>
-    <item msgid="6681865010714743948">"1 minuut"</item>
-    <item msgid="2327505114623595779">"5 minuten"</item>
-    <item msgid="1657410063332547113">"10 minuten"</item>
-    <item msgid="366087535181197780">"15 minuten"</item>
-    <item msgid="6252612791145061929">"20 minuten"</item>
-    <item msgid="7896694531989090700">"25 minuten"</item>
-    <item msgid="8754510169374808607">"30 minuten"</item>
-    <item msgid="3113380274218454394">"45 minuten"</item>
-    <item msgid="8546646645868526283">"1 uur"</item>
-    <item msgid="6467845211024768872">"2 uur"</item>
-    <item msgid="8201677619511076575">"3 uur"</item>
-    <item msgid="7172504281650128893">"12 uur"</item>
-    <item msgid="9114286702181482496">"24 uur"</item>
-    <item msgid="3107009344872997366">"2 dagen"</item>
-    <item msgid="6135563708172153696">"1 week"</item>
-  </string-array>
   <string-array name="preferences_default_reminder_labels">
     <item msgid="7495163916242649023">"Geen"</item>
     <item msgid="5883344836499335043">"0 minuten"</item>
@@ -58,6 +40,8 @@
     <item msgid="3172669681920709561">"24 uur"</item>
     <item msgid="5557836606782821910">"2 dagen"</item>
     <item msgid="8336577387266744930">"1 week"</item>
+    <item>2 weeks</item>
+    <item>4 weeks</item>
   </string-array>
   <string-array name="preferences_week_start_day_labels">
     <item msgid="986150274035512339">"Standaardlandinstelling"</item>

--- a/res/values-nl/arrays.xml
+++ b/res/values-nl/arrays.xml
@@ -22,27 +22,6 @@
     <item msgid="2658001219380695677">"Sms"</item>
     <item msgid="7926918288165444873">"Alarm"</item>
   </string-array>
-  <string-array name="preferences_default_reminder_labels">
-    <item msgid="7495163916242649023">"Geen"</item>
-    <item msgid="5883344836499335043">"0 minuten"</item>
-    <item msgid="4354350447805231188">"1 minuut"</item>
-    <item msgid="265674592625309858">"5 minuten"</item>
-    <item msgid="8011089417728419666">"10 minuten"</item>
-    <item msgid="6177098581805412986">"15 minuten"</item>
-    <item msgid="356346660503078923">"20 minuten"</item>
-    <item msgid="992592434377054063">"25 minuten"</item>
-    <item msgid="9191353668596201944">"30 minuten"</item>
-    <item msgid="1192985682962908244">"45 minuten"</item>
-    <item msgid="1694315499429259938">"1 uur"</item>
-    <item msgid="8281019320591769635">"2 uur"</item>
-    <item msgid="2062931719019287773">"3 uur"</item>
-    <item msgid="4086495711621133006">"12 uur"</item>
-    <item msgid="3172669681920709561">"24 uur"</item>
-    <item msgid="5557836606782821910">"2 dagen"</item>
-    <item msgid="8336577387266744930">"1 week"</item>
-    <item>2 weeks</item>
-    <item>4 weeks</item>
-  </string-array>
   <string-array name="preferences_week_start_day_labels">
     <item msgid="986150274035512339">"Standaardlandinstelling"</item>
     <item msgid="134027225275475280">"Zaterdag"</item>

--- a/res/values-nl/strings.xml
+++ b/res/values-nl/strings.xml
@@ -336,4 +336,5 @@
     <string name="preferences_list_add_offline">Offline-agenda toevoegen</string>
     <string name="preferences_list_general">Algemene instellingen</string>
     <string name="app_copyright">© 2015-<xliff:g>%1$s</xliff:g> Het Etar-project. Delen van het © 2005-<xliff:g>%1$s</xliff:g> Het Android Open Source-project.</string>
+    <string name="no_reminder_label">Geen</string>
 </resources>

--- a/res/values-pl/arrays.xml
+++ b/res/values-pl/arrays.xml
@@ -22,27 +22,6 @@
     <item msgid="2658001219380695677">"SMS"</item>
     <item msgid="7926918288165444873">"Alarm"</item>
   </string-array>
-  <string-array name="preferences_default_reminder_labels">
-    <item msgid="7495163916242649023">"Brak"</item>
-    <item msgid="5883344836499335043">"0 minut"</item>
-    <item msgid="4354350447805231188">"1 minuta"</item>
-    <item msgid="265674592625309858">"5 minut"</item>
-    <item msgid="8011089417728419666">"10 minut"</item>
-    <item msgid="6177098581805412986">"15 minut"</item>
-    <item msgid="356346660503078923">"20 minut"</item>
-    <item msgid="992592434377054063">"25 minut"</item>
-    <item msgid="9191353668596201944">"30 minut"</item>
-    <item msgid="1192985682962908244">"45 minut"</item>
-    <item msgid="1694315499429259938">"1 godzina"</item>
-    <item msgid="8281019320591769635">"2 godziny"</item>
-    <item msgid="2062931719019287773">"3 godziny"</item>
-    <item msgid="4086495711621133006">"12 godzin"</item>
-    <item msgid="3172669681920709561">"24 godziny"</item>
-    <item msgid="5557836606782821910">"2 dni"</item>
-    <item msgid="8336577387266744930">"1 tydzień"</item>
-    <item>2 weeks</item>
-    <item>4 weeks</item>
-  </string-array>
   <string-array name="preferences_week_start_day_labels">
     <item msgid="986150274035512339">"Domyślny dla regionu"</item>
     <item msgid="134027225275475280">"Sobota"</item>

--- a/res/values-pl/arrays.xml
+++ b/res/values-pl/arrays.xml
@@ -22,24 +22,6 @@
     <item msgid="2658001219380695677">"SMS"</item>
     <item msgid="7926918288165444873">"Alarm"</item>
   </string-array>
-  <string-array name="reminder_minutes_labels">
-    <item msgid="2416970002377237011">"0 minut"</item>
-    <item msgid="6681865010714743948">"1 minuta"</item>
-    <item msgid="2327505114623595779">"5 minut"</item>
-    <item msgid="1657410063332547113">"10 minut"</item>
-    <item msgid="366087535181197780">"15 minut"</item>
-    <item msgid="6252612791145061929">"20 minut"</item>
-    <item msgid="7896694531989090700">"25 minut"</item>
-    <item msgid="8754510169374808607">"30 minut"</item>
-    <item msgid="3113380274218454394">"45 minut"</item>
-    <item msgid="8546646645868526283">"1 godzina"</item>
-    <item msgid="6467845211024768872">"2 godziny"</item>
-    <item msgid="8201677619511076575">"3 godziny"</item>
-    <item msgid="7172504281650128893">"12 godzin"</item>
-    <item msgid="9114286702181482496">"24 godziny"</item>
-    <item msgid="3107009344872997366">"2 dni"</item>
-    <item msgid="6135563708172153696">"1 tydzień"</item>
-  </string-array>
   <string-array name="preferences_default_reminder_labels">
     <item msgid="7495163916242649023">"Brak"</item>
     <item msgid="5883344836499335043">"0 minut"</item>
@@ -58,6 +40,8 @@
     <item msgid="3172669681920709561">"24 godziny"</item>
     <item msgid="5557836606782821910">"2 dni"</item>
     <item msgid="8336577387266744930">"1 tydzień"</item>
+    <item>2 weeks</item>
+    <item>4 weeks</item>
   </string-array>
   <string-array name="preferences_week_start_day_labels">
     <item msgid="986150274035512339">"Domyślny dla regionu"</item>

--- a/res/values-pl/strings.xml
+++ b/res/values-pl/strings.xml
@@ -365,4 +365,5 @@
 \nW aplikacji DAVx⁵ można wyłączyć \'Zarządzanie kolorami kalendarza\', aby temu zapobiec.</string>
     <string name="cal_import_error_time_zone_msg">Nie można zrozumieć podanej strefy czasowej: %s</string>
     <string name="preferences_list_add_offline_message">Kalendarze offline NIE SĄ synchronizowane z usługą w chmurze i są dostępne tylko w Twoim telefonie.</string>
+    <string name="no_reminder_label">Brak</string>
 </resources>

--- a/res/values-pt-rPT/arrays.xml
+++ b/res/values-pt-rPT/arrays.xml
@@ -22,27 +22,6 @@
     <item msgid="2658001219380695677">"SMS"</item>
     <item msgid="7926918288165444873">"Alarme"</item>
   </string-array>
-  <string-array name="preferences_default_reminder_labels">
-    <item msgid="7495163916242649023">"Nenhum"</item>
-    <item msgid="5883344836499335043">"0 minutos"</item>
-    <item msgid="4354350447805231188">"1 minuto"</item>
-    <item msgid="265674592625309858">"5 minutos"</item>
-    <item msgid="8011089417728419666">"10 minutos"</item>
-    <item msgid="6177098581805412986">"15 minutos"</item>
-    <item msgid="356346660503078923">"20 minutos"</item>
-    <item msgid="992592434377054063">"25 minutos"</item>
-    <item msgid="9191353668596201944">"30 minutos"</item>
-    <item msgid="1192985682962908244">"45 minutos"</item>
-    <item msgid="1694315499429259938">"1 hora"</item>
-    <item msgid="8281019320591769635">"2 horas"</item>
-    <item msgid="2062931719019287773">"3 horas"</item>
-    <item msgid="4086495711621133006">"12 horas"</item>
-    <item msgid="3172669681920709561">"24 horas"</item>
-    <item msgid="5557836606782821910">"2 dias"</item>
-    <item msgid="8336577387266744930">"1 semana"</item>
-    <item>2 weeks</item>
-    <item>4 weeks</item>
-  </string-array>
   <string-array name="preferences_week_start_day_labels">
     <item msgid="986150274035512339">"Local predefinido"</item>
     <item msgid="134027225275475280">"Sábado"</item>

--- a/res/values-pt-rPT/arrays.xml
+++ b/res/values-pt-rPT/arrays.xml
@@ -22,24 +22,6 @@
     <item msgid="2658001219380695677">"SMS"</item>
     <item msgid="7926918288165444873">"Alarme"</item>
   </string-array>
-  <string-array name="reminder_minutes_labels">
-    <item msgid="2416970002377237011">"0 minutos"</item>
-    <item msgid="6681865010714743948">"1 minuto"</item>
-    <item msgid="2327505114623595779">"5 minutos"</item>
-    <item msgid="1657410063332547113">"10 minutos"</item>
-    <item msgid="366087535181197780">"15 minutos"</item>
-    <item msgid="6252612791145061929">"20 minutos"</item>
-    <item msgid="7896694531989090700">"25 minutos"</item>
-    <item msgid="8754510169374808607">"30 minutos"</item>
-    <item msgid="3113380274218454394">"45 minutos"</item>
-    <item msgid="8546646645868526283">"1 hora"</item>
-    <item msgid="6467845211024768872">"2 horas"</item>
-    <item msgid="8201677619511076575">"3 horas"</item>
-    <item msgid="7172504281650128893">"12 horas"</item>
-    <item msgid="9114286702181482496">"24 horas"</item>
-    <item msgid="3107009344872997366">"2 dias"</item>
-    <item msgid="6135563708172153696">"1 semana"</item>
-  </string-array>
   <string-array name="preferences_default_reminder_labels">
     <item msgid="7495163916242649023">"Nenhum"</item>
     <item msgid="5883344836499335043">"0 minutos"</item>
@@ -58,6 +40,8 @@
     <item msgid="3172669681920709561">"24 horas"</item>
     <item msgid="5557836606782821910">"2 dias"</item>
     <item msgid="8336577387266744930">"1 semana"</item>
+    <item>2 weeks</item>
+    <item>4 weeks</item>
   </string-array>
   <string-array name="preferences_week_start_day_labels">
     <item msgid="986150274035512339">"Local predefinido"</item>

--- a/res/values-pt-rPT/strings.xml
+++ b/res/values-pt-rPT/strings.xml
@@ -337,4 +337,5 @@
     <string name="preferences_list_add_remote_etesync">Adicionar calendário EteSync</string>
     <string name="preferences_list_add_remote">Adicionar calendário CalDAV</string>
     <string name="preferences_pure_black_night_mode">Modo escuro em preto puro</string>
+    <string name="no_reminder_label">Nenhum</string>
 </resources>

--- a/res/values-pt/arrays.xml
+++ b/res/values-pt/arrays.xml
@@ -22,24 +22,6 @@
     <item msgid="2658001219380695677">"SMS"</item>
     <item msgid="7926918288165444873">"Alarme"</item>
   </string-array>
-  <string-array name="reminder_minutes_labels">
-    <item msgid="2416970002377237011">"0 minutos"</item>
-    <item msgid="6681865010714743948">"Um minuto"</item>
-    <item msgid="2327505114623595779">"Cinco minutos"</item>
-    <item msgid="1657410063332547113">"10 minutos"</item>
-    <item msgid="366087535181197780">"15 minutos"</item>
-    <item msgid="6252612791145061929">"20 minutos"</item>
-    <item msgid="7896694531989090700">"25 minutos"</item>
-    <item msgid="8754510169374808607">"30 minutos"</item>
-    <item msgid="3113380274218454394">"45 minutos"</item>
-    <item msgid="8546646645868526283">"Uma hora"</item>
-    <item msgid="6467845211024768872">"Duas horas"</item>
-    <item msgid="8201677619511076575">"Três horas"</item>
-    <item msgid="7172504281650128893">"12 horas"</item>
-    <item msgid="9114286702181482496">"24 horas"</item>
-    <item msgid="3107009344872997366">"Dois dias"</item>
-    <item msgid="6135563708172153696">"Uma semana"</item>
-  </string-array>
   <string-array name="preferences_default_reminder_labels">
     <item msgid="7495163916242649023">"Nenhum"</item>
     <item msgid="5883344836499335043">"0 minutos"</item>
@@ -58,6 +40,8 @@
     <item msgid="3172669681920709561">"24 horas"</item>
     <item msgid="5557836606782821910">"Dois dias"</item>
     <item msgid="8336577387266744930">"Uma semana"</item>
+    <item>2 weeks</item>
+    <item>4 weeks</item>
   </string-array>
   <string-array name="preferences_week_start_day_labels">
     <item msgid="986150274035512339">"Localidade padrão"</item>

--- a/res/values-pt/arrays.xml
+++ b/res/values-pt/arrays.xml
@@ -22,27 +22,6 @@
     <item msgid="2658001219380695677">"SMS"</item>
     <item msgid="7926918288165444873">"Alarme"</item>
   </string-array>
-  <string-array name="preferences_default_reminder_labels">
-    <item msgid="7495163916242649023">"Nenhum"</item>
-    <item msgid="5883344836499335043">"0 minutos"</item>
-    <item msgid="4354350447805231188">"Um minuto"</item>
-    <item msgid="265674592625309858">"5 minutos"</item>
-    <item msgid="8011089417728419666">"10 minutos"</item>
-    <item msgid="6177098581805412986">"15 minutos"</item>
-    <item msgid="356346660503078923">"20 minutos"</item>
-    <item msgid="992592434377054063">"25 minutos"</item>
-    <item msgid="9191353668596201944">"30 minutos"</item>
-    <item msgid="1192985682962908244">"45 minutos"</item>
-    <item msgid="1694315499429259938">"Uma hora"</item>
-    <item msgid="8281019320591769635">"Duas horas"</item>
-    <item msgid="2062931719019287773">"Três horas"</item>
-    <item msgid="4086495711621133006">"12 horas"</item>
-    <item msgid="3172669681920709561">"24 horas"</item>
-    <item msgid="5557836606782821910">"Dois dias"</item>
-    <item msgid="8336577387266744930">"Uma semana"</item>
-    <item>2 weeks</item>
-    <item>4 weeks</item>
-  </string-array>
   <string-array name="preferences_week_start_day_labels">
     <item msgid="986150274035512339">"Localidade padrão"</item>
     <item msgid="134027225275475280">"Sábado"</item>

--- a/res/values-pt/strings.xml
+++ b/res/values-pt/strings.xml
@@ -337,4 +337,5 @@
     <string name="preferences_list_add_remote_etesync">Adicionar calendário EteSync</string>
     <string name="preferences_list_add_remote">Adicionar calendário CalDAV</string>
     <string name="preferences_pure_black_night_mode">Modo escuro em preto puro</string>
+    <string name="no_reminder_label">Nenhum</string>
 </resources>

--- a/res/values-ro/arrays.xml
+++ b/res/values-ro/arrays.xml
@@ -22,27 +22,6 @@
     <item msgid="2658001219380695677">"SMS"</item>
     <item msgid="7926918288165444873">"Alarmă"</item>
   </string-array>
-  <string-array name="preferences_default_reminder_labels">
-    <item msgid="7495163916242649023">"Niciunul"</item>
-    <item msgid="5883344836499335043">"0 minute"</item>
-    <item msgid="4354350447805231188">"1 minut"</item>
-    <item msgid="265674592625309858">"5 minute"</item>
-    <item msgid="8011089417728419666">"10 minute"</item>
-    <item msgid="6177098581805412986">"15 minute"</item>
-    <item msgid="356346660503078923">"20 de minute"</item>
-    <item msgid="992592434377054063">"25 de minute"</item>
-    <item msgid="9191353668596201944">"30 de minute"</item>
-    <item msgid="1192985682962908244">"45 de minute"</item>
-    <item msgid="1694315499429259938">"1 oră"</item>
-    <item msgid="8281019320591769635">"2 ore"</item>
-    <item msgid="2062931719019287773">"3 ore"</item>
-    <item msgid="4086495711621133006">"12 ore"</item>
-    <item msgid="3172669681920709561">"24 de ore"</item>
-    <item msgid="5557836606782821910">"2 zile"</item>
-    <item msgid="8336577387266744930">"1 săptămână"</item>
-    <item>2 weeks</item>
-    <item>4 weeks</item>
-  </string-array>
   <string-array name="preferences_week_start_day_labels">
     <item msgid="986150274035512339">"Codul local prestabilit"</item>
     <item msgid="134027225275475280">"Sâmbătă"</item>

--- a/res/values-ro/arrays.xml
+++ b/res/values-ro/arrays.xml
@@ -22,24 +22,6 @@
     <item msgid="2658001219380695677">"SMS"</item>
     <item msgid="7926918288165444873">"Alarmă"</item>
   </string-array>
-  <string-array name="reminder_minutes_labels">
-    <item msgid="2416970002377237011">"0 minute"</item>
-    <item msgid="6681865010714743948">"1 minut"</item>
-    <item msgid="2327505114623595779">"5 minute"</item>
-    <item msgid="1657410063332547113">"10 minute"</item>
-    <item msgid="366087535181197780">"15 minute"</item>
-    <item msgid="6252612791145061929">"20 de minute"</item>
-    <item msgid="7896694531989090700">"25 de minute"</item>
-    <item msgid="8754510169374808607">"30 de minute"</item>
-    <item msgid="3113380274218454394">"45 de minute"</item>
-    <item msgid="8546646645868526283">"1 oră"</item>
-    <item msgid="6467845211024768872">"2 ore"</item>
-    <item msgid="8201677619511076575">"3 ore"</item>
-    <item msgid="7172504281650128893">"12 ore"</item>
-    <item msgid="9114286702181482496">"24 de ore"</item>
-    <item msgid="3107009344872997366">"2 zile"</item>
-    <item msgid="6135563708172153696">"1 săptămână"</item>
-  </string-array>
   <string-array name="preferences_default_reminder_labels">
     <item msgid="7495163916242649023">"Niciunul"</item>
     <item msgid="5883344836499335043">"0 minute"</item>
@@ -58,6 +40,8 @@
     <item msgid="3172669681920709561">"24 de ore"</item>
     <item msgid="5557836606782821910">"2 zile"</item>
     <item msgid="8336577387266744930">"1 săptămână"</item>
+    <item>2 weeks</item>
+    <item>4 weeks</item>
   </string-array>
   <string-array name="preferences_week_start_day_labels">
     <item msgid="986150274035512339">"Codul local prestabilit"</item>

--- a/res/values-ro/strings.xml
+++ b/res/values-ro/strings.xml
@@ -236,4 +236,5 @@
     <string name="visibility_default">Prestabilit</string>
     <string name="visibility_private">Privat</string>
     <string name="visibility_public">Public</string>
+    <string name="no_reminder_label">Niciunul</string>
 </resources>

--- a/res/values-ru/arrays.xml
+++ b/res/values-ru/arrays.xml
@@ -22,24 +22,6 @@
     <item msgid="2658001219380695677">"SMS"</item>
     <item msgid="7926918288165444873">"Сигнал"</item>
   </string-array>
-  <string-array name="reminder_minutes_labels">
-    <item msgid="2416970002377237011">"0 минут"</item>
-    <item msgid="6681865010714743948">"1 минута"</item>
-    <item msgid="2327505114623595779">"5 минут"</item>
-    <item msgid="1657410063332547113">"10 минут"</item>
-    <item msgid="366087535181197780">"15 минут"</item>
-    <item msgid="6252612791145061929">"20 минут"</item>
-    <item msgid="7896694531989090700">"25 минут"</item>
-    <item msgid="8754510169374808607">"30 минут"</item>
-    <item msgid="3113380274218454394">"45 минут"</item>
-    <item msgid="8546646645868526283">"1 час"</item>
-    <item msgid="6467845211024768872">"2 часа"</item>
-    <item msgid="8201677619511076575">"3 часа"</item>
-    <item msgid="7172504281650128893">"12 часов"</item>
-    <item msgid="9114286702181482496">"24 часа"</item>
-    <item msgid="3107009344872997366">"2 дня"</item>
-    <item msgid="6135563708172153696">"1 неделя"</item>
-  </string-array>
   <string-array name="preferences_default_reminder_labels">
     <item msgid="7495163916242649023">"Нет"</item>
     <item msgid="5883344836499335043">"0 минут"</item>
@@ -58,6 +40,8 @@
     <item msgid="3172669681920709561">"24 часа"</item>
     <item msgid="5557836606782821910">"2 дня"</item>
     <item msgid="8336577387266744930">"1 неделя"</item>
+    <item>2 weeks</item>
+    <item>4 weeks</item>
   </string-array>
   <string-array name="preferences_week_start_day_labels">
     <item msgid="986150274035512339">"Региональные настройки по умолчанию"</item>

--- a/res/values-ru/arrays.xml
+++ b/res/values-ru/arrays.xml
@@ -22,27 +22,6 @@
     <item msgid="2658001219380695677">"SMS"</item>
     <item msgid="7926918288165444873">"Сигнал"</item>
   </string-array>
-  <string-array name="preferences_default_reminder_labels">
-    <item msgid="7495163916242649023">"Нет"</item>
-    <item msgid="5883344836499335043">"0 минут"</item>
-    <item msgid="4354350447805231188">"1 минута"</item>
-    <item msgid="265674592625309858">"5 минут"</item>
-    <item msgid="8011089417728419666">"10 минут"</item>
-    <item msgid="6177098581805412986">"15 минут"</item>
-    <item msgid="356346660503078923">"20 минут"</item>
-    <item msgid="992592434377054063">"25 минут"</item>
-    <item msgid="9191353668596201944">"30 минут"</item>
-    <item msgid="1192985682962908244">"45 минут"</item>
-    <item msgid="1694315499429259938">"1 час"</item>
-    <item msgid="8281019320591769635">"2 часа"</item>
-    <item msgid="2062931719019287773">"3 часа"</item>
-    <item msgid="4086495711621133006">"12 часов"</item>
-    <item msgid="3172669681920709561">"24 часа"</item>
-    <item msgid="5557836606782821910">"2 дня"</item>
-    <item msgid="8336577387266744930">"1 неделя"</item>
-    <item>2 weeks</item>
-    <item>4 weeks</item>
-  </string-array>
   <string-array name="preferences_week_start_day_labels">
     <item msgid="986150274035512339">"Региональные настройки по умолчанию"</item>
     <item msgid="134027225275475280">"суббота"</item>

--- a/res/values-ru/strings.xml
+++ b/res/values-ru/strings.xml
@@ -353,4 +353,5 @@
     <string name="preferences_list_add_remote_etesync">Добавить календарь EteSync</string>
     <string name="preferences_list_add_remote">Добавить календарь CalDAV</string>
     <string name="preferences_pure_black_night_mode">Чёрный ночной режим</string>
+    <string name="no_reminder_label">Нет</string>
 </resources>

--- a/res/values-sk/arrays.xml
+++ b/res/values-sk/arrays.xml
@@ -22,27 +22,6 @@
     <item msgid="2658001219380695677">"SMS"</item>
     <item msgid="7926918288165444873">"Budík"</item>
   </string-array>
-  <string-array name="preferences_default_reminder_labels">
-    <item msgid="7495163916242649023">"Žiadne"</item>
-    <item msgid="5883344836499335043">"0 minút"</item>
-    <item msgid="4354350447805231188">"1 minúta"</item>
-    <item msgid="265674592625309858">"5 minút"</item>
-    <item msgid="8011089417728419666">"10 minút"</item>
-    <item msgid="6177098581805412986">"15 minút"</item>
-    <item msgid="356346660503078923">"20 minút"</item>
-    <item msgid="992592434377054063">"25 minút"</item>
-    <item msgid="9191353668596201944">"30 minút"</item>
-    <item msgid="1192985682962908244">"45 minút"</item>
-    <item msgid="1694315499429259938">"1 hodina"</item>
-    <item msgid="8281019320591769635">"2 hodiny"</item>
-    <item msgid="2062931719019287773">"3 hodiny"</item>
-    <item msgid="4086495711621133006">"12 hodín"</item>
-    <item msgid="3172669681920709561">"24 hodín"</item>
-    <item msgid="5557836606782821910">"2 dni"</item>
-    <item msgid="8336577387266744930">"1 týždeň"</item>
-    <item>2 weeks</item>
-    <item>4 weeks</item>
-  </string-array>
   <string-array name="preferences_week_start_day_labels">
     <item msgid="986150274035512339">"Predvolená hodnota miestneho nastavenia"</item>
     <item msgid="134027225275475280">"Sobota"</item>

--- a/res/values-sk/arrays.xml
+++ b/res/values-sk/arrays.xml
@@ -22,24 +22,6 @@
     <item msgid="2658001219380695677">"SMS"</item>
     <item msgid="7926918288165444873">"Budík"</item>
   </string-array>
-  <string-array name="reminder_minutes_labels">
-    <item msgid="2416970002377237011">"0 minút"</item>
-    <item msgid="6681865010714743948">"1 minúta"</item>
-    <item msgid="2327505114623595779">"5 minút"</item>
-    <item msgid="1657410063332547113">"10 minút"</item>
-    <item msgid="366087535181197780">"15 minút"</item>
-    <item msgid="6252612791145061929">"20 minút"</item>
-    <item msgid="7896694531989090700">"25 minút"</item>
-    <item msgid="8754510169374808607">"30 minút"</item>
-    <item msgid="3113380274218454394">"45 minút"</item>
-    <item msgid="8546646645868526283">"1 hodina"</item>
-    <item msgid="6467845211024768872">"2 hodiny"</item>
-    <item msgid="8201677619511076575">"3 hodiny"</item>
-    <item msgid="7172504281650128893">"12 hodín"</item>
-    <item msgid="9114286702181482496">"24 hodín"</item>
-    <item msgid="3107009344872997366">"2 dni"</item>
-    <item msgid="6135563708172153696">"1 týždeň"</item>
-  </string-array>
   <string-array name="preferences_default_reminder_labels">
     <item msgid="7495163916242649023">"Žiadne"</item>
     <item msgid="5883344836499335043">"0 minút"</item>
@@ -58,6 +40,8 @@
     <item msgid="3172669681920709561">"24 hodín"</item>
     <item msgid="5557836606782821910">"2 dni"</item>
     <item msgid="8336577387266744930">"1 týždeň"</item>
+    <item>2 weeks</item>
+    <item>4 weeks</item>
   </string-array>
   <string-array name="preferences_week_start_day_labels">
     <item msgid="986150274035512339">"Predvolená hodnota miestneho nastavenia"</item>

--- a/res/values-sk/strings.xml
+++ b/res/values-sk/strings.xml
@@ -289,4 +289,5 @@
     <string name="show_time_start_end">Čas začatia a ukončenia</string>
     <string name="show_time_start_end_below">Počiatočný a koncový čas pod udalosťou</string>
     <string name="maximum_number_of_lines">Maximálny počet riadkov v udalosti</string>
+    <string name="no_reminder_label">Žiadne</string>
 </resources>

--- a/res/values-sl/arrays.xml
+++ b/res/values-sl/arrays.xml
@@ -22,24 +22,6 @@
     <item msgid="2658001219380695677">"SMS"</item>
     <item msgid="7926918288165444873">"Alarm"</item>
   </string-array>
-  <string-array name="reminder_minutes_labels">
-    <item msgid="2416970002377237011">"0 minut"</item>
-    <item msgid="6681865010714743948">"1 minuta"</item>
-    <item msgid="2327505114623595779">"5 minut"</item>
-    <item msgid="1657410063332547113">"10 minut"</item>
-    <item msgid="366087535181197780">"15 minut"</item>
-    <item msgid="6252612791145061929">"20 minut"</item>
-    <item msgid="7896694531989090700">"25 minut"</item>
-    <item msgid="8754510169374808607">"30 minut"</item>
-    <item msgid="3113380274218454394">"45 minut"</item>
-    <item msgid="8546646645868526283">"1 ura"</item>
-    <item msgid="6467845211024768872">"2 uri"</item>
-    <item msgid="8201677619511076575">"3 ure"</item>
-    <item msgid="7172504281650128893">"12 ur"</item>
-    <item msgid="9114286702181482496">"24 ur"</item>
-    <item msgid="3107009344872997366">"2 dni"</item>
-    <item msgid="6135563708172153696">"1 teden"</item>
-  </string-array>
   <string-array name="preferences_default_reminder_labels">
     <item msgid="7495163916242649023">"Brez"</item>
     <item msgid="5883344836499335043">"0 minut"</item>
@@ -58,6 +40,8 @@
     <item msgid="3172669681920709561">"24 ur"</item>
     <item msgid="5557836606782821910">"2 dneva"</item>
     <item msgid="8336577387266744930">"1 teden"</item>
+    <item>2 weeks</item>
+    <item>4 weeks</item>
   </string-array>
   <string-array name="preferences_week_start_day_labels">
     <item msgid="986150274035512339">"Privzete območne nastavitve"</item>

--- a/res/values-sl/arrays.xml
+++ b/res/values-sl/arrays.xml
@@ -22,27 +22,6 @@
     <item msgid="2658001219380695677">"SMS"</item>
     <item msgid="7926918288165444873">"Alarm"</item>
   </string-array>
-  <string-array name="preferences_default_reminder_labels">
-    <item msgid="7495163916242649023">"Brez"</item>
-    <item msgid="5883344836499335043">"0 minut"</item>
-    <item msgid="4354350447805231188">"1 minuta"</item>
-    <item msgid="265674592625309858">"5 minut"</item>
-    <item msgid="8011089417728419666">"10 minut"</item>
-    <item msgid="6177098581805412986">"15 minut"</item>
-    <item msgid="356346660503078923">"20 minut"</item>
-    <item msgid="992592434377054063">"25 minut"</item>
-    <item msgid="9191353668596201944">"30 minut"</item>
-    <item msgid="1192985682962908244">"45 minut"</item>
-    <item msgid="1694315499429259938">"1 ura"</item>
-    <item msgid="8281019320591769635">"2 uri"</item>
-    <item msgid="2062931719019287773">"3 ure"</item>
-    <item msgid="4086495711621133006">"12 ur"</item>
-    <item msgid="3172669681920709561">"24 ur"</item>
-    <item msgid="5557836606782821910">"2 dneva"</item>
-    <item msgid="8336577387266744930">"1 teden"</item>
-    <item>2 weeks</item>
-    <item>4 weeks</item>
-  </string-array>
   <string-array name="preferences_week_start_day_labels">
     <item msgid="986150274035512339">"Privzete območne nastavitve"</item>
     <item msgid="134027225275475280">"Sobota"</item>

--- a/res/values-sl/strings.xml
+++ b/res/values-sl/strings.xml
@@ -236,4 +236,5 @@
     <string name="visibility_default">Privzeto</string>
     <string name="visibility_private">Zasebno</string>
     <string name="visibility_public">Javno</string>
+    <string name="no_reminder_label">Brez</string>
 </resources>

--- a/res/values-sr/arrays.xml
+++ b/res/values-sr/arrays.xml
@@ -22,27 +22,6 @@
     <item msgid="2658001219380695677">"SMS"</item>
     <item msgid="7926918288165444873">"Аларм"</item>
   </string-array>
-  <string-array name="preferences_default_reminder_labels">
-    <item msgid="7495163916242649023">"Ништа"</item>
-    <item msgid="5883344836499335043">"0 минута"</item>
-    <item msgid="4354350447805231188">"1 минут"</item>
-    <item msgid="265674592625309858">"5 минута"</item>
-    <item msgid="8011089417728419666">"10 минута"</item>
-    <item msgid="6177098581805412986">"15 минута"</item>
-    <item msgid="356346660503078923">"20 минута"</item>
-    <item msgid="992592434377054063">"25 минута"</item>
-    <item msgid="9191353668596201944">"30 минута"</item>
-    <item msgid="1192985682962908244">"45 минута"</item>
-    <item msgid="1694315499429259938">"1 сат"</item>
-    <item msgid="8281019320591769635">"2 сата"</item>
-    <item msgid="2062931719019287773">"3 сата"</item>
-    <item msgid="4086495711621133006">"12 сати"</item>
-    <item msgid="3172669681920709561">"24 сата"</item>
-    <item msgid="5557836606782821910">"2 дана"</item>
-    <item msgid="8336577387266744930">"1 недеља"</item>
-    <item>2 weeks</item>
-    <item>4 weeks</item>
-  </string-array>
   <string-array name="preferences_week_start_day_labels">
     <item msgid="986150274035512339">"Подразумевано за локалитет"</item>
     <item msgid="134027225275475280">"субота"</item>

--- a/res/values-sr/arrays.xml
+++ b/res/values-sr/arrays.xml
@@ -22,24 +22,6 @@
     <item msgid="2658001219380695677">"SMS"</item>
     <item msgid="7926918288165444873">"Аларм"</item>
   </string-array>
-  <string-array name="reminder_minutes_labels">
-    <item msgid="2416970002377237011">"0 минута"</item>
-    <item msgid="6681865010714743948">"1 минут"</item>
-    <item msgid="2327505114623595779">"5 минута"</item>
-    <item msgid="1657410063332547113">"10 минута"</item>
-    <item msgid="366087535181197780">"15 минута"</item>
-    <item msgid="6252612791145061929">"20 минута"</item>
-    <item msgid="7896694531989090700">"25 минута"</item>
-    <item msgid="8754510169374808607">"30 минута"</item>
-    <item msgid="3113380274218454394">"45 минута"</item>
-    <item msgid="8546646645868526283">"1 сат"</item>
-    <item msgid="6467845211024768872">"2 сата"</item>
-    <item msgid="8201677619511076575">"3 сата"</item>
-    <item msgid="7172504281650128893">"12 сати"</item>
-    <item msgid="9114286702181482496">"24 сата"</item>
-    <item msgid="3107009344872997366">"2 дана"</item>
-    <item msgid="6135563708172153696">"1 недеља"</item>
-  </string-array>
   <string-array name="preferences_default_reminder_labels">
     <item msgid="7495163916242649023">"Ништа"</item>
     <item msgid="5883344836499335043">"0 минута"</item>
@@ -58,6 +40,8 @@
     <item msgid="3172669681920709561">"24 сата"</item>
     <item msgid="5557836606782821910">"2 дана"</item>
     <item msgid="8336577387266744930">"1 недеља"</item>
+    <item>2 weeks</item>
+    <item>4 weeks</item>
   </string-array>
   <string-array name="preferences_week_start_day_labels">
     <item msgid="986150274035512339">"Подразумевано за локалитет"</item>

--- a/res/values-sr/strings.xml
+++ b/res/values-sr/strings.xml
@@ -255,4 +255,5 @@
     <string name="display_options">Погледај детаље</string>
     <string name="display_time">Прикажи Време</string>
     <string name="display_location">Прикажи Локацију</string>
+    <string name="no_reminder_label">Ништа</string>
 </resources>

--- a/res/values-sv/arrays.xml
+++ b/res/values-sv/arrays.xml
@@ -22,24 +22,6 @@
     <item msgid="2658001219380695677">"SMS"</item>
     <item msgid="7926918288165444873">"Larm"</item>
   </string-array>
-  <string-array name="reminder_minutes_labels">
-    <item msgid="2416970002377237011">"0 minuter"</item>
-    <item msgid="6681865010714743948">"1 minut"</item>
-    <item msgid="2327505114623595779">"5 minuter"</item>
-    <item msgid="1657410063332547113">"10 minuter"</item>
-    <item msgid="366087535181197780">"15 minuter"</item>
-    <item msgid="6252612791145061929">"20 minuter"</item>
-    <item msgid="7896694531989090700">"25 minuter"</item>
-    <item msgid="8754510169374808607">"30 minuter"</item>
-    <item msgid="3113380274218454394">"45 minuter"</item>
-    <item msgid="8546646645868526283">"1 timme"</item>
-    <item msgid="6467845211024768872">"2 timmar"</item>
-    <item msgid="8201677619511076575">"3 timmar"</item>
-    <item msgid="7172504281650128893">"12 timmar"</item>
-    <item msgid="9114286702181482496">"24 timmar"</item>
-    <item msgid="3107009344872997366">"2 dagar"</item>
-    <item msgid="6135563708172153696">"1 vecka"</item>
-  </string-array>
   <string-array name="preferences_default_reminder_labels">
     <item msgid="7495163916242649023">"Inga"</item>
     <item msgid="5883344836499335043">"0 minuter"</item>
@@ -58,6 +40,8 @@
     <item msgid="3172669681920709561">"24 timmar"</item>
     <item msgid="5557836606782821910">"2 dagar"</item>
     <item msgid="8336577387266744930">"1 vecka"</item>
+    <item>2 weeks</item>
+    <item>4 weeks</item>
   </string-array>
   <string-array name="preferences_week_start_day_labels">
     <item msgid="986150274035512339">"Standardinställning för språkkod"</item>

--- a/res/values-sv/arrays.xml
+++ b/res/values-sv/arrays.xml
@@ -22,27 +22,6 @@
     <item msgid="2658001219380695677">"SMS"</item>
     <item msgid="7926918288165444873">"Larm"</item>
   </string-array>
-  <string-array name="preferences_default_reminder_labels">
-    <item msgid="7495163916242649023">"Inga"</item>
-    <item msgid="5883344836499335043">"0 minuter"</item>
-    <item msgid="4354350447805231188">"1 minut"</item>
-    <item msgid="265674592625309858">"5 minuter"</item>
-    <item msgid="8011089417728419666">"10 minuter"</item>
-    <item msgid="6177098581805412986">"15 minuter"</item>
-    <item msgid="356346660503078923">"20 minuter"</item>
-    <item msgid="992592434377054063">"25 minuter"</item>
-    <item msgid="9191353668596201944">"30 minuter"</item>
-    <item msgid="1192985682962908244">"45 minuter"</item>
-    <item msgid="1694315499429259938">"1 timme"</item>
-    <item msgid="8281019320591769635">"2 timmar"</item>
-    <item msgid="2062931719019287773">"3 timmar"</item>
-    <item msgid="4086495711621133006">"12 timmar"</item>
-    <item msgid="3172669681920709561">"24 timmar"</item>
-    <item msgid="5557836606782821910">"2 dagar"</item>
-    <item msgid="8336577387266744930">"1 vecka"</item>
-    <item>2 weeks</item>
-    <item>4 weeks</item>
-  </string-array>
   <string-array name="preferences_week_start_day_labels">
     <item msgid="986150274035512339">"Standardinställning för språkkod"</item>
     <item msgid="134027225275475280">"lördag"</item>

--- a/res/values-sv/strings.xml
+++ b/res/values-sv/strings.xml
@@ -295,4 +295,5 @@
     <string name="foreground_notification_channel_name">Varningssynkronisering</string>
     <string name="foreground_notification_channel_description">Förgrundsmeddelande krävs för intern varningssynkronisering. Vänligen stäng av ljudet</string>
     <string name="preferences_system_theme">Systemets standard</string>
+    <string name="no_reminder_label">Inga</string>
 </resources>

--- a/res/values-sw/arrays.xml
+++ b/res/values-sw/arrays.xml
@@ -22,27 +22,6 @@
     <item msgid="2658001219380695677">"Ujumbe mfupi"</item>
     <item msgid="7926918288165444873">"Kengele"</item>
   </string-array>
-  <string-array name="preferences_default_reminder_labels">
-    <item msgid="7495163916242649023">"Hamna"</item>
-    <item msgid="5883344836499335043">"Dakika 0"</item>
-    <item msgid="4354350447805231188">"Dakika 1"</item>
-    <item msgid="265674592625309858">"Dakika 5"</item>
-    <item msgid="8011089417728419666">"Dakika 10"</item>
-    <item msgid="6177098581805412986">"Dakika 15"</item>
-    <item msgid="356346660503078923">"Dakika 20"</item>
-    <item msgid="992592434377054063">"Dakika 25"</item>
-    <item msgid="9191353668596201944">"Dakika 30"</item>
-    <item msgid="1192985682962908244">"Dakika 45"</item>
-    <item msgid="1694315499429259938">"Saa 1"</item>
-    <item msgid="8281019320591769635">"Saa 2"</item>
-    <item msgid="2062931719019287773">"Saa 3"</item>
-    <item msgid="4086495711621133006">"Saa 12"</item>
-    <item msgid="3172669681920709561">"Saa 24"</item>
-    <item msgid="5557836606782821910">"Siku 2"</item>
-    <item msgid="8336577387266744930">"Wiki 1"</item>
-    <item>2 weeks</item>
-    <item>4 weeks</item>
-  </string-array>
   <string-array name="preferences_week_start_day_labels">
     <item msgid="986150274035512339">"Eneo la kawaida"</item>
     <item msgid="134027225275475280">"Jumamosi"</item>

--- a/res/values-sw/arrays.xml
+++ b/res/values-sw/arrays.xml
@@ -22,24 +22,6 @@
     <item msgid="2658001219380695677">"Ujumbe mfupi"</item>
     <item msgid="7926918288165444873">"Kengele"</item>
   </string-array>
-  <string-array name="reminder_minutes_labels">
-    <item msgid="2416970002377237011">"Dakika 0"</item>
-    <item msgid="6681865010714743948">"Dakika 1"</item>
-    <item msgid="2327505114623595779">"Dakika 5"</item>
-    <item msgid="1657410063332547113">"Dakika 10"</item>
-    <item msgid="366087535181197780">"Dakika 15"</item>
-    <item msgid="6252612791145061929">"Dakika 20"</item>
-    <item msgid="7896694531989090700">"Dakika 25"</item>
-    <item msgid="8754510169374808607">"Dakika 30"</item>
-    <item msgid="3113380274218454394">"Dakika 45"</item>
-    <item msgid="8546646645868526283">"Saa 1"</item>
-    <item msgid="6467845211024768872">"Saa 2"</item>
-    <item msgid="8201677619511076575">"Saa 3"</item>
-    <item msgid="7172504281650128893">"Saa 12"</item>
-    <item msgid="9114286702181482496">"Saa 24"</item>
-    <item msgid="3107009344872997366">"Siku 2"</item>
-    <item msgid="6135563708172153696">"Wiki 1"</item>
-  </string-array>
   <string-array name="preferences_default_reminder_labels">
     <item msgid="7495163916242649023">"Hamna"</item>
     <item msgid="5883344836499335043">"Dakika 0"</item>
@@ -58,6 +40,8 @@
     <item msgid="3172669681920709561">"Saa 24"</item>
     <item msgid="5557836606782821910">"Siku 2"</item>
     <item msgid="8336577387266744930">"Wiki 1"</item>
+    <item>2 weeks</item>
+    <item>4 weeks</item>
   </string-array>
   <string-array name="preferences_week_start_day_labels">
     <item msgid="986150274035512339">"Eneo la kawaida"</item>

--- a/res/values-sw/strings.xml
+++ b/res/values-sw/strings.xml
@@ -236,4 +236,5 @@
     <string name="visibility_default">Chaguo-msingi</string>
     <string name="visibility_private">Faragha</string>
     <string name="visibility_public">Umma</string>
+    <string name="no_reminder_label">Hamna</string>
 </resources>

--- a/res/values-th/arrays.xml
+++ b/res/values-th/arrays.xml
@@ -22,27 +22,6 @@
     <item msgid="2658001219380695677">"SMS"</item>
     <item msgid="7926918288165444873">"เตือน"</item>
   </string-array>
-  <string-array name="preferences_default_reminder_labels">
-    <item msgid="7495163916242649023">"ไม่มี"</item>
-    <item msgid="5883344836499335043">"0 นาที"</item>
-    <item msgid="4354350447805231188">"1 นาที"</item>
-    <item msgid="265674592625309858">"5 นาที"</item>
-    <item msgid="8011089417728419666">"10 นาที"</item>
-    <item msgid="6177098581805412986">"15 นาที"</item>
-    <item msgid="356346660503078923">"20 นาที"</item>
-    <item msgid="992592434377054063">"25 นาที"</item>
-    <item msgid="9191353668596201944">"30 นาที"</item>
-    <item msgid="1192985682962908244">"45 นาที"</item>
-    <item msgid="1694315499429259938">"1 ชั่วโมง"</item>
-    <item msgid="8281019320591769635">"2 ชั่วโมง"</item>
-    <item msgid="2062931719019287773">"3 ชั่วโมง"</item>
-    <item msgid="4086495711621133006">"12 ชั่วโมง"</item>
-    <item msgid="3172669681920709561">"24 ชั่วโมง"</item>
-    <item msgid="5557836606782821910">"2 วัน"</item>
-    <item msgid="8336577387266744930">"1 สัปดาห์"</item>
-    <item>2 weeks</item>
-    <item>4 weeks</item>
-  </string-array>
   <string-array name="preferences_week_start_day_labels">
     <item msgid="986150274035512339">"ตามท้องถิ่น"</item>
     <item msgid="134027225275475280">"วันเสาร์"</item>

--- a/res/values-th/arrays.xml
+++ b/res/values-th/arrays.xml
@@ -22,24 +22,6 @@
     <item msgid="2658001219380695677">"SMS"</item>
     <item msgid="7926918288165444873">"เตือน"</item>
   </string-array>
-  <string-array name="reminder_minutes_labels">
-    <item msgid="2416970002377237011">"0 นาที"</item>
-    <item msgid="6681865010714743948">"1 นาที"</item>
-    <item msgid="2327505114623595779">"5 นาที"</item>
-    <item msgid="1657410063332547113">"10 นาที"</item>
-    <item msgid="366087535181197780">"15 นาที"</item>
-    <item msgid="6252612791145061929">"20 นาที"</item>
-    <item msgid="7896694531989090700">"25 นาที"</item>
-    <item msgid="8754510169374808607">"30 นาที"</item>
-    <item msgid="3113380274218454394">"45 นาที"</item>
-    <item msgid="8546646645868526283">"1 ชั่วโมง"</item>
-    <item msgid="6467845211024768872">"2 ชั่วโมง"</item>
-    <item msgid="8201677619511076575">"3 ชั่วโมง"</item>
-    <item msgid="7172504281650128893">"12 ชั่วโมง"</item>
-    <item msgid="9114286702181482496">"24 ชั่วโมง"</item>
-    <item msgid="3107009344872997366">"2 วัน"</item>
-    <item msgid="6135563708172153696">"1 สัปดาห์"</item>
-  </string-array>
   <string-array name="preferences_default_reminder_labels">
     <item msgid="7495163916242649023">"ไม่มี"</item>
     <item msgid="5883344836499335043">"0 นาที"</item>
@@ -58,6 +40,8 @@
     <item msgid="3172669681920709561">"24 ชั่วโมง"</item>
     <item msgid="5557836606782821910">"2 วัน"</item>
     <item msgid="8336577387266744930">"1 สัปดาห์"</item>
+    <item>2 weeks</item>
+    <item>4 weeks</item>
   </string-array>
   <string-array name="preferences_week_start_day_labels">
     <item msgid="986150274035512339">"ตามท้องถิ่น"</item>

--- a/res/values-th/strings.xml
+++ b/res/values-th/strings.xml
@@ -236,4 +236,5 @@
     <string name="visibility_default">เริ่มต้น</string>
     <string name="visibility_private">ส่วนบุคคล</string>
     <string name="visibility_public">สาธารณะ</string>
+    <string name="no_reminder_label">ไม่มี</string>
 </resources>

--- a/res/values-tl/arrays.xml
+++ b/res/values-tl/arrays.xml
@@ -22,24 +22,6 @@
     <item msgid="2658001219380695677">"SMS"</item>
     <item msgid="7926918288165444873">"Alarma"</item>
   </string-array>
-  <string-array name="reminder_minutes_labels">
-    <item msgid="2416970002377237011">"0 minuto"</item>
-    <item msgid="6681865010714743948">"1 minuto"</item>
-    <item msgid="2327505114623595779">"5 minuto"</item>
-    <item msgid="1657410063332547113">"10 minuto"</item>
-    <item msgid="366087535181197780">"15 minuto"</item>
-    <item msgid="6252612791145061929">"20 minuto"</item>
-    <item msgid="7896694531989090700">"25 minuto"</item>
-    <item msgid="8754510169374808607">"30 minuto"</item>
-    <item msgid="3113380274218454394">"45 minuto"</item>
-    <item msgid="8546646645868526283">"1 oras"</item>
-    <item msgid="6467845211024768872">"2 oras"</item>
-    <item msgid="8201677619511076575">"3 oras"</item>
-    <item msgid="7172504281650128893">"12 oras"</item>
-    <item msgid="9114286702181482496">"24 oras"</item>
-    <item msgid="3107009344872997366">"2 araw"</item>
-    <item msgid="6135563708172153696">"1 linggo"</item>
-  </string-array>
   <string-array name="preferences_default_reminder_labels">
     <item msgid="7495163916242649023">"Wala"</item>
     <item msgid="5883344836499335043">"0 minuto"</item>
@@ -58,6 +40,8 @@
     <item msgid="3172669681920709561">"24 na oras"</item>
     <item msgid="5557836606782821910">"2 araw"</item>
     <item msgid="8336577387266744930">"1 linggo"</item>
+    <item>2 weeks</item>
+    <item>4 weeks</item>
   </string-array>
   <string-array name="preferences_week_start_day_labels">
     <item msgid="986150274035512339">"Lokal na default"</item>

--- a/res/values-tl/arrays.xml
+++ b/res/values-tl/arrays.xml
@@ -22,27 +22,6 @@
     <item msgid="2658001219380695677">"SMS"</item>
     <item msgid="7926918288165444873">"Alarma"</item>
   </string-array>
-  <string-array name="preferences_default_reminder_labels">
-    <item msgid="7495163916242649023">"Wala"</item>
-    <item msgid="5883344836499335043">"0 minuto"</item>
-    <item msgid="4354350447805231188">"1 minuto"</item>
-    <item msgid="265674592625309858">"5 minuto"</item>
-    <item msgid="8011089417728419666">"10 minuto"</item>
-    <item msgid="6177098581805412986">"15 minuto"</item>
-    <item msgid="356346660503078923">"20 minuto"</item>
-    <item msgid="992592434377054063">"25 minuto"</item>
-    <item msgid="9191353668596201944">"30 minuto"</item>
-    <item msgid="1192985682962908244">"45 minuto"</item>
-    <item msgid="1694315499429259938">"1 oras"</item>
-    <item msgid="8281019320591769635">"2 oras"</item>
-    <item msgid="2062931719019287773">"3 oras"</item>
-    <item msgid="4086495711621133006">"12 oras"</item>
-    <item msgid="3172669681920709561">"24 na oras"</item>
-    <item msgid="5557836606782821910">"2 araw"</item>
-    <item msgid="8336577387266744930">"1 linggo"</item>
-    <item>2 weeks</item>
-    <item>4 weeks</item>
-  </string-array>
   <string-array name="preferences_week_start_day_labels">
     <item msgid="986150274035512339">"Lokal na default"</item>
     <item msgid="134027225275475280">"Sabado"</item>

--- a/res/values-tl/strings.xml
+++ b/res/values-tl/strings.xml
@@ -236,4 +236,5 @@
     <string name="visibility_default">Default</string>
     <string name="visibility_private">Pribado</string>
     <string name="visibility_public">Pampubliko</string>
+    <string name="no_reminder_label">Wala</string>
 </resources>

--- a/res/values-tr/arrays.xml
+++ b/res/values-tr/arrays.xml
@@ -22,27 +22,6 @@
     <item msgid="2658001219380695677">"SMS"</item>
     <item msgid="7926918288165444873">"Alarm"</item>
   </string-array>
-  <string-array name="preferences_default_reminder_labels">
-    <item msgid="7495163916242649023">"Yok"</item>
-    <item msgid="5883344836499335043">"0 dakika"</item>
-    <item msgid="4354350447805231188">"1 dakika"</item>
-    <item msgid="265674592625309858">"5 dakika"</item>
-    <item msgid="8011089417728419666">"10 dakika"</item>
-    <item msgid="6177098581805412986">"15 dakika"</item>
-    <item msgid="356346660503078923">"20 dakika"</item>
-    <item msgid="992592434377054063">"25 dakika"</item>
-    <item msgid="9191353668596201944">"30 dakika"</item>
-    <item msgid="1192985682962908244">"45 dakika"</item>
-    <item msgid="1694315499429259938">"1 saat"</item>
-    <item msgid="8281019320591769635">"2 saat"</item>
-    <item msgid="2062931719019287773">"3 saat"</item>
-    <item msgid="4086495711621133006">"12 saat"</item>
-    <item msgid="3172669681920709561">"24 saat"</item>
-    <item msgid="5557836606782821910">"2 gün"</item>
-    <item msgid="8336577387266744930">"1 hafta"</item>
-    <item>2 weeks</item>
-    <item>4 weeks</item>
-  </string-array>
   <string-array name="preferences_week_start_day_labels">
     <item msgid="986150274035512339">"Varsayılan yerel ayar"</item>
     <item msgid="134027225275475280">"Cumartesi"</item>

--- a/res/values-tr/arrays.xml
+++ b/res/values-tr/arrays.xml
@@ -22,24 +22,6 @@
     <item msgid="2658001219380695677">"SMS"</item>
     <item msgid="7926918288165444873">"Alarm"</item>
   </string-array>
-  <string-array name="reminder_minutes_labels">
-    <item msgid="2416970002377237011">"0 dakika"</item>
-    <item msgid="6681865010714743948">"1 dakika"</item>
-    <item msgid="2327505114623595779">"5 dakika"</item>
-    <item msgid="1657410063332547113">"10 dakika"</item>
-    <item msgid="366087535181197780">"15 dakika"</item>
-    <item msgid="6252612791145061929">"20 dakika"</item>
-    <item msgid="7896694531989090700">"25 dakika"</item>
-    <item msgid="8754510169374808607">"30 dakika"</item>
-    <item msgid="3113380274218454394">"45 dakika"</item>
-    <item msgid="8546646645868526283">"1 saat"</item>
-    <item msgid="6467845211024768872">"2 saat"</item>
-    <item msgid="8201677619511076575">"3 saat"</item>
-    <item msgid="7172504281650128893">"12 saat"</item>
-    <item msgid="9114286702181482496">"24 saat"</item>
-    <item msgid="3107009344872997366">"2 gün"</item>
-    <item msgid="6135563708172153696">"1 hafta"</item>
-  </string-array>
   <string-array name="preferences_default_reminder_labels">
     <item msgid="7495163916242649023">"Yok"</item>
     <item msgid="5883344836499335043">"0 dakika"</item>
@@ -58,6 +40,8 @@
     <item msgid="3172669681920709561">"24 saat"</item>
     <item msgid="5557836606782821910">"2 gün"</item>
     <item msgid="8336577387266744930">"1 hafta"</item>
+    <item>2 weeks</item>
+    <item>4 weeks</item>
   </string-array>
   <string-array name="preferences_week_start_day_labels">
     <item msgid="986150274035512339">"Varsayılan yerel ayar"</item>

--- a/res/values-tr/strings.xml
+++ b/res/values-tr/strings.xml
@@ -337,4 +337,5 @@
     <string name="preferences_list_add_remote_etesync">EteSync takvimi ekle</string>
     <string name="preferences_list_add_remote">CalDAV takvimi ekle</string>
     <string name="preferences_pure_black_night_mode">Saf siyah gece modu</string>
+    <string name="no_reminder_label">Yok</string>
 </resources>

--- a/res/values-ug/arrays.xml
+++ b/res/values-ug/arrays.xml
@@ -20,24 +20,6 @@
     <item msgid="2658001219380695677">"قىسقا ئۇچۇر"</item>
     <item msgid="7926918288165444873">"قوڭغۇراق"</item>
   </string-array>
-  <string-array name="reminder_minutes_labels">
-    <item msgid="2416970002377237011">"0 مىنۇت"</item>
-    <item msgid="6681865010714743948">"1 مىنۇت"</item>
-    <item msgid="2327505114623595779">"5 مىنۇت"</item>
-    <item msgid="1657410063332547113">"10 مىنۇت"</item>
-    <item msgid="366087535181197780">"15 مىنۇت"</item>
-    <item msgid="6252612791145061929">"20 مىنۇت"</item>
-    <item msgid="7896694531989090700">"25 مىنۇت"</item>
-    <item msgid="8754510169374808607">"30 مىنۇت"</item>
-    <item msgid="3113380274218454394">"45 مىنۇت"</item>
-    <item msgid="8546646645868526283">"1 سائەت"</item>
-    <item msgid="6467845211024768872">"2 سائەت"</item>
-    <item msgid="8201677619511076575">"3 سائەت"</item>
-    <item msgid="7172504281650128893">"12 سائەت"</item>
-    <item msgid="9114286702181482496">"24 سائەت"</item>
-    <item msgid="3107009344872997366">"2 كۈن"</item>
-    <item msgid="6135563708172153696">"1 ھەپتە"</item>
-  </string-array>
   <string-array name="preferences_default_reminder_labels">
     <item msgid="7495163916242649023">"يوق"</item>
     <item msgid="5883344836499335043">"0 مىنۇت"</item>
@@ -56,6 +38,8 @@
     <item msgid="3172669681920709561">"24 سائەت"</item>
     <item msgid="5557836606782821910">"2 كۈن"</item>
     <item msgid="8336577387266744930">"1 ھەپتە"</item>
+    <item>2 weeks</item>
+    <item>4 weeks</item>
   </string-array>
   <string-array name="preferences_week_start_day_labels">
     <item msgid="986150274035512339">"يەرلىك كۆڭۈلدىكى قىممەت"</item>

--- a/res/values-ug/arrays.xml
+++ b/res/values-ug/arrays.xml
@@ -20,27 +20,6 @@
     <item msgid="2658001219380695677">"قىسقا ئۇچۇر"</item>
     <item msgid="7926918288165444873">"قوڭغۇراق"</item>
   </string-array>
-  <string-array name="preferences_default_reminder_labels">
-    <item msgid="7495163916242649023">"يوق"</item>
-    <item msgid="5883344836499335043">"0 مىنۇت"</item>
-    <item msgid="4354350447805231188">"1 مىنۇت"</item>
-    <item msgid="265674592625309858">"5 مىنۇت"</item>
-    <item msgid="8011089417728419666">"10 مىنۇت"</item>
-    <item msgid="6177098581805412986">"15 مىنۇت"</item>
-    <item msgid="356346660503078923">"20 مىنۇت"</item>
-    <item msgid="992592434377054063">"25 مىنۇت"</item>
-    <item msgid="9191353668596201944">"30 مىنۇت"</item>
-    <item msgid="1192985682962908244">"45 مىنۇت"</item>
-    <item msgid="1694315499429259938">"1 سائەت"</item>
-    <item msgid="8281019320591769635">"2 سائەت"</item>
-    <item msgid="2062931719019287773">"3 سائەت"</item>
-    <item msgid="4086495711621133006">"12 سائەت"</item>
-    <item msgid="3172669681920709561">"24 سائەت"</item>
-    <item msgid="5557836606782821910">"2 كۈن"</item>
-    <item msgid="8336577387266744930">"1 ھەپتە"</item>
-    <item>2 weeks</item>
-    <item>4 weeks</item>
-  </string-array>
   <string-array name="preferences_week_start_day_labels">
     <item msgid="986150274035512339">"يەرلىك كۆڭۈلدىكى قىممەت"</item>
     <item msgid="134027225275475280">"شەنبە"</item>

--- a/res/values-ug/strings.xml
+++ b/res/values-ug/strings.xml
@@ -242,4 +242,5 @@
     <string name="snooze_delay_dialog_title">ئەسكەرتىشنى ۋاقىتلىق توختىتىدىغان قايتىلىنىش ۋاقتىنى بەلگىلەش</string>
     <string name="preferences_default_snooze_delay_title">كۆڭۈلدىكى ئەسكەرتىشنى ۋاقىتلىق توختىتىش ۋاقتىنىڭ ئۇزۇنلۇقى</string>
     <string name="preferences_default_snooze_delay_dialog">كۆڭۈلدىكى ئەسكەرتىشنى ۋاقىتلىق توختىتىش ۋاقتى</string>
+    <string name="no_reminder_label">يوق</string>
 </resources>

--- a/res/values-uk/arrays.xml
+++ b/res/values-uk/arrays.xml
@@ -22,27 +22,6 @@
     <item msgid="2658001219380695677">"SMS"</item>
     <item msgid="7926918288165444873">"Сигнал"</item>
   </string-array>
-  <string-array name="preferences_default_reminder_labels">
-    <item msgid="7495163916242649023">"Немає"</item>
-    <item msgid="5883344836499335043">"0 хвилин"</item>
-    <item msgid="4354350447805231188">"1 хвилина"</item>
-    <item msgid="265674592625309858">"5 хвилин"</item>
-    <item msgid="8011089417728419666">"10 хвилин"</item>
-    <item msgid="6177098581805412986">"15 хвилин"</item>
-    <item msgid="356346660503078923">"20 хвилин"</item>
-    <item msgid="992592434377054063">"25 хвилин"</item>
-    <item msgid="9191353668596201944">"30 хвилин"</item>
-    <item msgid="1192985682962908244">"45 хвилин"</item>
-    <item msgid="1694315499429259938">"1 година"</item>
-    <item msgid="8281019320591769635">"2 години"</item>
-    <item msgid="2062931719019287773">"3 години"</item>
-    <item msgid="4086495711621133006">"12 годин"</item>
-    <item msgid="3172669681920709561">"24 години"</item>
-    <item msgid="5557836606782821910">"2 дні"</item>
-    <item msgid="8336577387266744930">"1 тиждень"</item>
-    <item>2 weeks</item>
-    <item>4 weeks</item>
-  </string-array>
   <string-array name="preferences_week_start_day_labels">
     <item msgid="986150274035512339">"Код мови за умовч."</item>
     <item msgid="134027225275475280">"Субота"</item>

--- a/res/values-uk/arrays.xml
+++ b/res/values-uk/arrays.xml
@@ -22,24 +22,6 @@
     <item msgid="2658001219380695677">"SMS"</item>
     <item msgid="7926918288165444873">"Сигнал"</item>
   </string-array>
-  <string-array name="reminder_minutes_labels">
-    <item msgid="2416970002377237011">"0 хвилин"</item>
-    <item msgid="6681865010714743948">"1 хвилина"</item>
-    <item msgid="2327505114623595779">"5 хвилин"</item>
-    <item msgid="1657410063332547113">"10 хвилин"</item>
-    <item msgid="366087535181197780">"15 хвилин"</item>
-    <item msgid="6252612791145061929">"20 хвилин"</item>
-    <item msgid="7896694531989090700">"25 хвилин"</item>
-    <item msgid="8754510169374808607">"30 хвилин"</item>
-    <item msgid="3113380274218454394">"45 хвилин"</item>
-    <item msgid="8546646645868526283">"1 година"</item>
-    <item msgid="6467845211024768872">"2 години"</item>
-    <item msgid="8201677619511076575">"3 години"</item>
-    <item msgid="7172504281650128893">"12 годин"</item>
-    <item msgid="9114286702181482496">"24 години"</item>
-    <item msgid="3107009344872997366">"2 дні"</item>
-    <item msgid="6135563708172153696">"1 тиждень"</item>
-  </string-array>
   <string-array name="preferences_default_reminder_labels">
     <item msgid="7495163916242649023">"Немає"</item>
     <item msgid="5883344836499335043">"0 хвилин"</item>
@@ -58,6 +40,8 @@
     <item msgid="3172669681920709561">"24 години"</item>
     <item msgid="5557836606782821910">"2 дні"</item>
     <item msgid="8336577387266744930">"1 тиждень"</item>
+    <item>2 weeks</item>
+    <item>4 weeks</item>
   </string-array>
   <string-array name="preferences_week_start_day_labels">
     <item msgid="986150274035512339">"Код мови за умовч."</item>

--- a/res/values-uk/strings.xml
+++ b/res/values-uk/strings.xml
@@ -356,4 +356,5 @@
     <string name="two_days">2 дні</string>
     <string name="preferences_pure_black_night_mode">Чистий чорний нічний режим</string>
     <string name="preferences_system_theme">Системна</string>
+    <string name="no_reminder_label">Немає</string>
 </resources>

--- a/res/values-vi/arrays.xml
+++ b/res/values-vi/arrays.xml
@@ -22,24 +22,6 @@
     <item msgid="2658001219380695677">"SMS"</item>
     <item msgid="7926918288165444873">"Báo thức"</item>
   </string-array>
-  <string-array name="reminder_minutes_labels">
-    <item msgid="2416970002377237011">"0 phút"</item>
-    <item msgid="6681865010714743948">"1 phút"</item>
-    <item msgid="2327505114623595779">"5 phút"</item>
-    <item msgid="1657410063332547113">"10 phút"</item>
-    <item msgid="366087535181197780">"15 phút"</item>
-    <item msgid="6252612791145061929">"20 phút"</item>
-    <item msgid="7896694531989090700">"25 phút"</item>
-    <item msgid="8754510169374808607">"30 phút"</item>
-    <item msgid="3113380274218454394">"45 phút"</item>
-    <item msgid="8546646645868526283">"1 giờ"</item>
-    <item msgid="6467845211024768872">"2 giờ"</item>
-    <item msgid="8201677619511076575">"3 giờ"</item>
-    <item msgid="7172504281650128893">"12 giờ"</item>
-    <item msgid="9114286702181482496">"24 giờ"</item>
-    <item msgid="3107009344872997366">"2 ngày"</item>
-    <item msgid="6135563708172153696">"1 tuần"</item>
-  </string-array>
   <string-array name="preferences_default_reminder_labels">
     <item msgid="7495163916242649023">"Không"</item>
     <item msgid="5883344836499335043">"0 phút"</item>
@@ -58,6 +40,8 @@
     <item msgid="3172669681920709561">"24 giờ"</item>
     <item msgid="5557836606782821910">"2 ngày"</item>
     <item msgid="8336577387266744930">"1 tuần"</item>
+    <item>2 weeks</item>
+    <item>4 weeks</item>
   </string-array>
   <string-array name="preferences_week_start_day_labels">
     <item msgid="986150274035512339">"Ngôn ngữ mặc định"</item>

--- a/res/values-vi/arrays.xml
+++ b/res/values-vi/arrays.xml
@@ -22,27 +22,6 @@
     <item msgid="2658001219380695677">"SMS"</item>
     <item msgid="7926918288165444873">"Báo thức"</item>
   </string-array>
-  <string-array name="preferences_default_reminder_labels">
-    <item msgid="7495163916242649023">"Không"</item>
-    <item msgid="5883344836499335043">"0 phút"</item>
-    <item msgid="4354350447805231188">"1 phút"</item>
-    <item msgid="265674592625309858">"5 phút"</item>
-    <item msgid="8011089417728419666">"10 phút"</item>
-    <item msgid="6177098581805412986">"15 phút"</item>
-    <item msgid="356346660503078923">"20 phút"</item>
-    <item msgid="992592434377054063">"25 phút"</item>
-    <item msgid="9191353668596201944">"30 phút"</item>
-    <item msgid="1192985682962908244">"45 phút"</item>
-    <item msgid="1694315499429259938">"1 giờ"</item>
-    <item msgid="8281019320591769635">"2 giờ"</item>
-    <item msgid="2062931719019287773">"3 giờ"</item>
-    <item msgid="4086495711621133006">"12 giờ"</item>
-    <item msgid="3172669681920709561">"24 giờ"</item>
-    <item msgid="5557836606782821910">"2 ngày"</item>
-    <item msgid="8336577387266744930">"1 tuần"</item>
-    <item>2 weeks</item>
-    <item>4 weeks</item>
-  </string-array>
   <string-array name="preferences_week_start_day_labels">
     <item msgid="986150274035512339">"Ngôn ngữ mặc định"</item>
     <item msgid="134027225275475280">"Thứ Bảy"</item>

--- a/res/values-vi/strings.xml
+++ b/res/values-vi/strings.xml
@@ -326,4 +326,5 @@
     <string name="view_settings">Xem cài đặt</string>
     <string name="goto_date">Đi đến…</string>
     <string name="share_label">Chia sẻ</string>
+    <string name="no_reminder_label">Không</string>
 </resources>

--- a/res/values-zh-rCN/arrays.xml
+++ b/res/values-zh-rCN/arrays.xml
@@ -22,24 +22,6 @@
     <item msgid="2658001219380695677">"短信"</item>
     <item msgid="7926918288165444873">"闹钟"</item>
   </string-array>
-  <string-array name="reminder_minutes_labels">
-    <item msgid="2416970002377237011">"0 分钟"</item>
-    <item msgid="6681865010714743948">"1 分钟"</item>
-    <item msgid="2327505114623595779">"5 分钟"</item>
-    <item msgid="1657410063332547113">"10 分钟"</item>
-    <item msgid="366087535181197780">"15 分钟"</item>
-    <item msgid="6252612791145061929">"20 分钟"</item>
-    <item msgid="7896694531989090700">"25 分钟"</item>
-    <item msgid="8754510169374808607">"30 分钟"</item>
-    <item msgid="3113380274218454394">"45 分钟"</item>
-    <item msgid="8546646645868526283">"1 小时"</item>
-    <item msgid="6467845211024768872">"2 小时"</item>
-    <item msgid="8201677619511076575">"3 小时"</item>
-    <item msgid="7172504281650128893">"12 小时"</item>
-    <item msgid="9114286702181482496">"24 小时"</item>
-    <item msgid="3107009344872997366">"2 天"</item>
-    <item msgid="6135563708172153696">"1 周"</item>
-  </string-array>
   <string-array name="preferences_default_reminder_labels">
     <item msgid="7495163916242649023">"无"</item>
     <item msgid="5883344836499335043">"0 分钟"</item>
@@ -58,6 +40,8 @@
     <item msgid="3172669681920709561">"24 小时"</item>
     <item msgid="5557836606782821910">"2 天"</item>
     <item msgid="8336577387266744930">"1 周"</item>
+    <item>2 weeks</item>
+    <item>4 weeks</item>
   </string-array>
   <string-array name="preferences_week_start_day_labels">
     <item msgid="986150274035512339">"语言区域的默认设置"</item>

--- a/res/values-zh-rCN/arrays.xml
+++ b/res/values-zh-rCN/arrays.xml
@@ -22,27 +22,6 @@
     <item msgid="2658001219380695677">"短信"</item>
     <item msgid="7926918288165444873">"闹钟"</item>
   </string-array>
-  <string-array name="preferences_default_reminder_labels">
-    <item msgid="7495163916242649023">"无"</item>
-    <item msgid="5883344836499335043">"0 分钟"</item>
-    <item msgid="4354350447805231188">"1 分钟"</item>
-    <item msgid="265674592625309858">"5 分钟"</item>
-    <item msgid="8011089417728419666">"10 分钟"</item>
-    <item msgid="6177098581805412986">"15 分钟"</item>
-    <item msgid="356346660503078923">"20 分钟"</item>
-    <item msgid="992592434377054063">"25 分钟"</item>
-    <item msgid="9191353668596201944">"30 分钟"</item>
-    <item msgid="1192985682962908244">"45 分钟"</item>
-    <item msgid="1694315499429259938">"1 小时"</item>
-    <item msgid="8281019320591769635">"2 小时"</item>
-    <item msgid="2062931719019287773">"3 小时"</item>
-    <item msgid="4086495711621133006">"12 小时"</item>
-    <item msgid="3172669681920709561">"24 小时"</item>
-    <item msgid="5557836606782821910">"2 天"</item>
-    <item msgid="8336577387266744930">"1 周"</item>
-    <item>2 weeks</item>
-    <item>4 weeks</item>
-  </string-array>
   <string-array name="preferences_week_start_day_labels">
     <item msgid="986150274035512339">"语言区域的默认设置"</item>
     <item msgid="134027225275475280">"星期六"</item>

--- a/res/values-zh-rCN/strings.xml
+++ b/res/values-zh-rCN/strings.xml
@@ -334,4 +334,5 @@
     <string name="preferences_list_add_remote_etesync">添加 EteSync 日历</string>
     <string name="preferences_list_add_remote">添加 CalDAV日历</string>
     <string name="preferences_pure_black_night_mode">纯黑夜间模式</string>
+    <string name="no_reminder_label">无</string>
 </resources>

--- a/res/values-zh-rTW/arrays.xml
+++ b/res/values-zh-rTW/arrays.xml
@@ -22,24 +22,6 @@
     <item msgid="2658001219380695677">"簡訊"</item>
     <item msgid="7926918288165444873">"鬧鐘"</item>
   </string-array>
-  <string-array name="reminder_minutes_labels">
-    <item msgid="2416970002377237011">"0 分鐘"</item>
-    <item msgid="6681865010714743948">"1 分鐘"</item>
-    <item msgid="2327505114623595779">"5 分鐘"</item>
-    <item msgid="1657410063332547113">"10 分鐘"</item>
-    <item msgid="366087535181197780">"15 分鐘"</item>
-    <item msgid="6252612791145061929">"20 分鐘"</item>
-    <item msgid="7896694531989090700">"25 分鐘"</item>
-    <item msgid="8754510169374808607">"30 分鐘"</item>
-    <item msgid="3113380274218454394">"45 分鐘"</item>
-    <item msgid="8546646645868526283">"1 小時"</item>
-    <item msgid="6467845211024768872">"2 小時"</item>
-    <item msgid="8201677619511076575">"3 小時"</item>
-    <item msgid="7172504281650128893">"12 小時"</item>
-    <item msgid="9114286702181482496">"24 小時"</item>
-    <item msgid="3107009344872997366">"2 天"</item>
-    <item msgid="6135563708172153696">"1 週"</item>
-  </string-array>
   <string-array name="preferences_default_reminder_labels">
     <item msgid="7495163916242649023">"無"</item>
     <item msgid="5883344836499335043">"0 分鐘"</item>
@@ -58,6 +40,8 @@
     <item msgid="3172669681920709561">"24 小時"</item>
     <item msgid="5557836606782821910">"2 天"</item>
     <item msgid="8336577387266744930">"1 週"</item>
+    <item>2 weeks</item>
+    <item>4 weeks</item>
   </string-array>
   <string-array name="preferences_week_start_day_labels">
     <item msgid="986150274035512339">"地區設定預設值"</item>

--- a/res/values-zh-rTW/arrays.xml
+++ b/res/values-zh-rTW/arrays.xml
@@ -22,27 +22,6 @@
     <item msgid="2658001219380695677">"簡訊"</item>
     <item msgid="7926918288165444873">"鬧鐘"</item>
   </string-array>
-  <string-array name="preferences_default_reminder_labels">
-    <item msgid="7495163916242649023">"無"</item>
-    <item msgid="5883344836499335043">"0 分鐘"</item>
-    <item msgid="4354350447805231188">"1 分鐘"</item>
-    <item msgid="265674592625309858">"5 分鐘"</item>
-    <item msgid="8011089417728419666">"10 分鐘"</item>
-    <item msgid="6177098581805412986">"15 分鐘"</item>
-    <item msgid="356346660503078923">"20 分鐘"</item>
-    <item msgid="992592434377054063">"25 分鐘"</item>
-    <item msgid="9191353668596201944">"30 分鐘"</item>
-    <item msgid="1192985682962908244">"45 分鐘"</item>
-    <item msgid="1694315499429259938">"1 小時"</item>
-    <item msgid="8281019320591769635">"2 小時"</item>
-    <item msgid="2062931719019287773">"3 小時"</item>
-    <item msgid="4086495711621133006">"12 小時"</item>
-    <item msgid="3172669681920709561">"24 小時"</item>
-    <item msgid="5557836606782821910">"2 天"</item>
-    <item msgid="8336577387266744930">"1 週"</item>
-    <item>2 weeks</item>
-    <item>4 weeks</item>
-  </string-array>
   <string-array name="preferences_week_start_day_labels">
     <item msgid="986150274035512339">"地區設定預設值"</item>
     <item msgid="134027225275475280">"週六"</item>

--- a/res/values-zh-rTW/strings.xml
+++ b/res/values-zh-rTW/strings.xml
@@ -242,4 +242,5 @@
     <string name="snooze_delay_dialog_title">設定重響延遲</string>
     <string name="preferences_default_snooze_delay_title">預設重響延遲時間</string>
     <string name="preferences_default_snooze_delay_dialog">預設重響延遲</string>
+    <string name="no_reminder_label">無</string>
 </resources>

--- a/res/values-zu/arrays.xml
+++ b/res/values-zu/arrays.xml
@@ -22,27 +22,6 @@
     <item msgid="2658001219380695677">"SMS"</item>
     <item msgid="7926918288165444873">"I-alamu"</item>
   </string-array>
-  <string-array name="preferences_default_reminder_labels">
-    <item msgid="7495163916242649023">"Lutho"</item>
-    <item msgid="5883344836499335043">"0 amaminithi"</item>
-    <item msgid="4354350447805231188">"1 iminithi"</item>
-    <item msgid="265674592625309858">"5 amaminithi"</item>
-    <item msgid="8011089417728419666">"10 amaminithi"</item>
-    <item msgid="6177098581805412986">"15 amaminithi"</item>
-    <item msgid="356346660503078923">"20 amaminithi"</item>
-    <item msgid="992592434377054063">"25 amaminithi"</item>
-    <item msgid="9191353668596201944">"30 amaminithi"</item>
-    <item msgid="1192985682962908244">"45 amaminithi"</item>
-    <item msgid="1694315499429259938">"1 ihora"</item>
-    <item msgid="8281019320591769635">"2 amahora"</item>
-    <item msgid="2062931719019287773">"3 amahora"</item>
-    <item msgid="4086495711621133006">"12 amahora"</item>
-    <item msgid="3172669681920709561">"24 amahora"</item>
-    <item msgid="5557836606782821910">"2 izinsuku"</item>
-    <item msgid="8336577387266744930">"1 iviki"</item>
-    <item>2 weeks</item>
-    <item>4 weeks</item>
-  </string-array>
   <string-array name="preferences_week_start_day_labels">
     <item msgid="986150274035512339">"Okuzenzakalelayo kwezici zakhona"</item>
     <item msgid="134027225275475280">"Umgqibelo"</item>

--- a/res/values-zu/arrays.xml
+++ b/res/values-zu/arrays.xml
@@ -22,24 +22,6 @@
     <item msgid="2658001219380695677">"SMS"</item>
     <item msgid="7926918288165444873">"I-alamu"</item>
   </string-array>
-  <string-array name="reminder_minutes_labels">
-    <item msgid="2416970002377237011">"0 amaminithi"</item>
-    <item msgid="6681865010714743948">"1 iminithi"</item>
-    <item msgid="2327505114623595779">"5 amaminithi"</item>
-    <item msgid="1657410063332547113">"10 amaminithi"</item>
-    <item msgid="366087535181197780">"15 amaminithi"</item>
-    <item msgid="6252612791145061929">"20 amaminithi"</item>
-    <item msgid="7896694531989090700">"25 amaminithi"</item>
-    <item msgid="8754510169374808607">"30 amaminithi"</item>
-    <item msgid="3113380274218454394">"45 amaminithi"</item>
-    <item msgid="8546646645868526283">"1 ihora"</item>
-    <item msgid="6467845211024768872">"2 amahora"</item>
-    <item msgid="8201677619511076575">"3 amahora"</item>
-    <item msgid="7172504281650128893">"12 amahora"</item>
-    <item msgid="9114286702181482496">"24 amahora"</item>
-    <item msgid="3107009344872997366">"2 izinsuku"</item>
-    <item msgid="6135563708172153696">"1 iviki"</item>
-  </string-array>
   <string-array name="preferences_default_reminder_labels">
     <item msgid="7495163916242649023">"Lutho"</item>
     <item msgid="5883344836499335043">"0 amaminithi"</item>
@@ -58,6 +40,8 @@
     <item msgid="3172669681920709561">"24 amahora"</item>
     <item msgid="5557836606782821910">"2 izinsuku"</item>
     <item msgid="8336577387266744930">"1 iviki"</item>
+    <item>2 weeks</item>
+    <item>4 weeks</item>
   </string-array>
   <string-array name="preferences_week_start_day_labels">
     <item msgid="986150274035512339">"Okuzenzakalelayo kwezici zakhona"</item>

--- a/res/values-zu/strings.xml
+++ b/res/values-zu/strings.xml
@@ -241,4 +241,5 @@
     <string name="visibility_default">Okuzenzakalelayo</string>
     <string name="visibility_private">Imfihlo</string>
     <string name="visibility_public">Okusesidlangalaleni</string>
+    <string name="no_reminder_label">Lutho</string>
 </resources>

--- a/res/values/arrays.xml
+++ b/res/values/arrays.xml
@@ -64,32 +64,6 @@
         <item>4</item>  <!-- METHOD_ALARM -->
     </integer-array>
 
-    <!-- Choices for the "Reminder minutes" spinner.
-         These must be kept in sync with the reminder_minutes_values array.
-         For consistency, the format should match what
-         EventViewUtils.constructReminderLabel() generates.  (TODO: eliminate
-         this and just generate the list from reminder_minutes_values?)
-         [CHAR LIMIT=15]
-    -->
-    <string-array name="reminder_minutes_labels">
-        <item>0 minutes</item>
-        <item>1 minute</item>
-        <item>5 minutes</item>
-        <item>10 minutes</item>
-        <item>15 minutes</item>
-        <item>20 minutes</item>
-        <item>25 minutes</item>
-        <item>30 minutes</item>
-        <item>45 minutes</item>
-        <item>1 hour</item>
-        <item>2 hours</item>
-        <item>3 hours</item>
-        <item>12 hours</item>
-        <item>24 hours</item>
-        <item>2 days</item>
-        <item>1 week</item>
-    </string-array>
-
     <integer-array name="reminder_minutes_values" translatable="false">
         <item>0</item>
         <item>1</item>
@@ -103,10 +77,12 @@
         <item>60</item>
         <item>120</item>
         <item>180</item>
-        <item>720</item>
-        <item>1440</item>
-        <item>2880</item>
-        <item>10080</item>
+        <item>720</item> <!-- 12 hours -->
+        <item>1440</item> <!-- 24 hours -->
+        <item>2880</item> <!-- 2 days -->
+        <item>10080</item> <!-- 1 week -->
+        <item>20160</item> <!-- 2 weeks -->
+        <item>40320</item> <!-- 4 weeks -->
     </integer-array>
 
   <!-- Choices for the "Reminder minutes" spinner in the settings.
@@ -131,6 +107,8 @@
         <item>24 hours</item>
         <item>2 days</item>
         <item>1 week</item>
+        <item>2 weeks</item>
+        <item>4 weeks</item>
     </string-array>
 
     <string-array name="preferences_default_reminder_values" translatable="false">
@@ -151,6 +129,8 @@
         <item>"1440"</item>
         <item>"2880"</item>
         <item>"10080"</item>
+        <item>"20160"</item>
+        <item>"40320"</item>
     </string-array>
 
     <string-array name="preferences_default_snooze_delay_values" translatable="false">

--- a/res/values/arrays.xml
+++ b/res/values/arrays.xml
@@ -85,32 +85,6 @@
         <item>40320</item> <!-- 4 weeks -->
     </integer-array>
 
-  <!-- Choices for the "Reminder minutes" spinner in the settings.
-         These must be kept in sync with the preferences_default_reminder_values array.
-         [CHAR LIMIT=12]
-    -->
-       <string-array name="preferences_default_reminder_labels">
-        <item>None</item>
-        <item>0 minutes</item>
-        <item>1 minute</item>
-        <item>5 minutes</item>
-        <item>10 minutes</item>
-        <item>15 minutes</item>
-        <item>20 minutes</item>
-        <item>25 minutes</item>
-        <item>30 minutes</item>
-        <item>45 minutes</item>
-        <item>1 hour</item>
-        <item>2 hours</item>
-        <item>3 hours</item>
-        <item>12 hours</item>
-        <item>24 hours</item>
-        <item>2 days</item>
-        <item>1 week</item>
-        <item>2 weeks</item>
-        <item>4 weeks</item>
-    </string-array>
-
     <string-array name="preferences_default_reminder_values" translatable="false">
         <item>"-1"</item>
         <item>"0"</item>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -40,6 +40,7 @@
     <string name="no_title_label">(No title)</string>
 
     <!-- Reminder format strings -->
+    <string name="no_reminder_label">None</string>
     <plurals name="Nminutes">
         <!-- This is the label for a 1-minute reminder. -->
         <item quantity="one">1 minute</item>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -78,6 +78,16 @@
              days is a parameter. -->
         <item quantity="other"><xliff:g id="count">%d</xliff:g> days</item>
     </plurals>
+    <!-- This is the number of weeks displayed for a calendar reminder.  For example,
+         a reminder of 2 weeks would be displayed as '2 weeks'.  The translation
+         should use the shortest acceptable abbreviation of 'week' to save space. -->
+    <plurals name="Nweeks">
+        <!-- This is the label for a reminder of 1 week. -->
+        <item quantity="one">1 week</item>
+        <!-- This is the label for a reminder of 2 or more weeks. The actual number of
+             weeks is a parameter. -->
+        <item quantity="other"><xliff:g id="count">%d</xliff:g> weeks</item>
+    </plurals>
     <!-- This is for displaying the week of the year near the date. Eg. "January, 2011 Week 1" -->
     <plurals name="weekN">
         <!-- Label for displaying week of the year for all week values [CHAR LIMIT=16] -->

--- a/res/xml-v26/general_preferences.xml
+++ b/res/xml-v26/general_preferences.xml
@@ -116,7 +116,6 @@
             app:key="preferences_default_reminder"
             app:defaultValue="@string/preferences_default_reminder_default"
             app:title="@string/preferences_default_reminder_title"
-            app:entries="@array/preferences_default_reminder_labels"
             app:entryValues="@array/preferences_default_reminder_values"
             app:dialogTitle="@string/preferences_default_reminder_dialog" />
 

--- a/res/xml-v29/general_preferences.xml
+++ b/res/xml-v29/general_preferences.xml
@@ -117,7 +117,6 @@ xmlns:app="http://schemas.android.com/apk/res-auto">
         app:key="preferences_default_reminder"
         app:defaultValue="@string/preferences_default_reminder_default"
         app:title="@string/preferences_default_reminder_title"
-        app:entries="@array/preferences_default_reminder_labels"
         app:entryValues="@array/preferences_default_reminder_values"
         app:dialogTitle="@string/preferences_default_reminder_dialog" />
 

--- a/res/xml/general_preferences.xml
+++ b/res/xml/general_preferences.xml
@@ -131,7 +131,6 @@
             app:key="preferences_default_reminder"
             app:defaultValue="@string/preferences_default_reminder_default"
             app:title="@string/preferences_default_reminder_title"
-            app:entries="@array/preferences_default_reminder_labels"
             app:entryValues="@array/preferences_default_reminder_values"
             app:dialogTitle="@string/preferences_default_reminder_dialog" />
 

--- a/src/com/android/calendar/EventInfoFragment.java
+++ b/src/com/android/calendar/EventInfoFragment.java
@@ -2143,7 +2143,8 @@ public class EventInfoFragment extends DialogFragment implements OnCheckedChange
         // new event that aren't in the default set.
         Resources r = mActivity.getResources();
         mReminderMinuteValues = loadIntegerArray(r, R.array.reminder_minutes_values);
-        mReminderMinuteLabels = loadStringArray(r, R.array.reminder_minutes_labels);
+        mReminderMinuteLabels = EventViewUtils.constructReminderLabelsFromValues(mActivity,
+                mReminderMinuteValues, false);
         mReminderMethodValues = loadIntegerArray(r, R.array.reminder_methods_values);
         mReminderMethodLabels = loadStringArray(r, R.array.reminder_methods_labels);
 

--- a/src/com/android/calendar/event/EditEventView.java
+++ b/src/com/android/calendar/event/EditEventView.java
@@ -741,7 +741,8 @@ public class EditEventView implements View.OnClickListener, DialogInterface.OnCa
         // is mostly relevant for "methods", since we shouldn't have any "minutes" values in a
         // new event that aren't in the default set.
         mReminderMinuteValues = loadIntegerArray(r, R.array.reminder_minutes_values);
-        mReminderMinuteLabels = loadStringArray(r, R.array.reminder_minutes_labels);
+        mReminderMinuteLabels = EventViewUtils.constructReminderLabelsFromValues(mActivity,
+                mReminderMinuteValues, false);
         mReminderMethodValues = loadIntegerArray(r, R.array.reminder_methods_values);
         mReminderMethodLabels = loadStringArray(r, R.array.reminder_methods_labels);
 

--- a/src/com/android/calendar/event/EventViewUtils.java
+++ b/src/com/android/calendar/event/EventViewUtils.java
@@ -49,7 +49,14 @@ public class EventViewUtils {
         Resources resources = context.getResources();
         int value, resId;
 
-        if (minutes % 60 != 0 || minutes == 0) {
+        if (minutes < 0) {
+            value = 0;
+            resId = R.string.no_reminder_label;
+
+            String format = resources.getString(resId, value);
+            return String.format(format, value);
+
+        } else if (minutes % 60 != 0 || minutes == 0) {
             value = minutes;
             if (abbrev) {
                 resId = R.plurals.Nmins;

--- a/src/com/android/calendar/event/EventViewUtils.java
+++ b/src/com/android/calendar/event/EventViewUtils.java
@@ -49,7 +49,7 @@ public class EventViewUtils {
         Resources resources = context.getResources();
         int value, resId;
 
-        if (minutes % 60 != 0) {
+        if (minutes % 60 != 0 || minutes == 0) {
             value = minutes;
             if (abbrev) {
                 resId = R.plurals.Nmins;
@@ -59,13 +59,36 @@ public class EventViewUtils {
         } else if (minutes % (24 * 60) != 0) {
             value = minutes / 60;
             resId = R.plurals.Nhours;
-        } else {
+        } else if (minutes % (7 * 24 * 60) != 0) {
             value = minutes / (24 * 60);
             resId = R.plurals.Ndays;
+        } else {
+            value = minutes / (7 * 24 * 60);
+            resId = R.plurals.Nweeks;
         }
 
         String format = resources.getQuantityString(resId, value);
         return String.format(format, value);
+    }
+
+    /**
+     * Constructs a list of labels for a list of minute values.
+     * <p>
+     * For example, if the given list of minutes contains 10, 120, 2880 and 40320 (in that order),
+     * the returned list will contain "10 minutes", "2 hours", "2 days" and "4 weeks" (in that
+     * order).
+     * @param context the context to use for resources
+     * @param minutes the list of minutes for which the labels will be constructed
+     * @param abbrev whether the labels shall be abbreviated, if possible
+     * @return a list of labels constructed from the given list of minute values
+     */
+    public static ArrayList<String> constructReminderLabelsFromValues(Context context,
+            ArrayList<Integer> minutes, boolean abbrev) {
+        ArrayList<String> labels = new ArrayList<>(minutes.size());
+        for (int val: minutes) {
+            labels.add(EventViewUtils.constructReminderLabel(context, val, abbrev));
+        }
+        return labels;
     }
 
     /**

--- a/src/com/android/calendar/settings/GeneralPreferences.kt
+++ b/src/com/android/calendar/settings/GeneralPreferences.kt
@@ -136,6 +136,7 @@ class GeneralPreferences : PreferenceFragmentCompat(),
         }
 
         buildSnoozeDelayEntries()
+        buildDefaultReminderPrefEntries()
         defaultEventDurationPref.summary = defaultEventDurationPref.entry
         themePref.summary = themePref.entry
         weekStartPref.summary = weekStartPref.entry
@@ -389,6 +390,19 @@ class GeneralPreferences : PreferenceFragmentCompat(),
         }
 
         snoozeDelayPref.entries = entries
+    }
+
+    private fun buildDefaultReminderPrefEntries() {
+        val values = defaultReminderPref.entryValues
+        val count = values.size
+        val entries = arrayOfNulls<CharSequence>(count)
+
+        for (i in 0 until count) {
+            val value = Integer.parseInt(values[i].toString())
+            entries[i] = EventViewUtils.constructReminderLabel(requireActivity(), value, false)
+        }
+
+        defaultReminderPref.entries = entries
     }
 
     override fun onPreferenceTreeClick(preference: Preference?): Boolean {


### PR DESCRIPTION
Similar to #729 I would like more options for when I get reminded. That's why I added the two and four weeks options. Personally I'd like the option to add custom reminder values in the settings, but I fear that's beyond the scope of my Android programming skills.

Also, as mentioned by a TODO comment, it would be nice for the reminder labels to be generated from the minute values. To accomplish that I updated `EventViewUtils.java.constructReminderLabel()` to be able to handle minutes representing weeks and used that to generate the labels. For that I added a new plurals entry in `strings.xml` for "week(s)". I replaced the resource array with the generated list everywhere Android Studio found a usage of the original array (only two locations).

Of course the new plural entry needs to be translated for this change to work in all supported languages.

It would be nice to eliminate the `preferences_default_reminder_labels` and `preferences_default_reminder_labels` and have them generated using `reminder_minutes_values` as well, but I'm not sure how to accomplish that (I'm not that familiar with Android programming).

ToDo list:
- translate the new "week(s)" plurals entry into other languages
- translate the new "2/4 weeks" entries in `preferences_default_reminder_labels` into other languages

I'm not sure how to accomplish the translations, that would probably require work from many different contributors to cover all currently supported languages?