### PR TITLE
Skip Reminders option is not showing selected preference on the popup

### DIFF
--- a/src/com/android/calendar/settings/GeneralPreferences.kt
+++ b/src/com/android/calendar/settings/GeneralPreferences.kt
@@ -34,6 +34,7 @@ import android.provider.CalendarContract.CalendarCache
 import android.provider.SearchRecentSuggestions
 import android.provider.Settings
 import android.text.TextUtils
+import android.util.Log
 import android.util.SparseIntArray
 import android.widget.Toast
 import androidx.core.content.ContextCompat
@@ -360,7 +361,8 @@ class GeneralPreferences : PreferenceFragmentCompat(),
                 return true
             }
             skipRemindersPref -> {
-                updateSkipRemindersSummary(newValue as String)
+                skipRemindersPref.value = newValue as String
+                skipRemindersPref.summary = skipRemindersPref.entry
             }
             else -> {
                 return true

--- a/src/com/android/calendar/settings/GeneralPreferences.kt
+++ b/src/com/android/calendar/settings/GeneralPreferences.kt
@@ -34,7 +34,6 @@ import android.provider.CalendarContract.CalendarCache
 import android.provider.SearchRecentSuggestions
 import android.provider.Settings
 import android.text.TextUtils
-import android.util.Log
 import android.util.SparseIntArray
 import android.widget.Toast
 import androidx.core.content.ContextCompat


### PR DESCRIPTION
`Skip Reminders` option has two different values, namely `Only if declined` & `If declined or not responded`. Even if we select the second option that is `If declined or not responded`, it always shows the first option(Only if declined) as the selected option.

### Steps:
1. Open `Settings` from the side menu
2. Tap on `General settings`
3. Tap on the last option `Skip Reminders`
4. Select `If declined or not responded` from the popup
5. Again tap on the `Skip Reminders` option
6. It always shows `Only if declined` as the selected option

### Screen Recording

https://user-images.githubusercontent.com/20037228/140657322-ab4831e7-d293-4160-a677-c84a5e99bc19.mp4
