### PR TITLE
Fixed crash of WeekView, Agenda, Settings & MonthView screens when calendar permission is not given

### DIFF
--- a/src/com/android/calendar/AllInOneActivity.java
+++ b/src/com/android/calendar/AllInOneActivity.java
@@ -73,15 +73,6 @@ import android.widget.RelativeLayout;
 import android.widget.RelativeLayout.LayoutParams;
 import android.widget.TextView;
 import android.widget.Toast;
-
-import androidx.appcompat.app.ActionBar;
-import androidx.appcompat.widget.SearchView;
-import androidx.appcompat.widget.Toolbar;
-import androidx.core.app.ActivityCompat;
-import androidx.core.content.ContextCompat;
-import androidx.core.view.GravityCompat;
-import androidx.drawerlayout.widget.DrawerLayout;
-
 import com.android.calendar.CalendarController.EventHandler;
 import com.android.calendar.CalendarController.EventInfo;
 import com.android.calendar.CalendarController.EventType;
@@ -90,13 +81,6 @@ import com.android.calendar.agenda.AgendaFragment;
 import com.android.calendar.alerts.AlertService;
 import com.android.calendar.month.MonthByWeekFragment;
 import com.android.calendar.selectcalendars.SelectVisibleCalendarsFragment;
-import com.android.calendar.settings.GeneralPreferences;
-import com.android.calendar.settings.SettingsActivity;
-import com.android.calendar.settings.SettingsActivityKt;
-import com.android.calendar.settings.ViewDetailsPreferences;
-import com.google.android.material.floatingactionbutton.FloatingActionButton;
-import com.google.android.material.navigation.NavigationView;
-
 import java.io.File;
 import java.util.Calendar;
 import java.util.List;

--- a/src/com/android/calendar/AllInOneActivity.java
+++ b/src/com/android/calendar/AllInOneActivity.java
@@ -423,7 +423,9 @@ public class AllInOneActivity extends AbstractCalendarActivity implements EventH
                 // If request is cancelled, the result arrays are empty.
                 if (grantResults.length > 0
                         && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
+
                     // permission was granted, yay!
+
                 } else {
                     Toast.makeText(getApplicationContext(), R.string.user_rejected_calendar_write_permission, Toast.LENGTH_LONG).show();
                 }
@@ -1268,7 +1270,7 @@ public class AllInOneActivity extends AbstractCalendarActivity implements EventH
                     mShowSideViews = false;
                     if (!mHideControls) {
                             final ObjectAnimator slideAnimation = ObjectAnimator.ofInt(this,
-                                "controlsOffset", 0, animationSize);
+                                    "controlsOffset", 0, animationSize);
                             slideAnimation.addListener(mSlideAnimationDoneListener);
                             slideAnimation.setDuration(mCalendarControlsAnimationTime);
                             ObjectAnimator.setFrameDelay(0);

--- a/src/com/android/calendar/AllInOneActivity.java
+++ b/src/com/android/calendar/AllInOneActivity.java
@@ -421,11 +421,9 @@ public class AllInOneActivity extends AbstractCalendarActivity implements EventH
         switch (requestCode) {
             case PERMISSIONS_REQUEST_WRITE_CALENDAR: {
                 // If request is cancelled, the result arrays are empty.
-                if (grantResults.length > 0 && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
+                if (grantResults.length > 0
+                        && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
                     // permission was granted, yay!
-                    if (mController.getViewType() == ViewType.MONTH) {
-                        initFragments(mController.getTime(), ViewType.MONTH, null);
-                    }
                 } else {
                     Toast.makeText(getApplicationContext(), R.string.user_rejected_calendar_write_permission, Toast.LENGTH_LONG).show();
                 }

--- a/src/com/android/calendar/AllInOneActivity.java
+++ b/src/com/android/calendar/AllInOneActivity.java
@@ -401,11 +401,11 @@ public class AllInOneActivity extends AbstractCalendarActivity implements EventH
                 Manifest.permission.WRITE_CALENDAR)
                 != PackageManager.PERMISSION_GRANTED ||
                 ContextCompat.checkSelfPermission(this,
-                        Manifest.permission.READ_CALENDAR)
-                        != PackageManager.PERMISSION_GRANTED ||
+                Manifest.permission.READ_CALENDAR)
+                != PackageManager.PERMISSION_GRANTED ||
                 ContextCompat.checkSelfPermission(this,
-                        Manifest.permission.WRITE_EXTERNAL_STORAGE)
-                        != PackageManager.PERMISSION_GRANTED)) {
+                Manifest.permission.WRITE_EXTERNAL_STORAGE)
+                != PackageManager.PERMISSION_GRANTED)) {
 
             // No explanation needed, we can request the permission.
 
@@ -531,7 +531,7 @@ public class AllInOneActivity extends AbstractCalendarActivity implements EventH
                         mIntentEventStartMillis = intent.getLongExtra(EXTRA_EVENT_BEGIN_TIME, 0);
                         mIntentEventEndMillis = intent.getLongExtra(EXTRA_EVENT_END_TIME, 0);
                         mIntentAttendeeResponse = intent.getIntExtra(
-                                ATTENDEE_STATUS, Attendees.ATTENDEE_STATUS_NONE);
+                            ATTENDEE_STATUS, Attendees.ATTENDEE_STATUS_NONE);
                         mIntentAllDay = intent.getBooleanExtra(EXTRA_EVENT_ALL_DAY, false);
                         timeMillis = mIntentEventStartMillis;
                     }
@@ -568,9 +568,7 @@ public class AllInOneActivity extends AbstractCalendarActivity implements EventH
         mController.registerFirstEventHandler(HANDLER_KEY, this);
         mOnSaveInstanceStateCalled = false;
 
