### PR TITLE
Improve strings used in foreground service

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -209,8 +209,9 @@
     <string name="alert_title">Calendar notifications</string>
     <!-- Notification window messages: -->
     <skip/>
-    <string name="foreground_notification_channel_name">Alert sync</string>
-    <string name="foreground_notification_channel_description">Foreground notification required for internal alert sync.</string>
+    <string name="foreground_notification_title">Scheduling new reminders…</string>
+    <string name="foreground_notification_channel_name">Background tasks</string>
+    <string name="foreground_notification_channel_description">Notifications required for internal sync. You can safely hide this channel.</string>
 
     <!-- Event info/edit screen labels:-->
     <skip/>

--- a/src/com/android/calendar/alerts/AlertService.java
+++ b/src/com/android/calendar/alerts/AlertService.java
@@ -64,7 +64,7 @@ import ws.xsoh.etar.R;
  */
 public class AlertService extends Service {
 
-    public static final String ALERT_CHANNEL_ID = "alert_channel_01";// The id of the channel.
+    public static final String ALERT_CHANNEL_ID = "alert_channel_01";
     public static final String FOREGROUND_CHANNEL_ID = "foreground_channel_01";
 
     // Hard limit to the number of notifications displayed.
@@ -925,7 +925,7 @@ public class AlertService extends Service {
 
                 createChannels(this);
                 Notification notification = new NotificationCompat.Builder(this, FOREGROUND_CHANNEL_ID)
-                        .setContentTitle("Event notifications")
+                        .setContentTitle(getString(R.string.foreground_notification_title))
                         .setSmallIcon(R.drawable.stat_notify_calendar)
                         .setShowWhen(false)
                         .build();


### PR DESCRIPTION
From a user perspective this service isn't anything "in foreground", but
rather a background sync. Therefore don't mention "alert" or
"foreground" in the strings of this notification channel.

Also don't hardcode the notification title. "Event notification" sounds
like that this notification is some reminder of an event, but it isn't.