### PR TITLE
Hide debug/experimental preference "CopyDataBase"

### DIFF
--- a/res/xml/general_preferences.xml
+++ b/res/xml/general_preferences.xml
@@ -145,7 +145,8 @@
         app:title="@string/preferences_experimental_category">
         <Preference
             app:key="preferences_copy_db"
-            app:title="@string/copy_db" />
+            app:title="@string/copy_db"
+            app:isPreferenceVisible="false" />
 
         <ListPreference
             app:key="preferences_reminders_responded"


### PR DESCRIPTION
Hide the debug/experimental setting "CopyDataBase" to not confuse users and avoid crashes in the application. Fix #1015 