-        if (Build.VERSION.SDK_INT >= 23 && ContextCompat.checkSelfPermission(this,
-                Manifest.permission.READ_CALENDAR)
-                != PackageManager.PERMISSION_GRANTED) {
+        if (!Utils.isCalendarPermissionGranted(this, true)) {
             //If permission is not granted then just return.
             Log.d(TAG, "Manifest.permission.READ_CALENDAR is not granted");
             return;
@@ -623,9 +621,7 @@ public class AllInOneActivity extends AbstractCalendarActivity implements EventH
         mPaused = true;
         mHomeTime.removeCallbacks(mHomeTimeUpdater);
 
-        if (Build.VERSION.SDK_INT >= 23 && ContextCompat.checkSelfPermission(this,
-                Manifest.permission.READ_CALENDAR)
-                != PackageManager.PERMISSION_GRANTED) {
+        if (!Utils.isCalendarPermissionGranted(this, false)) {
             //If permission is not granted then just return.
             Log.d(TAG, "Manifest.permission.WRITE_CALENDAR is not granted");
             return;
@@ -904,8 +900,8 @@ public class AllInOneActivity extends AbstractCalendarActivity implements EventH
                 }
             };
             DatePickerDialog datePickerDialog = new DatePickerDialog(this,datePickerListener,t.year, t.month,t.monthDay);
-            datePickerDialog.getDatePicker().setFirstDayOfWeek(Utils.getFirstDayOfWeekAsCalendar(this));
-            datePickerDialog.show();
+                    datePickerDialog.getDatePicker().setFirstDayOfWeek(Utils.getFirstDayOfWeekAsCalendar(this));
+                    datePickerDialog.show();
 
         } else if (itemId == R.id.action_hide_controls) {
             mHideControls = !mHideControls;
@@ -933,7 +929,7 @@ public class AllInOneActivity extends AbstractCalendarActivity implements EventH
             intent.putExtra(SettingsActivityKt.EXTRA_SHOW_FRAGMENT, ViewDetailsPreferences.class.getName());
             startActivity(intent);
         } else {
-            return mExtensions.handleItemSelected(item, this);
+                return mExtensions.handleItemSelected(item, this);
         }
 
         return true;
@@ -1210,7 +1206,7 @@ public class AllInOneActivity extends AbstractCalendarActivity implements EventH
 
         if (mHomeTime != null
                 && (mCurrentView == ViewType.DAY || mCurrentView == ViewType.WEEK
-                || mCurrentView == ViewType.AGENDA)
+                        || mCurrentView == ViewType.AGENDA)
                 && !TextUtils.equals(mTimeZone, Time.getCurrentTimezone())) {
             Time time = new Time(mTimeZone);
             time.setToNow();
@@ -1271,12 +1267,12 @@ public class AllInOneActivity extends AbstractCalendarActivity implements EventH
                     // hide minimonth and calendar frag
                     mShowSideViews = false;
                     if (!mHideControls) {
-                        final ObjectAnimator slideAnimation = ObjectAnimator.ofInt(this,
+                            final ObjectAnimator slideAnimation = ObjectAnimator.ofInt(this,
                                 "controlsOffset", 0, animationSize);
-                        slideAnimation.addListener(mSlideAnimationDoneListener);
-                        slideAnimation.setDuration(mCalendarControlsAnimationTime);
-                        ObjectAnimator.setFrameDelay(0);
-                        slideAnimation.start();
+                            slideAnimation.addListener(mSlideAnimationDoneListener);
+                            slideAnimation.setDuration(mCalendarControlsAnimationTime);
+                            ObjectAnimator.setFrameDelay(0);
+                            slideAnimation.start();
                     } else {
                         mMiniMonth.setVisibility(View.GONE);
                         mCalendarsList.setVisibility(View.GONE);
@@ -1290,7 +1286,7 @@ public class AllInOneActivity extends AbstractCalendarActivity implements EventH
                     mMiniMonthContainer.setVisibility(View.VISIBLE);
                     if (!mHideControls &&
                             (mController.getPreviousViewType() == ViewType.MONTH ||
-                                    mController.getPreviousViewType() == ViewType.AGENDA)) {
+                             mController.getPreviousViewType() == ViewType.AGENDA)) {
                         final ObjectAnimator slideAnimation = ObjectAnimator.ofInt(this,
                                 "controlsOffset", animationSize, 0);
                         slideAnimation.setDuration(mCalendarControlsAnimationTime);
@@ -1325,7 +1321,7 @@ public class AllInOneActivity extends AbstractCalendarActivity implements EventH
                             CalendarController.EXTRA_GOTO_TIME, null, null);
                 } else if (event.selectedTime != null) {
                     mController.sendEvent(this, EventType.GO_TO, event.selectedTime,
-                            event.selectedTime, event.id, ViewType.AGENDA);
+                        event.selectedTime, event.id, ViewType.AGENDA);
                 }
             } else {
                 // TODO Fix the temp hack below: && mCurrentView !=

--- a/src/com/android/calendar/AllInOneActivity.java
+++ b/src/com/android/calendar/AllInOneActivity.java
@@ -74,6 +74,14 @@ import android.widget.RelativeLayout.LayoutParams;
 import android.widget.TextView;
 import android.widget.Toast;
 
+import androidx.appcompat.app.ActionBar;
+import androidx.appcompat.widget.SearchView;
+import androidx.appcompat.widget.Toolbar;
+import androidx.core.app.ActivityCompat;
+import androidx.core.content.ContextCompat;
+import androidx.core.view.GravityCompat;
+import androidx.drawerlayout.widget.DrawerLayout;
+
 import com.android.calendar.CalendarController.EventHandler;
 import com.android.calendar.CalendarController.EventInfo;
 import com.android.calendar.CalendarController.EventType;
@@ -82,6 +90,12 @@ import com.android.calendar.agenda.AgendaFragment;
 import com.android.calendar.alerts.AlertService;
 import com.android.calendar.month.MonthByWeekFragment;
 import com.android.calendar.selectcalendars.SelectVisibleCalendarsFragment;
+import com.android.calendar.settings.GeneralPreferences;
+import com.android.calendar.settings.SettingsActivity;
+import com.android.calendar.settings.SettingsActivityKt;
+import com.android.calendar.settings.ViewDetailsPreferences;
+import com.google.android.material.floatingactionbutton.FloatingActionButton;
+import com.google.android.material.navigation.NavigationView;
 
 import java.io.File;
 import java.util.Calendar;
@@ -387,11 +401,11 @@ public class AllInOneActivity extends AbstractCalendarActivity implements EventH
                 Manifest.permission.WRITE_CALENDAR)
                 != PackageManager.PERMISSION_GRANTED ||
                 ContextCompat.checkSelfPermission(this,
-                Manifest.permission.READ_CALENDAR)
-                != PackageManager.PERMISSION_GRANTED ||
+                        Manifest.permission.READ_CALENDAR)
+                        != PackageManager.PERMISSION_GRANTED ||
                 ContextCompat.checkSelfPermission(this,
-                Manifest.permission.WRITE_EXTERNAL_STORAGE)
-                != PackageManager.PERMISSION_GRANTED)) {
+                        Manifest.permission.WRITE_EXTERNAL_STORAGE)
+                        != PackageManager.PERMISSION_GRANTED)) {
 
             // No explanation needed, we can request the permission.
 
@@ -407,11 +421,11 @@ public class AllInOneActivity extends AbstractCalendarActivity implements EventH
         switch (requestCode) {
             case PERMISSIONS_REQUEST_WRITE_CALENDAR: {
                 // If request is cancelled, the result arrays are empty.
-                if (grantResults.length > 0
-                        && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
-
+                if (grantResults.length > 0 && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
                     // permission was granted, yay!
-
+                    if (mController.getViewType() == ViewType.MONTH) {
+                        initFragments(mController.getTime(), ViewType.MONTH, null);
+                    }
                 } else {
                     Toast.makeText(getApplicationContext(), R.string.user_rejected_calendar_write_permission, Toast.LENGTH_LONG).show();
                 }
@@ -519,7 +533,7 @@ public class AllInOneActivity extends AbstractCalendarActivity implements EventH
                         mIntentEventStartMillis = intent.getLongExtra(EXTRA_EVENT_BEGIN_TIME, 0);
                         mIntentEventEndMillis = intent.getLongExtra(EXTRA_EVENT_END_TIME, 0);
                         mIntentAttendeeResponse = intent.getIntExtra(
-                            ATTENDEE_STATUS, Attendees.ATTENDEE_STATUS_NONE);
+                                ATTENDEE_STATUS, Attendees.ATTENDEE_STATUS_NONE);
                         mIntentAllDay = intent.getBooleanExtra(EXTRA_EVENT_ALL_DAY, false);
                         timeMillis = mIntentEventStartMillis;
                     }
@@ -892,8 +906,8 @@ public class AllInOneActivity extends AbstractCalendarActivity implements EventH
                 }
             };
             DatePickerDialog datePickerDialog = new DatePickerDialog(this,datePickerListener,t.year, t.month,t.monthDay);
-                    datePickerDialog.getDatePicker().setFirstDayOfWeek(Utils.getFirstDayOfWeekAsCalendar(this));
-                    datePickerDialog.show();
+            datePickerDialog.getDatePicker().setFirstDayOfWeek(Utils.getFirstDayOfWeekAsCalendar(this));
+            datePickerDialog.show();
 
         } else if (itemId == R.id.action_hide_controls) {
             mHideControls = !mHideControls;
@@ -921,7 +935,7 @@ public class AllInOneActivity extends AbstractCalendarActivity implements EventH
             intent.putExtra(SettingsActivityKt.EXTRA_SHOW_FRAGMENT, ViewDetailsPreferences.class.getName());
             startActivity(intent);
         } else {
-                return mExtensions.handleItemSelected(item, this);
+            return mExtensions.handleItemSelected(item, this);
         }
 
         return true;
