### PR TITLE
Divider color fixes

### DIFF
--- a/res/values/colors.xml
+++ b/res/values/colors.xml
@@ -309,7 +309,7 @@
     <color name="fg_dark_secondary">#99ffffff</color>
     <color name="app_bar_dark">@color/bg_dark</color>
 
-    <color name="grid_line_dark">#424242</color>
+    <color name="grid_line_dark">#999999</color>
 
     <color name="month_bgcolor_dark">@color/bg_dark</color>
     <color name="month_selected_week_bgcolor_dark">#FFDDDDDD</color>

--- a/res/values/colors.xml
+++ b/res/values/colors.xml
@@ -309,7 +309,7 @@
     <color name="fg_dark_secondary">#99ffffff</color>
     <color name="app_bar_dark">@color/bg_dark</color>
 
-    <color name="grid_line_dark">#999999</color>
+    <color name="grid_line_dark">#FF6A6A6A</color>
 
     <color name="month_bgcolor_dark">@color/bg_dark</color>
     <color name="month_selected_week_bgcolor_dark">#FFDDDDDD</color>


### PR DESCRIPTION
### Reproduce:
1. Use `System Dark Mode`
2. Keep `Pure black night mode` off

### Expected:
The divider lines in Day and Week view should be clearly visible. Maybe we can set a lighter shade for divider lines.

### Actual:
The lines are not clearly visible.

### Tested on:
OnePlus Nord, Android 11

### Screenshots with existing color:
<img src="https://user-images.githubusercontent.com/20037228/128308801-92e8a7d0-64f7-451d-9ecc-184fef0f95b0.jpg" width="300" height="660">        <img src="https://user-images.githubusercontent.com/20037228/128308788-0d8dbc82-66ea-44ba-90be-fe275bec121c.jpg" width="300" height="660">

### Screenshots after updating with new color shade:
<img src="https://user-images.githubusercontent.com/20037228/128312822-69c06e91-106e-46f4-9482-606d0f782fdf.jpg" width="300" height="660">        <img src="https://user-images.githubusercontent.com/20037228/128312835-28a5f820-204d-453f-a07e-919019b1233c.jpg" width="300" height="660">

Thank you!