### PR TITLE
Fix "more events" translation syntax

### DIFF
--- a/res/values-zh-rCN/strings.xml
+++ b/res/values-zh-rCN/strings.xml
@@ -169,7 +169,7 @@
     <string name="preferences_show_week_num_title" msgid="5280734329664503461">"显示周数"</string>
     <string name="preferences_build_version" msgid="8242471883413502068">"版本号"</string>
     <plurals name="month_more_events">
-        <item quantity="other">+&lt;xliff:g xmlns:xliff=\"urn:oasis:names:tc:xliff:document:1.2\" id=\"number\"&gt;%d&lt;/xliff:g&gt;</item>
+        <item quantity="other">"+<xliff:g xmlns:xliff=\"urn:oasis:names:tc:xliff:document:1.2\" id=\"number\">%d</xliff:g>"</item>
     </plurals>
     <string name="gadget_no_events" msgid="5209110911088302855">"最近没有任何日历活动"</string>
     <string name="preferences_experimental_category" msgid="8111213192001230350">"实验性"</string>


### PR DESCRIPTION
It's displaying the xml tags literally on my device.

Weblate does not seem to be relevant to this issue so I figured PR would be a better course of action