@@ -1198,7 +1212,7 @@ public class AllInOneActivity extends AbstractCalendarActivity implements EventH
 
         if (mHomeTime != null
                 && (mCurrentView == ViewType.DAY || mCurrentView == ViewType.WEEK
-                        || mCurrentView == ViewType.AGENDA)
+                || mCurrentView == ViewType.AGENDA)
                 && !TextUtils.equals(mTimeZone, Time.getCurrentTimezone())) {
             Time time = new Time(mTimeZone);
             time.setToNow();
@@ -1259,12 +1273,12 @@ public class AllInOneActivity extends AbstractCalendarActivity implements EventH
                     // hide minimonth and calendar frag
                     mShowSideViews = false;
                     if (!mHideControls) {
-                            final ObjectAnimator slideAnimation = ObjectAnimator.ofInt(this,
-                                    "controlsOffset", 0, animationSize);
-                            slideAnimation.addListener(mSlideAnimationDoneListener);
-                            slideAnimation.setDuration(mCalendarControlsAnimationTime);
-                            ObjectAnimator.setFrameDelay(0);
-                            slideAnimation.start();
+                        final ObjectAnimator slideAnimation = ObjectAnimator.ofInt(this,
+                                "controlsOffset", 0, animationSize);
+                        slideAnimation.addListener(mSlideAnimationDoneListener);
+                        slideAnimation.setDuration(mCalendarControlsAnimationTime);
+                        ObjectAnimator.setFrameDelay(0);
+                        slideAnimation.start();
                     } else {
                         mMiniMonth.setVisibility(View.GONE);
                         mCalendarsList.setVisibility(View.GONE);
@@ -1278,7 +1292,7 @@ public class AllInOneActivity extends AbstractCalendarActivity implements EventH
                     mMiniMonthContainer.setVisibility(View.VISIBLE);
                     if (!mHideControls &&
                             (mController.getPreviousViewType() == ViewType.MONTH ||
-                             mController.getPreviousViewType() == ViewType.AGENDA)) {
+                                    mController.getPreviousViewType() == ViewType.AGENDA)) {
                         final ObjectAnimator slideAnimation = ObjectAnimator.ofInt(this,
                                 "controlsOffset", animationSize, 0);
                         slideAnimation.setDuration(mCalendarControlsAnimationTime);
@@ -1313,7 +1327,7 @@ public class AllInOneActivity extends AbstractCalendarActivity implements EventH
                             CalendarController.EXTRA_GOTO_TIME, null, null);
                 } else if (event.selectedTime != null) {
                     mController.sendEvent(this, EventType.GO_TO, event.selectedTime,
-                        event.selectedTime, event.id, ViewType.AGENDA);
+                            event.selectedTime, event.id, ViewType.AGENDA);
                 }
             } else {
                 // TODO Fix the temp hack below: && mCurrentView !=

--- a/src/com/android/calendar/CalendarUtils.java
+++ b/src/com/android/calendar/CalendarUtils.java
@@ -264,9 +264,7 @@ public class CalendarUtils {
                         if (mHandler == null) {
                             mHandler = new AsyncTZHandler(context.getContentResolver());
                         }
-                        if (Build.VERSION.SDK_INT < 23 || ContextCompat.checkSelfPermission(context,
-                                Manifest.permission.READ_CALENDAR) ==
-                                PackageManager.PERMISSION_GRANTED) {
+                        if (Utils.isCalendarPermissionGranted(context, false)) {
                             mHandler.startQuery(0, context, CalendarCache.URI,
                                     CALENDAR_CACHE_POJECTION, null, null, null);
                         }

--- a/src/com/android/calendar/DayView.java
+++ b/src/com/android/calendar/DayView.java
@@ -4554,8 +4554,7 @@ public class DayView extends View implements View.OnCreateContextMenuListener,
 
         Uri uri = Calendars.CONTENT_URI;
         String where = String.format(CALENDARS_WHERE, calId);
-        if (Build.VERSION.SDK_INT >= 23 && ContextCompat.checkSelfPermission(context,
-                Manifest.permission.READ_CALENDAR) != PackageManager.PERMISSION_GRANTED) {
+        if (!Utils.isCalendarPermissionGranted(context, false)) {
             // If permission is not granted then just return.
             Log.d(TAG, "Manifest.permission.READ_CALENDAR is not granted");
             return 0;

--- a/src/com/android/calendar/Event.java
+++ b/src/com/android/calendar/Event.java
@@ -183,9 +183,7 @@ public class Event implements Cloneable {
             Debug.startMethodTracing("loadEvents");
         }
 
-        if (Build.VERSION.SDK_INT >= 23 && ContextCompat.checkSelfPermission(context,
-                Manifest.permission.READ_CALENDAR)
-                != PackageManager.PERMISSION_GRANTED) {
+        if (!Utils.isCalendarPermissionGranted(context, false)) {
             //If permission is not granted then just return.
             return;
         }

--- a/src/com/android/calendar/GoogleCalendarUriIntentFilter.java
+++ b/src/com/android/calendar/GoogleCalendarUriIntentFilter.java
@@ -158,9 +158,7 @@ public class GoogleCalendarUriIntentFilter extends Activity {
 
                     if (debug) Log.d(TAG, "selection: " + selection);
 
-                    if (Build.VERSION.SDK_INT >= 23 && ContextCompat.checkSelfPermission(this,
-                            Manifest.permission.READ_CALENDAR)
-                            != PackageManager.PERMISSION_GRANTED) {
+                    if (!Utils.isCalendarPermissionGranted(this, false)) {
                         //If permission is not granted then just return.
                         Log.d(TAG, "Manifest.permission.READ_CALENDAR is not granted");
                         return;

--- a/src/com/android/calendar/SearchActivity.java
+++ b/src/com/android/calendar/SearchActivity.java
@@ -56,7 +56,7 @@ public class SearchActivity extends AppCompatActivity implements CalendarControl
 
     protected static final String BUNDLE_KEY_RESTORE_TIME = "key_restore_time";
     protected static final String BUNDLE_KEY_RESTORE_SEARCH_QUERY =
-            "key_restore_search_query";
+        "key_restore_search_query";
     private static final String TAG = SearchActivity.class.getSimpleName();
     private static final boolean DEBUG = false;
     private static final int HANDLER_KEY = 0;

--- a/src/com/android/calendar/SearchActivity.java
+++ b/src/com/android/calendar/SearchActivity.java
@@ -104,7 +104,7 @@ public class SearchActivity extends AppCompatActivity implements CalendarControl
 
         mIsMultipane = Utils.getConfigBool(this, R.bool.multiple_pane_config);
         mShowEventDetailsWithAgenda =
-                Utils.getConfigBool(this, R.bool.show_event_details_with_agenda);
+            Utils.getConfigBool(this, R.bool.show_event_details_with_agenda);
 
         SimpleFrameLayoutMaterialBinding binding = SimpleFrameLayoutMaterialBinding.inflate(getLayoutInflater());
         setContentView(binding.getRoot());
@@ -120,7 +120,7 @@ public class SearchActivity extends AppCompatActivity implements CalendarControl
             }
         } else {
             if (getSupportActionBar() != null) {
-                getSupportActionBar().setDisplayOptions(0, ActionBar.DISPLAY_HOME_AS_UP | ActionBar.DISPLAY_SHOW_HOME);
+               getSupportActionBar().setDisplayOptions(0, ActionBar.DISPLAY_HOME_AS_UP | ActionBar.DISPLAY_SHOW_HOME);
             }
         }
 
@@ -322,7 +322,7 @@ public class SearchActivity extends AppCompatActivity implements CalendarControl
         invalidateOptionsMenu();
         mTimeChangesReceiver = Utils.setTimeChangesReceiver(this, mTimeChangesUpdater);
 
-        if (Utils.isCalendarPermissionGranted(getApplicationContext())) {
+        if (Utils.isCalendarPermissionGranted(getApplicationContext(), true)) {
             mContentResolver.registerContentObserver(Events.CONTENT_URI, true, mObserver);
             // We call this in case the user changed the time zone
             eventsChanged();

--- a/src/com/android/calendar/SearchActivity.java
+++ b/src/com/android/calendar/SearchActivity.java
@@ -29,14 +29,15 @@ import android.os.Bundle;
 import android.os.Handler;
 import android.provider.CalendarContract.Events;
 import android.provider.SearchRecentSuggestions;
-import androidx.appcompat.app.ActionBar;
-import androidx.core.view.MenuItemCompat;
-import androidx.appcompat.app.AppCompatActivity;
-import androidx.appcompat.widget.SearchView;
 import android.text.format.Time;
 import android.util.Log;
 import android.view.Menu;
 import android.view.MenuItem;
+
+import androidx.appcompat.app.ActionBar;
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.appcompat.widget.SearchView;
+import androidx.core.view.MenuItemCompat;
 
 import com.android.calendar.CalendarController.EventInfo;
 import com.android.calendar.CalendarController.EventType;
@@ -55,11 +56,11 @@ public class SearchActivity extends AppCompatActivity implements CalendarControl
 
     protected static final String BUNDLE_KEY_RESTORE_TIME = "key_restore_time";
     protected static final String BUNDLE_KEY_RESTORE_SEARCH_QUERY =
-        "key_restore_search_query";
+            "key_restore_search_query";
     private static final String TAG = SearchActivity.class.getSimpleName();
     private static final boolean DEBUG = false;
     private static final int HANDLER_KEY = 0;
-   private static boolean mIsMultipane;
+    private static boolean mIsMultipane;
     // display event details to the side of the event list
     private boolean mShowEventDetailsWithAgenda;
     private CalendarController mController;
@@ -103,7 +104,7 @@ public class SearchActivity extends AppCompatActivity implements CalendarControl
 
         mIsMultipane = Utils.getConfigBool(this, R.bool.multiple_pane_config);
         mShowEventDetailsWithAgenda =
-            Utils.getConfigBool(this, R.bool.show_event_details_with_agenda);
+                Utils.getConfigBool(this, R.bool.show_event_details_with_agenda);
 
         SimpleFrameLayoutMaterialBinding binding = SimpleFrameLayoutMaterialBinding.inflate(getLayoutInflater());
         setContentView(binding.getRoot());
@@ -119,7 +120,7 @@ public class SearchActivity extends AppCompatActivity implements CalendarControl
             }
         } else {
             if (getSupportActionBar() != null) {
-               getSupportActionBar().setDisplayOptions(0, ActionBar.DISPLAY_HOME_AS_UP | ActionBar.DISPLAY_SHOW_HOME);
+                getSupportActionBar().setDisplayOptions(0, ActionBar.DISPLAY_HOME_AS_UP | ActionBar.DISPLAY_SHOW_HOME);
             }
         }
 
@@ -320,9 +321,12 @@ public class SearchActivity extends AppCompatActivity implements CalendarControl
         // Make sure the today icon is up to date
         invalidateOptionsMenu();
         mTimeChangesReceiver = Utils.setTimeChangesReceiver(this, mTimeChangesUpdater);
-        mContentResolver.registerContentObserver(Events.CONTENT_URI, true, mObserver);
-        // We call this in case the user changed the time zone
-        eventsChanged();
+
+        if (Utils.isCalendarPermissionGranted(getApplicationContext())) {
+            mContentResolver.registerContentObserver(Events.CONTENT_URI, true, mObserver);
+            // We call this in case the user changed the time zone
+            eventsChanged();
+        }
     }
 
     @Override

--- a/src/com/android/calendar/Utils.java
+++ b/src/com/android/calendar/Utils.java
@@ -2136,7 +2136,7 @@ public class Utils {
         if (ContextCompat.checkSelfPermission(context,
                 Manifest.permission.READ_CALENDAR) == PackageManager.PERMISSION_GRANTED) {
             return true;
-        } else{
+        } else {
             if (showWarningToast) {
                 Toast.makeText(context, R.string.user_rejected_calendar_write_permission, Toast.LENGTH_SHORT).show();
             }

--- a/src/com/android/calendar/Utils.java
+++ b/src/com/android/calendar/Utils.java
@@ -16,6 +16,7 @@
 
 package com.android.calendar;
 
+import android.Manifest;
 import android.accounts.Account;
 import android.app.Activity;
 import android.app.SearchManager;
@@ -41,6 +42,8 @@ import android.provider.CalendarContract.Calendars;
 
 import androidx.annotation.NonNull;
 import androidx.appcompat.widget.SearchView;
+import androidx.core.content.ContextCompat;
+
 import android.text.Spannable;
 import android.text.SpannableString;
 import android.text.Spanned;
@@ -51,6 +54,7 @@ import android.text.format.Time;
 import android.text.style.URLSpan;
 import android.text.util.Linkify;
 import android.util.Log;
+import android.widget.Toast;
 
 import com.android.calendar.CalendarController.ViewType;
 import com.android.calendar.CalendarEventModel.ReminderEntry;
@@ -2124,6 +2128,16 @@ public class Utils {
                     mCallBack.run();
                 }
             }
+        }
+    }
+
+    public static boolean isCalendarPermissionGranted(Context context) {
+        if (Build.VERSION.SDK_INT >= 23 && ContextCompat.checkSelfPermission(context,
+                Manifest.permission.READ_CALENDAR) == PackageManager.PERMISSION_GRANTED) {
+            return true;
+        } else{
+            Toast.makeText(context, R.string.user_rejected_calendar_write_permission, Toast.LENGTH_LONG).show();
+            return false;
         }
     }
 

--- a/src/com/android/calendar/Utils.java
+++ b/src/com/android/calendar/Utils.java
@@ -2136,7 +2136,7 @@ public class Utils {
                 Manifest.permission.READ_CALENDAR) == PackageManager.PERMISSION_GRANTED) {
             return true;
         } else{
-            Toast.makeText(context, R.string.user_rejected_calendar_write_permission, Toast.LENGTH_LONG).show();
+            Toast.makeText(context, R.string.user_rejected_calendar_write_permission, Toast.LENGTH_SHORT).show();
             return false;
         }
     }

--- a/src/com/android/calendar/Utils.java
+++ b/src/com/android/calendar/Utils.java
@@ -2132,7 +2132,8 @@ public class Utils {
     }
 
     public static boolean isCalendarPermissionGranted(Context context, boolean showWarningToast) {
-        if (Build.VERSION.SDK_INT >= 23 && ContextCompat.checkSelfPermission(context,
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) return true;
+        if (ContextCompat.checkSelfPermission(context,
                 Manifest.permission.READ_CALENDAR) == PackageManager.PERMISSION_GRANTED) {
             return true;
         } else{

--- a/src/com/android/calendar/Utils.java
+++ b/src/com/android/calendar/Utils.java
@@ -2131,12 +2131,14 @@ public class Utils {
         }
     }
 
-    public static boolean isCalendarPermissionGranted(Context context) {
+    public static boolean isCalendarPermissionGranted(Context context, boolean showWarningToast) {
         if (Build.VERSION.SDK_INT >= 23 && ContextCompat.checkSelfPermission(context,
                 Manifest.permission.READ_CALENDAR) == PackageManager.PERMISSION_GRANTED) {
             return true;
         } else{
-            Toast.makeText(context, R.string.user_rejected_calendar_write_permission, Toast.LENGTH_SHORT).show();
+            if (showWarningToast) {
+                Toast.makeText(context, R.string.user_rejected_calendar_write_permission, Toast.LENGTH_SHORT).show();
+            }
             return false;
         }
     }

--- a/src/com/android/calendar/agenda/AgendaWindowAdapter.java
+++ b/src/com/android/calendar/agenda/AgendaWindowAdapter.java
@@ -73,7 +73,7 @@ Check for leaks and excessive allocations
  */
 
 public class AgendaWindowAdapter extends BaseAdapter
-        implements StickyHeaderListView.HeaderIndexer, StickyHeaderListView.HeaderHeightListener{
+    implements StickyHeaderListView.HeaderIndexer, StickyHeaderListView.HeaderHeightListener{
 
     public static final int INDEX_INSTANCE_ID = 0;
     public static final int INDEX_TITLE = 1;
@@ -212,7 +212,7 @@ public class AgendaWindowAdapter extends BaseAdapter
     private AgendaAdapter.ViewHolder mSelectedVH = null;
 
     public AgendaWindowAdapter(Context context,
-                               AgendaListView agendaListView, boolean showEventOnStart) {
+            AgendaListView agendaListView, boolean showEventOnStart) {
         mContext = context;
         mResources = context.getResources();
         mSelectedItemBackgroundColor = mResources
@@ -331,7 +331,7 @@ public class AgendaWindowAdapter extends BaseAdapter
             if (curPos >= 0) {
                 info.cursor.moveToPosition(curPos);
                 return info.cursor.getLong(AgendaWindowAdapter.INDEX_EVENT_ID) << 20 +
-                        info.cursor.getLong(AgendaWindowAdapter.INDEX_BEGIN);
+                    info.cursor.getLong(AgendaWindowAdapter.INDEX_BEGIN);
             }
             // Day Header
             return info.dayAdapter.findJulianDayFromPosition(position);
@@ -479,7 +479,7 @@ public class AgendaWindowAdapter extends BaseAdapter
      * @return
      */
     public AgendaItem getAgendaItemByPosition(final int positionInListView,
-                                              boolean returnEventStartDay) {
+            boolean returnEventStartDay) {
         if (DEBUGLOG) Log.e(TAG, "getEventByPosition " + positionInListView);
         if (positionInListView < 0) {
             return null;
@@ -514,7 +514,7 @@ public class AgendaWindowAdapter extends BaseAdapter
     }
 
     private AgendaItem buildAgendaItemFromCursor(final Cursor cursor, int cursorPosition,
-                                                 boolean isDayHeader) {
+            boolean isDayHeader) {
         if (cursorPosition <= -1) {
             cursor.moveToFirst();
         } else {
@@ -567,15 +567,15 @@ public class AgendaWindowAdapter extends BaseAdapter
             Log.d(TAG, "Sent (AgendaWindowAdapter): VIEW EVENT: " + new Date(startTime));
         }
         CalendarController.getInstance(mContext)
-                .sendEventRelatedEventWithExtra(this, EventType.VIEW_EVENT,
-                        item.id, startTime, endTime, 0,
-                        0, CalendarController.EventInfo.buildViewExtraLong(
-                                Attendees.ATTENDEE_STATUS_NONE,
-                                item.allDay), selectedTime);
+        .sendEventRelatedEventWithExtra(this, EventType.VIEW_EVENT,
+                item.id, startTime, endTime, 0,
+                0, CalendarController.EventInfo.buildViewExtraLong(
+                            Attendees.ATTENDEE_STATUS_NONE,
+                            item.allDay), selectedTime);
     }
 
     public void refresh(Time goToTime, long id, String searchQuery, boolean forced,
-                        boolean refreshEventInfo) {
+            boolean refreshEventInfo) {
         if (searchQuery != null) {
             mSearchQuery = searchQuery;
         }
@@ -747,7 +747,7 @@ public class AgendaWindowAdapter extends BaseAdapter
     }
 
     private boolean queueQuery(int start, int end, Time goToTime,
-                               String searchQuery, int queryType, long id) {
+            String searchQuery, int queryType, long id) {
         QuerySpec queryData = new QuerySpec(queryType);
         queryData.goToTime = new Time(goToTime);    // Creates a new time reference per QuerySpec.
         queryData.start = start;
@@ -1076,7 +1076,7 @@ public class AgendaWindowAdapter extends BaseAdapter
 
             if (cursor == null) {
                 if (mAgendaListView != null && mAgendaListView.getContext() instanceof Activity) {
-                    if (Utils.isCalendarPermissionGranted(mContext)) {
+                    if (Utils.isCalendarPermissionGranted(mContext, true)) {
                         ((Activity) mAgendaListView.getContext()).finish();
                     } else {
                         mHeaderView.setText(R.string.calendar_permission_not_granted);
@@ -1179,12 +1179,12 @@ public class AgendaWindowAdapter extends BaseAdapter
                             // know about the selected view and fill it in.
                             mSelectedVH = new AgendaAdapter.ViewHolder();
                             mSelectedVH.allDay =
-                                    cursor.getInt(AgendaWindowAdapter.INDEX_ALL_DAY) != 0;
+                                cursor.getInt(AgendaWindowAdapter.INDEX_ALL_DAY) != 0;
                             tempCursor = cursor;
                         }
                     } else if (newPosition != -1) {
-                        tempCursor = getCursorByPosition(newPosition);
-                        tempCursorPosition = getCursorPositionByPosition(newPosition);
+                         tempCursor = getCursorByPosition(newPosition);
+                         tempCursorPosition = getCursorPositionByPosition(newPosition);
                     }
                     if (tempCursor != null) {
                         AgendaItem item = buildAgendaItemFromCursor(tempCursor, tempCursorPosition,

--- a/src/com/android/calendar/agenda/AgendaWindowAdapter.java
+++ b/src/com/android/calendar/agenda/AgendaWindowAdapter.java
@@ -1077,7 +1077,6 @@ public class AgendaWindowAdapter extends BaseAdapter
             if (cursor == null) {
                 if (mAgendaListView != null && mAgendaListView.getContext() instanceof Activity) {
                     if (Utils.isCalendarPermissionGranted(mContext)) {
-                        //If permission is granted then return.
                         ((Activity) mAgendaListView.getContext()).finish();
                     } else {
                         mHeaderView.setText(R.string.calendar_permission_not_granted);

--- a/src/com/android/calendar/agenda/AgendaWindowAdapter.java
+++ b/src/com/android/calendar/agenda/AgendaWindowAdapter.java
@@ -64,10 +64,8 @@ Bugs Bugs Bugs:
 - Track ball clicks at the header/footer doesn't work.
 - Potential ping pong effect if the prefetch window is big and data is limited
 - Add index in calendar provider
-
 ToDo ToDo ToDo:
 Get design of header and footer from designer
-
 Make scrolling smoother.
 Test for correctness
 Loading speed
@@ -75,7 +73,7 @@ Check for leaks and excessive allocations
  */
 
 public class AgendaWindowAdapter extends BaseAdapter
-    implements StickyHeaderListView.HeaderIndexer, StickyHeaderListView.HeaderHeightListener{
+        implements StickyHeaderListView.HeaderIndexer, StickyHeaderListView.HeaderHeightListener{
 
     public static final int INDEX_INSTANCE_ID = 0;
     public static final int INDEX_TITLE = 1;
@@ -214,7 +212,7 @@ public class AgendaWindowAdapter extends BaseAdapter
     private AgendaAdapter.ViewHolder mSelectedVH = null;
 
     public AgendaWindowAdapter(Context context,
-            AgendaListView agendaListView, boolean showEventOnStart) {
+                               AgendaListView agendaListView, boolean showEventOnStart) {
         mContext = context;
         mResources = context.getResources();
         mSelectedItemBackgroundColor = mResources
@@ -333,7 +331,7 @@ public class AgendaWindowAdapter extends BaseAdapter
             if (curPos >= 0) {
                 info.cursor.moveToPosition(curPos);
                 return info.cursor.getLong(AgendaWindowAdapter.INDEX_EVENT_ID) << 20 +
-                    info.cursor.getLong(AgendaWindowAdapter.INDEX_BEGIN);
+                        info.cursor.getLong(AgendaWindowAdapter.INDEX_BEGIN);
             }
             // Day Header
             return info.dayAdapter.findJulianDayFromPosition(position);
@@ -481,7 +479,7 @@ public class AgendaWindowAdapter extends BaseAdapter
      * @return
      */
     public AgendaItem getAgendaItemByPosition(final int positionInListView,
-            boolean returnEventStartDay) {
+                                              boolean returnEventStartDay) {
         if (DEBUGLOG) Log.e(TAG, "getEventByPosition " + positionInListView);
         if (positionInListView < 0) {
             return null;
@@ -516,7 +514,7 @@ public class AgendaWindowAdapter extends BaseAdapter
     }
 
     private AgendaItem buildAgendaItemFromCursor(final Cursor cursor, int cursorPosition,
-            boolean isDayHeader) {
+                                                 boolean isDayHeader) {
         if (cursorPosition <= -1) {
             cursor.moveToFirst();
         } else {
@@ -569,15 +567,15 @@ public class AgendaWindowAdapter extends BaseAdapter
             Log.d(TAG, "Sent (AgendaWindowAdapter): VIEW EVENT: " + new Date(startTime));
         }
         CalendarController.getInstance(mContext)
-        .sendEventRelatedEventWithExtra(this, EventType.VIEW_EVENT,
-                item.id, startTime, endTime, 0,
-                0, CalendarController.EventInfo.buildViewExtraLong(
-                        Attendees.ATTENDEE_STATUS_NONE,
-                        item.allDay), selectedTime);
+                .sendEventRelatedEventWithExtra(this, EventType.VIEW_EVENT,
+                        item.id, startTime, endTime, 0,
+                        0, CalendarController.EventInfo.buildViewExtraLong(
+                                Attendees.ATTENDEE_STATUS_NONE,
+                                item.allDay), selectedTime);
     }
 
     public void refresh(Time goToTime, long id, String searchQuery, boolean forced,
-            boolean refreshEventInfo) {
+                        boolean refreshEventInfo) {
         if (searchQuery != null) {
             mSearchQuery = searchQuery;
         }
@@ -749,7 +747,7 @@ public class AgendaWindowAdapter extends BaseAdapter
     }
 
     private boolean queueQuery(int start, int end, Time goToTime,
-            String searchQuery, int queryType, long id) {
+                               String searchQuery, int queryType, long id) {
         QuerySpec queryData = new QuerySpec(queryType);
         queryData.goToTime = new Time(goToTime);    // Creates a new time reference per QuerySpec.
         queryData.start = start;
@@ -1077,10 +1075,15 @@ public class AgendaWindowAdapter extends BaseAdapter
             QuerySpec data = (QuerySpec)cookie;
 
             if (cursor == null) {
-              if (mAgendaListView != null && mAgendaListView.getContext() instanceof Activity) {
-                ((Activity) mAgendaListView.getContext()).finish();
-              }
-              return;
+                if (mAgendaListView != null && mAgendaListView.getContext() instanceof Activity) {
+                    if (Utils.isCalendarPermissionGranted(mContext)) {
+                        //If permission is granted then return.
+                        ((Activity) mAgendaListView.getContext()).finish();
+                    } else {
+                        mHeaderView.setText(R.string.calendar_permission_not_granted);
+                    }
+                }
+                return;
             }
 
             if (BASICLOG) {
@@ -1177,12 +1180,12 @@ public class AgendaWindowAdapter extends BaseAdapter
                             // know about the selected view and fill it in.
                             mSelectedVH = new AgendaAdapter.ViewHolder();
                             mSelectedVH.allDay =
-                                cursor.getInt(AgendaWindowAdapter.INDEX_ALL_DAY) != 0;
+                                    cursor.getInt(AgendaWindowAdapter.INDEX_ALL_DAY) != 0;
                             tempCursor = cursor;
                         }
                     } else if (newPosition != -1) {
-                         tempCursor = getCursorByPosition(newPosition);
-                         tempCursorPosition = getCursorPositionByPosition(newPosition);
+                        tempCursor = getCursorByPosition(newPosition);
+                        tempCursorPosition = getCursorPositionByPosition(newPosition);
                     }
                     if (tempCursor != null) {
                         AgendaItem item = buildAgendaItemFromCursor(tempCursor, tempCursorPosition,

--- a/src/com/android/calendar/agenda/AgendaWindowAdapter.java
+++ b/src/com/android/calendar/agenda/AgendaWindowAdapter.java
@@ -569,9 +569,9 @@ public class AgendaWindowAdapter extends BaseAdapter
         CalendarController.getInstance(mContext)
         .sendEventRelatedEventWithExtra(this, EventType.VIEW_EVENT,
                 item.id, startTime, endTime, 0,
-                0, CalendarController.EventInfo.buildViewExtraLong(
-                            Attendees.ATTENDEE_STATUS_NONE,
-                            item.allDay), selectedTime);
+               0, CalendarController.EventInfo.buildViewExtraLong(
+                           Attendees.ATTENDEE_STATUS_NONE,
+                           item.allDay), selectedTime);
     }
 
     public void refresh(Time goToTime, long id, String searchQuery, boolean forced,

--- a/src/com/android/calendar/alerts/AlarmScheduler.java
+++ b/src/com/android/calendar/alerts/AlarmScheduler.java
@@ -137,9 +137,7 @@ public class AlarmScheduler {
         final long utcStartMin = localStartMin - localOffset;
         final long utcStartMax = utcStartMin + EVENT_LOOKAHEAD_WINDOW_MS;
 
-        if (Build.VERSION.SDK_INT >= 23 && ContextCompat.checkSelfPermission(context,
-                Manifest.permission.READ_CALENDAR)
-                != PackageManager.PERMISSION_GRANTED) {
+        if (!Utils.isCalendarPermissionGranted(context, true)) {
             //If permission is not granted then just return.
             Log.d(TAG, "Manifest.permission.READ_CALENDAR is not granted");
             return null;
@@ -245,9 +243,7 @@ public class AlarmScheduler {
             // Query the reminders table for the events found.
             Cursor cursor = null;
             try {
-                if (Build.VERSION.SDK_INT >= 23 && ContextCompat.checkSelfPermission(context,
-                        Manifest.permission.READ_CALENDAR)
-                        != PackageManager.PERMISSION_GRANTED) {
+                if (!Utils.isCalendarPermissionGranted(context, false)) {
                     //If permission is not granted then just return.
                     Log.d(TAG, "Manifest.permission.READ_CALENDAR is not granted");
                     return;

--- a/src/com/android/calendar/alerts/AlertReceiver.java
+++ b/src/com/android/calendar/alerts/AlertReceiver.java
@@ -488,9 +488,7 @@ public class AlertReceiver extends BroadcastReceiver {
     }
 
     private static Cursor getAttendeesCursor(Context context, long eventId) {
-        if (Build.VERSION.SDK_INT >= 23 && ContextCompat.checkSelfPermission(context,
-                Manifest.permission.READ_CALENDAR)
-                != PackageManager.PERMISSION_GRANTED) {
+        if (!Utils.isCalendarPermissionGranted(context, false)) {
             //If permission is not granted then just return.
             Log.d(TAG, "Manifest.permission.READ_CALENDAR is not granted");
             return null;

--- a/src/com/android/calendar/alerts/AlertService.java
+++ b/src/com/android/calendar/alerts/AlertService.java
@@ -164,9 +164,7 @@ public class AlertService extends Service {
             Log.d(TAG, "Beginning updateAlertNotification");
         }
 
-        if (Build.VERSION.SDK_INT >= 23 && ContextCompat.checkSelfPermission(context,
-                Manifest.permission.READ_CALENDAR)
-                != PackageManager.PERMISSION_GRANTED) {
+        if (!Utils.isCalendarPermissionGranted(context, false)) {
             //If permission is not granted then just return.
             Log.d(TAG, "Manifest.permission.READ_CALENDAR is not granted");
             return false;
@@ -789,9 +787,7 @@ public class AlertService extends Service {
             CalendarContract.CalendarAlerts.ALARM_TIME,
         };
 
-        if (Build.VERSION.SDK_INT >= 23 && ContextCompat.checkSelfPermission(context,
-                Manifest.permission.READ_CALENDAR)
-                != PackageManager.PERMISSION_GRANTED) {
+        if (!Utils.isCalendarPermissionGranted(context, false)) {
             //If permission is not granted then just return.
             Log.d(TAG, "Manifest.permission.READ_CALENDAR is not granted");
             return;

--- a/src/com/android/calendar/alerts/GlobalDismissManager.java
+++ b/src/com/android/calendar/alerts/GlobalDismissManager.java
@@ -38,6 +38,7 @@ import android.util.Pair;
 
 import com.android.calendar.CloudNotificationBackplane;
 import com.android.calendar.ExtensionsFactory;
+import com.android.calendar.Utils;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -425,9 +426,7 @@ public class GlobalDismissManager extends BroadcastReceiver {
         Map<Long, Long> eventsToCalendars = new HashMap<Long, Long>();
         ContentResolver resolver = context.getContentResolver();
         String eventSelection = buildMultipleIdQuery(eventIds, Events._ID);
-        if (Build.VERSION.SDK_INT >= 23 && ContextCompat.checkSelfPermission(context,
-                Manifest.permission.READ_CALENDAR)
-                != PackageManager.PERMISSION_GRANTED) {
+        if (!Utils.isCalendarPermissionGranted(context, false)) {
             //If permission is not granted then just return.
             Log.d(TAG, "Manifest.permission.READ_CALENDAR is not granted");
             return null;
@@ -461,9 +460,7 @@ public class GlobalDismissManager extends BroadcastReceiver {
                 new HashMap<Long, Pair<String, String>>();
         ContentResolver resolver = context.getContentResolver();
         String calendarSelection = buildMultipleIdQuery(calendars, Calendars._ID);
-        if (Build.VERSION.SDK_INT >= 23 && ContextCompat.checkSelfPermission(context,
-                Manifest.permission.READ_CALENDAR)
-                != PackageManager.PERMISSION_GRANTED) {
+        if (!Utils.isCalendarPermissionGranted(context, false)) {
             //If permission is not granted then just return.
             Log.d(TAG, "Manifest.permission.READ_CALENDAR is not granted");
             return null;

--- a/src/com/android/calendar/event/EditEventFragment.java
+++ b/src/com/android/calendar/event/EditEventFragment.java
@@ -57,6 +57,7 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.view.inputmethod.InputMethodManager;
 import android.widget.LinearLayout;
+import android.widget.TextView;
 import android.widget.Toast;
 
 import com.android.calendar.AsyncQueryService;
@@ -323,11 +324,9 @@ public class EditEventFragment extends Fragment implements EventHandler, OnColor
         }
         mView = new EditEventView(mActivity, view, mOnDone);
 
-        if (Build.VERSION.SDK_INT >= 23 && ContextCompat.checkSelfPermission(mActivity,
-                Manifest.permission.READ_CALENDAR)
-                != PackageManager.PERMISSION_GRANTED) {
+        if (!Utils.isCalendarPermissionGranted(mActivity)) {
             //If permission is not granted
-            Toast.makeText(mActivity, R.string.calendar_permission_not_granted, Toast.LENGTH_LONG).show();
+            ((TextView)view.findViewById(R.id.loading_message)).setText(R.string.calendar_permission_not_granted);
         } else {
             startQuery();
         }

--- a/src/com/android/calendar/event/EditEventFragment.java
+++ b/src/com/android/calendar/event/EditEventFragment.java
@@ -324,7 +324,7 @@ public class EditEventFragment extends Fragment implements EventHandler, OnColor
         }
         mView = new EditEventView(mActivity, view, mOnDone);
 
-        if (!Utils.isCalendarPermissionGranted(mActivity)) {
+        if (!Utils.isCalendarPermissionGranted(mActivity, true)) {
             //If permission is not granted
             ((TextView)view.findViewById(R.id.loading_message)).setText(R.string.calendar_permission_not_granted);
         } else {

--- a/src/com/android/calendar/event/EventLocationAdapter.java
+++ b/src/com/android/calendar/event/EventLocationAdapter.java
@@ -43,6 +43,7 @@ import android.widget.Filterable;
 import android.widget.ImageView;
 import android.widget.TextView;
 
+import com.android.calendar.Utils;
 import com.google.android.material.imageview.ShapeableImageView;
 
 import java.io.InputStream;
@@ -211,9 +212,7 @@ public class EventLocationAdapter extends ArrayAdapter<EventLocationAdapter.Resu
             return null;
         }
 
-        if (Build.VERSION.SDK_INT >= 23 && ContextCompat.checkSelfPermission(context,
-                Manifest.permission.READ_CALENDAR)
-                != PackageManager.PERMISSION_GRANTED) {
+        if (!Utils.isCalendarPermissionGranted(context, true)) {
             //If permission is not granted then just return.
             Log.d(TAG, "Manifest.permission.READ_CALENDAR is not granted");
             return null;

--- a/src/com/android/calendar/month/MonthByWeekFragment.java
+++ b/src/com/android/calendar/month/MonthByWeekFragment.java
@@ -342,10 +342,14 @@ public class MonthByWeekFragment extends SimpleDayPickerFragment implements
         synchronized (mUpdateLoader) {
             mFirstLoadedJulianDay =
                     Time.getJulianDay(mSelectedDay.toMillis(true), mSelectedDay.gmtoff)
-                    - (mNumWeeks * 7 / 2);
+                            - (mNumWeeks * 7 / 2);
             mEventUri = updateUri();
             String where = updateWhere();
 
+            if (!Utils.isCalendarPermissionGranted(mContext)) {
+                //If permission is not granted then return.
+                return null;
+            }
             loader = new CursorLoader(
                     getActivity(), mEventUri, Event.EVENT_PROJECTION, where,
                     null /* WHERE_CALENDARS_SELECTED_ARGS */, INSTANCES_SORT_ORDER);
@@ -356,7 +360,7 @@ public class MonthByWeekFragment extends SimpleDayPickerFragment implements
         }
         return loader;
     }
-    
+
     @Override
     public void doResumeUpdates() {
         mFirstDayOfWeek = Utils.getFirstDayOfWeek(mContext);
@@ -425,8 +429,8 @@ public class MonthByWeekFragment extends SimpleDayPickerFragment implements
             boolean animate = true;
             if (mDaysPerWeek * mNumWeeks * 2 < Math.abs(
                     Time.getJulianDay(event.selectedTime.toMillis(true), event.selectedTime.gmtoff)
-                    - Time.getJulianDay(mFirstVisibleDay.toMillis(true), mFirstVisibleDay.gmtoff)
-                    - mDaysPerWeek * mNumWeeks / 2)) {
+                            - Time.getJulianDay(mFirstVisibleDay.toMillis(true), mFirstVisibleDay.gmtoff)
+                            - mDaysPerWeek * mNumWeeks / 2)) {
                 animate = false;
             }
             mDesiredDay.set(event.selectedTime);

--- a/src/com/android/calendar/month/MonthByWeekFragment.java
+++ b/src/com/android/calendar/month/MonthByWeekFragment.java
@@ -342,11 +342,11 @@ public class MonthByWeekFragment extends SimpleDayPickerFragment implements
         synchronized (mUpdateLoader) {
             mFirstLoadedJulianDay =
                     Time.getJulianDay(mSelectedDay.toMillis(true), mSelectedDay.gmtoff)
-                            - (mNumWeeks * 7 / 2);
+                    - (mNumWeeks * 7 / 2);
             mEventUri = updateUri();
             String where = updateWhere();
 
-            if (!Utils.isCalendarPermissionGranted(mContext)) {
+            if (!Utils.isCalendarPermissionGranted(mContext, true)) {
                 return null;
             }
             loader = new CursorLoader(
@@ -428,8 +428,8 @@ public class MonthByWeekFragment extends SimpleDayPickerFragment implements
             boolean animate = true;
             if (mDaysPerWeek * mNumWeeks * 2 < Math.abs(
                     Time.getJulianDay(event.selectedTime.toMillis(true), event.selectedTime.gmtoff)
-                            - Time.getJulianDay(mFirstVisibleDay.toMillis(true), mFirstVisibleDay.gmtoff)
-                            - mDaysPerWeek * mNumWeeks / 2)) {
+                    - Time.getJulianDay(mFirstVisibleDay.toMillis(true), mFirstVisibleDay.gmtoff)
+                    - mDaysPerWeek * mNumWeeks / 2)) {
                 animate = false;
             }
             mDesiredDay.set(event.selectedTime);

--- a/src/com/android/calendar/month/MonthByWeekFragment.java
+++ b/src/com/android/calendar/month/MonthByWeekFragment.java
@@ -347,7 +347,6 @@ public class MonthByWeekFragment extends SimpleDayPickerFragment implements
             String where = updateWhere();
 
             if (!Utils.isCalendarPermissionGranted(mContext)) {
-                //If permission is not granted then return.
                 return null;
             }
             loader = new CursorLoader(

--- a/src/com/android/calendar/persistence/ContentProviderLiveData.kt
+++ b/src/com/android/calendar/persistence/ContentProviderLiveData.kt
@@ -47,7 +47,7 @@ abstract class ContentProviderLiveData<T>(
     }
 
     override fun onActive() {
-        if (Utils.isCalendarPermissionGranted(context)) {
+        if (Utils.isCalendarPermissionGranted(context, true)) {
             context.contentResolver.registerContentObserver(uri, true, observer)
             getContentProviderValueAsync()
         }

--- a/src/com/android/calendar/persistence/ContentProviderLiveData.kt
+++ b/src/com/android/calendar/persistence/ContentProviderLiveData.kt
@@ -48,7 +48,6 @@ abstract class ContentProviderLiveData<T>(
 
     override fun onActive() {
         if (Utils.isCalendarPermissionGranted(context)) {
-            //If permission is not granted then return.
             context.contentResolver.registerContentObserver(uri, true, observer)
             getContentProviderValueAsync()
         }

--- a/src/com/android/calendar/persistence/ContentProviderLiveData.kt
+++ b/src/com/android/calendar/persistence/ContentProviderLiveData.kt
@@ -21,6 +21,7 @@ import android.content.Context
 import android.database.ContentObserver
 import android.net.Uri
 import androidx.lifecycle.MutableLiveData
+import com.android.calendar.Utils
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.async
@@ -46,8 +47,11 @@ abstract class ContentProviderLiveData<T>(
     }
 
     override fun onActive() {
-        context.contentResolver.registerContentObserver(uri, true, observer)
-        getContentProviderValueAsync()
+        if (Utils.isCalendarPermissionGranted(context)) {
+            //If permission is not granted then return.
+            context.contentResolver.registerContentObserver(uri, true, observer)
+            getContentProviderValueAsync()
+        }
     }
 
     override fun onInactive() {

--- a/src/com/android/calendar/settings/GeneralPreferences.kt
+++ b/src/com/android/calendar/settings/GeneralPreferences.kt
@@ -312,14 +312,17 @@ class GeneralPreferences : PreferenceFragmentCompat(),
 
         when (preference) {
             useHomeTzPref -> {
-                val useHomeTz = newValue as Boolean
-                val tz: String? = if (useHomeTz) {
-                    timeZoneId
-                } else {
-                    CalendarCache.TIMEZONE_TYPE_AUTO
+                if (Utils.isCalendarPermissionGranted(requireContext())) {
+                    //If permission is not granted then return.
+                    val useHomeTz = newValue as Boolean
+                    val tz: String? = if (useHomeTz) {
+                        timeZoneId
+                    } else {
+                        CalendarCache.TIMEZONE_TYPE_AUTO
+                    }
+                    Utils.setTimeZone(activity, tz)
+                    return true
                 }
-                Utils.setTimeZone(activity, tz)
-                return true
             }
             themePref -> {
                 themePref.value = newValue as String

--- a/src/com/android/calendar/settings/GeneralPreferences.kt
+++ b/src/com/android/calendar/settings/GeneralPreferences.kt
@@ -312,7 +312,7 @@ class GeneralPreferences : PreferenceFragmentCompat(),
 
         when (preference) {
             useHomeTzPref -> {
-                if (Utils.isCalendarPermissionGranted(requireContext())) {
+                if (Utils.isCalendarPermissionGranted(requireContext(), true)) {
                     val useHomeTz = newValue as Boolean
                     val tz: String? = if (useHomeTz) {
                         timeZoneId

--- a/src/com/android/calendar/settings/GeneralPreferences.kt
+++ b/src/com/android/calendar/settings/GeneralPreferences.kt
@@ -313,7 +313,6 @@ class GeneralPreferences : PreferenceFragmentCompat(),
         when (preference) {
             useHomeTzPref -> {
                 if (Utils.isCalendarPermissionGranted(requireContext())) {
-                    //If permission is not granted then return.
                     val useHomeTz = newValue as Boolean
                     val tz: String? = if (useHomeTz) {
                         timeZoneId

--- a/src/com/android/calendar/widget/CalendarAppWidgetService.java
+++ b/src/com/android/calendar/widget/CalendarAppWidgetService.java
@@ -607,7 +607,7 @@ public class CalendarAppWidgetService extends RemoteViewsService {
                         mHandler.post(new Runnable() {
                             @Override
                             public void run() {
-                                if (ContextCompat.checkSelfPermission(context, Manifest.permission.READ_CALENDAR) != PackageManager.PERMISSION_GRANTED) {
+                                if (!Utils.isCalendarPermissionGranted(context, true)) {
                                     return;
                                 }
                                 initLoader(selection);


### PR DESCRIPTION
1. Issue: App crashes on multiple screens when Calendar permission is not granted.

### Steps to reproduce the crash:
1. Install the app & click `deny` for the Calendar permission popup
2. Move to MonthView / Agenda View / Settings/ Or perform search operation on any screen. The app crashes.

### Affected Screens:
1. Month View
2. Agenda View
3. Settings
4. Search View

![etar-crash](https://user-images.githubusercontent.com/20037228/127650222-7fbd68c8-3c8e-4c3f-89a2-ec231d7cc1d9.gif)

2. Issue: When Add event screen opened without calendar permission, it says `Loading...` which is misleading. It should show an error message instead of `Loading...`.

<img src="https://user-images.githubusercontent.com/20037228/127657904-49a0427e-c4a8-4d11-9da6-6fda5b9aa9a9.jpg" width="300" height="550">

This is my first PR. Let me know if you have any feedback.
Thank you!