### PR TITLE
Add DecSync and Birthday Adapter to "known" apps and don't crash

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -35,6 +35,8 @@
         <package android:name="at.bitfire.davdroid" />
         <package android:name="com.etesync.syncadapter" />
         <package android:name="com.google.android.gm" />
+        <package android:name="org.birthdayadapter" />
+        <package android:name="org.decsync.cc" />
 
         <intent>
             <action android:name="android.intent.action.VIEW" />

--- a/src/com/android/calendar/settings/CalendarPreferences.kt
+++ b/src/com/android/calendar/settings/CalendarPreferences.kt
@@ -21,6 +21,7 @@ import android.accounts.Account
 import android.accounts.AccountManager
 import android.accounts.AuthenticatorDescription
 import android.content.Intent
+import android.content.pm.PackageManager
 import android.graphics.drawable.Drawable
 import android.os.Bundle
 import android.provider.CalendarContract
@@ -196,13 +197,22 @@ class CalendarPreferences : PreferenceFragmentCompat() {
     private fun getAuthenticatorInfo(account: Account): AuthenticatorInfo? {
         val description = getAuthenticatorDescription(account) ?: return null
 
-        val pm = activity?.packageManager
-        val label = pm?.getResourcesForApplication(description.packageName)?.getString(
+        return try {
+            val pm = activity?.packageManager
+            val label = pm?.getResourcesForApplication(description.packageName)?.getString(
                 description.labelId)
-        val icon = pm?.getDrawable(description.packageName, description.iconId, null)
-        val intent = pm?.getLaunchIntentForPackage(description.packageName)
+            val icon = pm?.getDrawable(description.packageName, description.iconId, null)
+            val intent = pm?.getLaunchIntentForPackage(description.packageName)
 
-        return AuthenticatorInfo(label, icon, intent)
+            AuthenticatorInfo(label, icon, intent)
+
+        } catch (e: PackageManager.NameNotFoundException) {
+            val errorDialog = AlertDialog.Builder(requireActivity())
+                .setMessage("$e")
+                .create()
+            errorDialog.show()
+            return null
+        }
     }
 
     private fun getAuthenticatorDescription(account: Account): AuthenticatorDescription? {


### PR DESCRIPTION
As of API30, the Package Manager can only access a small list of apps.
To display other packages, we have to declare our application's need for
increased package visibility with the <queries> element.

Fix #1025