### PR TITLE
Hardcode `locationIconRounded` corner size

### DIFF
--- a/res/values/styles.xml
+++ b/res/values/styles.xml
@@ -222,7 +222,7 @@
 
     <style name="locationIconRounded">
         <item name="cornerFamily">rounded</item>
-        <item name="cornerSize">50%</item>
+        <item name="cornerSize">22dp</item>
     </style>
 
     <style name="WidgetDayOfWeekStyle">


### PR DESCRIPTION
cornerSize attribute is supposed to be a dimension,
therefore setting it to "50%" makes aapt2 show the following
error message: "styles.xml:225: error: expected dimension
but got (raw string) 50%" when compiling in AOSP environment.

According to Android Studio's design tab, 22dp seems to look
exactly the same as 50% would, as in it adds a light stroke
over the location icon.