### PR TITLE
[Draft] Feature/noid/month multiselect

### DIFF
--- a/src/com/android/calendar/AllInOneActivity.java
+++ b/src/com/android/calendar/AllInOneActivity.java
@@ -1240,28 +1240,6 @@ public class AllInOneActivity extends AbstractCalendarActivity implements EventH
     public void handleEvent(EventInfo event) {
         long displayTime = -1;
 
-
-        if(event.extraLong == CalendarController.EXTRA_GOTO_DATE_RANGE){
-
-            Calendar c = Calendar.getInstance();
-            Calendar c2 = Calendar.getInstance();
-            c.setTimeInMillis(event.startTime.toMillis(false));
-            c2.setTimeInMillis(event.endTime.toMillis(false));
-
-            // Normalize days, let them start at midnight
-            c.set(Calendar.SECOND, 0);
-            c.set(Calendar.MINUTE, 0);
-            c.set(Calendar.HOUR_OF_DAY, 0);
-            c2.set(Calendar.SECOND, 0);
-            c2.set(Calendar.MINUTE, 0);
-            c2.set(Calendar.HOUR_OF_DAY, 0);
-
-            long days = (c2.getTimeInMillis()-  c.getTimeInMillis()) / (24 * 60 * 60 * 1000);
-
-            mDaysToShowOverride = (int) days + 1;
-        }
-
-
         if (event.eventType == EventType.GO_TO) {
             if ((event.extraLong & CalendarController.EXTRA_GOTO_BACK_TO_PREVIOUS) != 0) {
                 mBackToPreviousView = true;
@@ -1271,6 +1249,27 @@ public class AllInOneActivity extends AbstractCalendarActivity implements EventH
                 mBackToPreviousView = false;
 
 
+            }
+
+            if( event.extraLong == (CalendarController.EXTRA_GOTO_DATE_RANGE | CalendarController.EXTRA_GOTO_BACK_TO_PREVIOUS) ){
+
+                Calendar c = Calendar.getInstance();
+                Calendar c2 = Calendar.getInstance();
+                c.setTimeInMillis(event.startTime.toMillis(false));
+                c2.setTimeInMillis(event.endTime.toMillis(false));
+
+                // Normalize days, let them start at midnight
+                c.set(Calendar.SECOND, 0);
+                c.set(Calendar.MINUTE, 0);
+                c.set(Calendar.HOUR_OF_DAY, 0);
+                c2.set(Calendar.SECOND, 0);
+                c2.set(Calendar.MINUTE, 0);
+                c2.set(Calendar.HOUR_OF_DAY, 0);
+
+                long days = (c2.getTimeInMillis()-  c.getTimeInMillis()) / (24 * 60 * 60 * 1000);
+
+                mDaysToShowOverride = (int) days + 1;
+                mBackToPreviousView=true;
             }
 
             setMainPane(

--- a/src/com/android/calendar/CalendarController.java
+++ b/src/com/android/calendar/CalendarController.java
@@ -70,6 +70,8 @@ public class CalendarController {
     public static final long EXTRA_GOTO_TIME = 2;
     public static final long EXTRA_GOTO_BACK_TO_PREVIOUS = 4;
     public static final long EXTRA_GOTO_TODAY = 8;
+    public static final long EXTRA_GOTO_DATE_RANGE = 9;
+
     private static final boolean DEBUG = false;
     private static final String TAG = "CalendarController";
     private static WeakHashMap<Context, WeakReference<CalendarController>> instances =

--- a/src/com/android/calendar/month/MonthByWeekAdapter.java
+++ b/src/com/android/calendar/month/MonthByWeekAdapter.java
@@ -115,13 +115,14 @@ public class MonthByWeekAdapter extends SimpleWeeksAdapter {
             if (mDoSelectionTapUpStart != null) {
                 Time start = mDoSelectionTapUpStart.getDayFromLocation(mClickedXLocation);
                 Time end = mDoSelectionTapUpStart.getDayFromLocation(mDoSelectionTapUpOffset);
-
-                Log.d(TAG, "Touched day at Row= day=" + start.yearDay);
-                Log.d(TAG, "Touched day at Row= day=" + end.yearDay);
                 if (Log.isLoggable(TAG, Log.DEBUG)) {
                     Log.d(TAG, "Touched day at Row=" + mSingleTapUpView.mWeek + " day=" + start.toString());
                 }
-                onDayTapped(start, end);
+                if(start.toMillis(false)<end.toMillis(false)){
+                    onDayTapped(start, end);
+                }else{
+                    onDayTapped(end, start);
+                }
 
                 clearClickedView(mDoSelectionTapUpStart);
                 mDoSelectionTapUpStart = null;
@@ -347,7 +348,7 @@ public class MonthByWeekAdapter extends SimpleWeeksAdapter {
         if(day != day_end){
             Log.e(TAG, "day set");
             mController.sendEvent(mContext, EventType.GO_TO, day, day_end, -1,
-                    ViewType.WEEK, CalendarController.EXTRA_GOTO_DATE_RANGE, null, null);
+                    ViewType.WEEK, CalendarController.EXTRA_GOTO_DATE_RANGE | CalendarController.EXTRA_GOTO_BACK_TO_PREVIOUS, null, null);
 
             return;
         }

--- a/src/com/android/calendar/month/MonthByWeekAdapter.java
+++ b/src/com/android/calendar/month/MonthByWeekAdapter.java
@@ -417,12 +417,20 @@ public class MonthByWeekAdapter extends SimpleWeeksAdapter {
                 case MotionEvent.ACTION_UP:
                     mwev.invalidate();
                     mListView.unblockScroll();
-                    Log.e(TAG, "Open cells: "+(cell-init_cell)+1);
+                    Log.e(TAG, "Open cells: "+((cell-init_cell)+1));
 
 
                     long delay = System.currentTimeMillis() - mClickTime;
 
                     int indexOfEnd = mListView.indexOfChild(v)+mwev.mSelectedDayIndexes.size();
+                    if(event.getY()<0){
+                        Log.e(TAG, "Released above row!");
+                    }
+
+                    if(event.getY()>mListView.getChildAt(indexOfEnd).getHeight()){
+                        Log.e(TAG, "Released below row!");
+                    }
+
                     mDoSelectionTapUpStart = (MonthWeekEventsView) v;
                     mDoSelectionTapUpOffset = event.getX();
 
@@ -440,11 +448,13 @@ public class MonthByWeekAdapter extends SimpleWeeksAdapter {
                     //Time day_n = mSingleTapUpView.getDayFromLocation(event.getX());
                     //mController.sendEvent(mContext, EventType.GO_TO, day, day_n, -1, ViewType.WEEK, CalendarController.EXTRA_GOTO_DATE, null, null);
                 case MotionEvent.ACTION_SCROLL:
-                    Log.e(TAG, "ACTION_SCROLL");
                 case MotionEvent.ACTION_CANCEL:
-                    Log.e(TAG, "ACTION_CANCEL");
                     clearClickedView((MonthWeekEventsView) v);
                     break;
+                case MonthListView.MOTION_EVENT_MOVE_LISTBLOCKED:
+                    //this "new" event allows the event to be handled, so that we can properly draw the selection.
+                    //if we dont change the event, the selection still works, but since the event is not propagated,
+                    //the selection does not update in the ui.
                 case MotionEvent.ACTION_MOVE:
                     // No need to cancel on vertical movement, ACTION_SCROLL will do that.
                     mwev.invalidate();

--- a/src/com/android/calendar/month/MonthByWeekAdapter.java
+++ b/src/com/android/calendar/month/MonthByWeekAdapter.java
@@ -131,7 +131,7 @@ public class MonthByWeekAdapter extends SimpleWeeksAdapter {
                     start.set(start.toMillis(false)-(daysBetweeen*24*60*60*1000));
 
                     //if the selection is larger than the limit, show only LIMIT_SELECTION days, starting with the earliest date in the selection
-                    if((end.toMillis(false)-start.toMillis(false)) > -1* LIMIT_SELECTION*24*60*60*1000){
+                    if((end.toMillis(false)-start.toMillis(false)) > LIMIT_SELECTION*24*60*60*1000){
                         start.set(end.toMillis(false)-(LIMIT_SELECTION*24*60*60*1000));
                     }
                 }

--- a/src/com/android/calendar/month/MonthByWeekFragment.java
+++ b/src/com/android/calendar/month/MonthByWeekFragment.java
@@ -311,7 +311,7 @@ public class MonthByWeekFragment extends SimpleDayPickerFragment implements
         } else {
             mLoader = (CursorLoader) getLoaderManager().initLoader(0, null, this);
         }
-        mAdapter.setListView(mListView);
+        mAdapter.setListView((MonthListView)mListView);
     }
 
     @Override

--- a/src/com/android/calendar/month/MonthListView.java
+++ b/src/com/android/calendar/month/MonthListView.java
@@ -212,16 +212,10 @@ public class MonthListView extends ListView {
     }
 
     public void blockScroll(){
-        Log.e(TAG, "blockScroll");
         mBlockScroll=true;
     }
 
     public void unblockScroll(){
-        Log.e(TAG, "unblockScroll");
         mBlockScroll=false;
-    }
-
-    public boolean isScrollBlocked(){
-        return mBlockScroll;
     }
 }

--- a/src/com/android/calendar/month/MonthListView.java
+++ b/src/com/android/calendar/month/MonthListView.java
@@ -45,6 +45,9 @@ public class MonthListView extends ListView {
     private static int FLING_VELOCITY_DIVIDER = 500;
     private static int FLING_TIME = 1000;
 
+
+    public static final int MOTION_EVENT_MOVE_LISTBLOCKED = MotionEvent.ACTION_MOVE *-1;
+
     // disposable variable used for time calculations
     protected Time mTempTime;
     private long mDownActionTime;
@@ -92,6 +95,16 @@ public class MonthListView extends ListView {
                 FLING_VELOCITY_DIVIDER *= mScale;
             }
         }
+    }
+
+    @Override
+    public boolean dispatchTouchEvent(MotionEvent ev) {
+        if(mBlockScroll && ev.getAction() == MotionEvent.ACTION_MOVE){
+          //  return true;
+            ev.setAction(MOTION_EVENT_MOVE_LISTBLOCKED);
+            super.dispatchTouchEvent(ev);
+        }
+        return super.dispatchTouchEvent(ev);
     }
 
     @Override
@@ -202,8 +215,13 @@ public class MonthListView extends ListView {
         Log.e(TAG, "blockScroll");
         mBlockScroll=true;
     }
+
     public void unblockScroll(){
         Log.e(TAG, "unblockScroll");
         mBlockScroll=false;
+    }
+
+    public boolean isScrollBlocked(){
+        return mBlockScroll;
     }
 }

--- a/src/com/android/calendar/month/MonthListView.java
+++ b/src/com/android/calendar/month/MonthListView.java
@@ -21,6 +21,7 @@ import android.graphics.Rect;
 import android.os.SystemClock;
 import android.text.format.Time;
 import android.util.AttributeSet;
+import android.util.Log;
 import android.view.MotionEvent;
 import android.view.VelocityTracker;
 import android.view.View;
@@ -48,6 +49,8 @@ public class MonthListView extends ListView {
     protected Time mTempTime;
     private long mDownActionTime;
     private final Rect mFirstViewRect = new Rect();
+
+    public boolean mBlockScroll = false;
 
     Context mListContext;
 
@@ -112,6 +115,14 @@ public class MonthListView extends ListView {
                 mDownActionTime = SystemClock.uptimeMillis();
                 break;
             // Accumulate velocity and do a custom fling when above threshold
+            case MotionEvent.ACTION_MOVE:
+            case MotionEvent.ACTION_SCROLL:
+                if(mBlockScroll){
+                    Log.e(TAG, "Fyou NOT");
+                    break;
+                }
+                Log.e(TAG, "Fyou");
+                break;
             case MotionEvent.ACTION_UP:
                 mTracker.addMovement(ev);
                 mTracker.computeCurrentVelocity(1000);    // in pixels per second
@@ -193,5 +204,14 @@ public class MonthListView extends ListView {
             return -1;
         }
         return child.getFirstJulianDay() + SimpleDayPickerFragment.DAYS_PER_WEEK - 1;
+    }
+
+    public void blockScroll(){
+        Log.e(TAG, "blockScroll");
+        mBlockScroll=true;
+    }
+    public void unblockScroll(){
+        Log.e(TAG, "unblockScroll");
+        mBlockScroll=false;
     }
 }

--- a/src/com/android/calendar/month/MonthListView.java
+++ b/src/com/android/calendar/month/MonthListView.java
@@ -115,14 +115,6 @@ public class MonthListView extends ListView {
                 mDownActionTime = SystemClock.uptimeMillis();
                 break;
             // Accumulate velocity and do a custom fling when above threshold
-            case MotionEvent.ACTION_MOVE:
-            case MotionEvent.ACTION_SCROLL:
-                if(mBlockScroll){
-                    Log.e(TAG, "Fyou NOT");
-                    break;
-                }
-                Log.e(TAG, "Fyou");
-                break;
             case MotionEvent.ACTION_UP:
                 mTracker.addMovement(ev);
                 mTracker.computeCurrentVelocity(1000);    // in pixels per second

--- a/src/com/android/calendar/month/MonthWeekEventsView.java
+++ b/src/com/android/calendar/month/MonthWeekEventsView.java
@@ -153,6 +153,7 @@ public class MonthWeekEventsView extends SimpleWeekView {
     protected int mTodayAnimateColor;
     HashMap<Integer, Utils.DNAStrand> mDna = null;
     private int mClickedDayIndex = -1;
+    public List<Integer> mSelectedDayIndexes = new ArrayList<>();
     private int mClickedDayColor;
     private boolean mAnimateToday;
     private int mAnimateTodayAlpha = 0;
@@ -465,6 +466,7 @@ public class MonthWeekEventsView extends SimpleWeekView {
             drawDNA(canvas);
         }
         drawClick(canvas);
+        drawSelection(canvas, mSelectedDayIndexes);
     }
 
     protected void drawToday(Canvas canvas) {
@@ -570,16 +572,27 @@ public class MonthWeekEventsView extends SimpleWeekView {
     // Draw the "clicked" color on the tapped day
     private void drawClick(Canvas canvas) {
         if (mClickedDayIndex != -1) {
-            int alpha = p.getAlpha();
-            p.setColor(mClickedDayColor);
-            p.setAlpha(mClickedAlpha);
-            r.left = computeDayLeftPosition(mClickedDayIndex);
-            r.right = computeDayLeftPosition(mClickedDayIndex + 1);
-            r.top = mDaySeparatorInnerWidth;
-            r.bottom = mHeight;
-            canvas.drawRect(r, p);
-            p.setAlpha(alpha);
+            drawHighlightOnCell(canvas, mClickedDayIndex);
         }
+    }
+
+    private void drawSelection(Canvas canvas, List<Integer> indexes){
+        for(int i : indexes){
+            if (i != -1) {
+                drawHighlightOnCell(canvas, i);
+            }
+        }
+    }
+    private void drawHighlightOnCell(Canvas canvas, int index){
+        int alpha = p.getAlpha();
+        p.setColor(mClickedDayColor);
+        p.setAlpha(mClickedAlpha);
+        r.left = computeDayLeftPosition(index);
+        r.right = computeDayLeftPosition(index + 1);
+        r.top = mDaySeparatorInnerWidth;
+        r.bottom = mHeight;
+        canvas.drawRect(r, p);
+        p.setAlpha(alpha);
     }
 
     @Override

--- a/src/com/android/calendar/month/SimpleDayPickerFragment.java
+++ b/src/com/android/calendar/month/SimpleDayPickerFragment.java
@@ -41,6 +41,7 @@ import com.android.calendar.Utils;
 
 import java.util.Calendar;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Locale;
 
 import ws.xsoh.etar.R;
@@ -251,6 +252,7 @@ public class SimpleDayPickerFragment extends ListFragment implements OnScrollLis
      * set a different list view behavior.
      */
     protected void setUpListView() {
+
         // Configure the listview
         mListView = getListView();
         // Transparent background on scroll

--- a/src/com/android/calendar/month/SimpleWeeksAdapter.java
+++ b/src/com/android/calendar/month/SimpleWeeksAdapter.java
@@ -294,9 +294,9 @@ public class SimpleWeeksAdapter extends BaseAdapter implements OnTouchListener {
         }
     }
 
-    ListView mListView;
+    MonthListView mListView;
 
-    public void setListView(ListView lv) {
+    public void setListView(MonthListView lv) {
         mListView = lv;
     }
 }

--- a/src/com/android/calendar/month/SimpleWeeksAdapter.java
+++ b/src/com/android/calendar/month/SimpleWeeksAdapter.java
@@ -263,7 +263,7 @@ public class SimpleWeeksAdapter extends BaseAdapter implements OnTouchListener {
                 Log.d(TAG, "Touched day at Row=" + view.mWeek + " day=" + day.toString());
             }
             if (day != null) {
-                onDayTapped(day);
+                onDayTapped(day, null);
             }
             return true;
         }
@@ -275,7 +275,7 @@ public class SimpleWeeksAdapter extends BaseAdapter implements OnTouchListener {
      *
      * @param day The day that was tapped
      */
-    protected void onDayTapped(Time day) {
+    protected void onDayTapped(Time day, Time end) {
         day.hour = mSelectedDay.hour;
         day.minute = mSelectedDay.minute;
         day.second = mSelectedDay.second;


### PR DESCRIPTION
This allows the selection of multiple days in the monthview, which then get shown in the weekview-style.

Currently it can do: 

- [x] Select range in single week

- [x] Select range in multiple weeks

- [ ] Highlight Selection

- [x] Block Listview from moving while selection is beeing made

- [x] Fix limit beeing applied even when selection is smaller than limit

Currently the logic works, it calculates the selected elements from the relative position of the first click to the position where it was released. It then checks wether the selection was made backwards in time or not, calculates the appropriate timestamps, and then recalculates the timestamp according to the limit which can be adjusted via a LIMIT_SELECTION constant (which is currently set to 14 days. 

The last thing that is missing (besides refactoring&cleanup) is visual feedback. It marks everything that is in the same row properly, but the other rows are currently unaffected, i have to find out how to do that. 

This could be further improved by #761