### PR TITLE
Replace dip with sp in event info text size

### DIFF
--- a/res/values-sw600dp/dimens.xml
+++ b/res/values-sw600dp/dimens.xml
@@ -16,7 +16,7 @@
 -->
 <resources>
 
-    <dimen name="event_info_text_size">18dip</dimen>
+    <dimen name="event_info_text_size">18sp</dimen>
     <dimen name="event_info_desc_margin_left">16dip</dimen>
     <dimen name="event_info_desc_margin_right">16dip</dimen>
     <dimen name="event_info_padding">14dip</dimen>

--- a/res/values/dimens.xml
+++ b/res/values/dimens.xml
@@ -40,7 +40,7 @@
     <dimen name="edit_event_view_padding_left">80dip</dimen>
     <dimen name="edit_event_view_padding_right">80dip</dimen>
     <dimen name="edit_reminder_min_size">36dip</dimen>
-    <dimen name="event_info_text_size">14dip</dimen>
+    <dimen name="event_info_text_size">14sp</dimen>
     <dimen name="event_info_desc_margin_left">0dip</dimen>
     <dimen name="event_info_desc_margin_right">0dip</dimen>
     <dimen name="event_info_padding">0dip</dimen>


### PR DESCRIPTION
Using the biggest font size the description doesn't grow

### **Before:**
<img src="https://user-images.githubusercontent.com/12877898/124861966-297d1700-df7a-11eb-906b-465d7a2cf1e3.png" width="320"/>

### **After**
<img src="https://user-images.githubusercontent.com/12877898/124861962-28e48080-df7a-11eb-904d-fce550b68343.png" width="320"/>

### **sw600dp**
### **Before**
<img src="https://user-images.githubusercontent.com/12877898/124862297-bcb64c80-df7a-11eb-9463-16ec660e45b8.png" width="320"/>

### **After**
<img src="https://user-images.githubusercontent.com/12877898/124862306-bfb13d00-df7a-11eb-8263-7aaf37de98fe.png" width="320"/>
