### PR TITLE
Add missing mutability flags to PendingIntents

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -30,6 +30,7 @@
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.READ_SYNC_SETTINGS" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
 
     <queries>
         <package android:name="at.bitfire.davdroid" />

--- a/src/com/android/calendar/Utils.java
+++ b/src/com/android/calendar/Utils.java
@@ -21,6 +21,7 @@ import static android.provider.CalendarContract.EXTRA_EVENT_BEGIN_TIME;
 import android.Manifest;
 import android.accounts.Account;
 import android.app.Activity;
+import android.app.PendingIntent;
 import android.app.SearchManager;
 import android.content.BroadcastReceiver;
 import android.content.ComponentName;
@@ -112,6 +113,8 @@ public class Utils {
     public static final int YEAR_MAX = 2036;
     public static final String KEY_QUICK_RESPONSES = "preferences_quick_responses";
     public static final String APPWIDGET_DATA_TYPE = "vnd.android.data/update";
+    public static final int PI_FLAG_IMMUTABLE = Build.VERSION.SDK_INT >= 23 ? PendingIntent.FLAG_IMMUTABLE : 0;
+
     // Defines used by the DNA generation code
     static final int DAY_IN_MINUTES = 60 * 24;
     static final int WEEK_IN_MINUTES = DAY_IN_MINUTES * 7;

--- a/src/com/android/calendar/alerts/AlarmScheduler.java
+++ b/src/com/android/calendar/alerts/AlarmScheduler.java
@@ -323,7 +323,7 @@ public class AlarmScheduler {
         Intent intent = new Intent(AlertReceiver.EVENT_REMINDER_APP_ACTION);
         intent.setClass(context, AlertReceiver.class);
         intent.putExtra(CalendarContract.CalendarAlerts.ALARM_TIME, alarmTime);
-        PendingIntent pi = PendingIntent.getBroadcast(context, 0, intent, 0);
+        PendingIntent pi = PendingIntent.getBroadcast(context, 0, intent, Utils.PI_FLAG_IMMUTABLE);
         alarmManager.set(AlarmManager.RTC_WAKEUP, alarmTime, pi);
     }
 }

--- a/src/com/android/calendar/alerts/AlertReceiver.java
+++ b/src/com/android/calendar/alerts/AlertReceiver.java
@@ -110,8 +110,6 @@ public class AlertReceiver extends BroadcastReceiver {
     static PowerManager.WakeLock mStartingService;
     private static Handler sAsyncHandler;
 
-    private static final int PI_FLAG_IMMUTABLE = Build.VERSION.SDK_INT >= 23 ? PendingIntent.FLAG_IMMUTABLE : 0;
-
     static {
         HandlerThread thr = new HandlerThread("AlertReceiver async");
         thr.start();
@@ -186,7 +184,7 @@ public class AlertReceiver extends BroadcastReceiver {
         ContentUris.appendId(builder, eventId);
         ContentUris.appendId(builder, startMillis);
         intent.setData(builder.build());
-        return PendingIntent.getService(context, 0, intent, PendingIntent.FLAG_UPDATE_CURRENT | PI_FLAG_IMMUTABLE);
+        return PendingIntent.getService(context, 0, intent, PendingIntent.FLAG_UPDATE_CURRENT | Utils.PI_FLAG_IMMUTABLE);
     }
 
     private static PendingIntent createSnoozeIntent(Context context, long eventId,
@@ -204,10 +202,10 @@ public class AlertReceiver extends BroadcastReceiver {
 
         if (Utils.useCustomSnoozeDelay(context)) {
             intent.setClass(context, SnoozeDelayActivity.class);
-            return PendingIntent.getActivity(context, 0, intent, PendingIntent.FLAG_UPDATE_CURRENT | PI_FLAG_IMMUTABLE);
+            return PendingIntent.getActivity(context, 0, intent, PendingIntent.FLAG_UPDATE_CURRENT | Utils.PI_FLAG_IMMUTABLE);
         } else {
             intent.setClass(context, SnoozeAlarmsService.class);
-            return PendingIntent.getService(context, 0, intent, PendingIntent.FLAG_UPDATE_CURRENT | PI_FLAG_IMMUTABLE);
+            return PendingIntent.getService(context, 0, intent, PendingIntent.FLAG_UPDATE_CURRENT | Utils.PI_FLAG_IMMUTABLE);
         }
     }
 
@@ -216,7 +214,7 @@ public class AlertReceiver extends BroadcastReceiver {
         clickIntent.setClass(context, AlertActivity.class);
         clickIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
         return PendingIntent.getActivity(context, 0, clickIntent,
-                    PendingIntent.FLAG_ONE_SHOT | PendingIntent.FLAG_UPDATE_CURRENT | PI_FLAG_IMMUTABLE);
+                    PendingIntent.FLAG_ONE_SHOT | PendingIntent.FLAG_UPDATE_CURRENT | Utils.PI_FLAG_IMMUTABLE);
     }
 
     public static NotificationWrapper makeBasicNotification(Context context, String title,
@@ -398,7 +396,7 @@ public class AlertReceiver extends BroadcastReceiver {
         deleteIntent.putExtra(AlertUtils.EVENT_IDS_KEY, eventIds);
         deleteIntent.putExtra(AlertUtils.EVENT_STARTS_KEY, startMillis);
         PendingIntent pendingDeleteIntent = PendingIntent.getService(context, 0, deleteIntent,
-                PendingIntent.FLAG_UPDATE_CURRENT | PI_FLAG_IMMUTABLE);
+                PendingIntent.FLAG_UPDATE_CURRENT | Utils.PI_FLAG_IMMUTABLE);
 
         if (digestTitle == null || digestTitle.length() == 0) {
             digestTitle = res.getString(R.string.no_title_label);
@@ -535,7 +533,7 @@ public class AlertReceiver extends BroadcastReceiver {
                         broadcastIntent.putExtra(EXTRA_EVENT_ID, eventId);
                         return PendingIntent.getBroadcast(context,
                                 Long.valueOf(eventId).hashCode(), broadcastIntent,
-                                PendingIntent.FLAG_CANCEL_CURRENT | PI_FLAG_IMMUTABLE);
+                                PendingIntent.FLAG_CANCEL_CURRENT | Utils.PI_FLAG_IMMUTABLE);
                     }
                 } while (attendeesCursor.moveToNext());
             }
@@ -672,7 +670,7 @@ public class AlertReceiver extends BroadcastReceiver {
                     broadcastIntent.putExtra(EXTRA_EVENT_ID, eventId);
                     return PendingIntent.getBroadcast(context,
                             Long.valueOf(eventId).hashCode(), broadcastIntent,
-                            PendingIntent.FLAG_CANCEL_CURRENT);
+                            PendingIntent.FLAG_CANCEL_CURRENT | Utils.PI_FLAG_IMMUTABLE);
                 }
             }
         }
@@ -723,7 +721,7 @@ public class AlertReceiver extends BroadcastReceiver {
                 broadcastIntent.putExtra(EXTRA_EVENT_ID, eventId);
                 return PendingIntent.getBroadcast(context,
                         Long.valueOf(eventId).hashCode(), broadcastIntent,
-                        PendingIntent.FLAG_CANCEL_CURRENT);
+                        PendingIntent.FLAG_CANCEL_CURRENT | Utils.PI_FLAG_IMMUTABLE);
             }
         }
 

--- a/src/com/android/calendar/alerts/AlertUtils.java
+++ b/src/com/android/calendar/alerts/AlertUtils.java
@@ -132,7 +132,7 @@ public class AlertUtils {
 
         intent.putExtra(CalendarContract.CalendarAlerts.ALARM_TIME, alarmTime);
         PendingIntent pi = PendingIntent.getBroadcast(context, 0, intent,
-                PendingIntent.FLAG_UPDATE_CURRENT);
+                PendingIntent.FLAG_UPDATE_CURRENT | Utils.PI_FLAG_IMMUTABLE);
         manager.set(alarmType, alarmTime, pi);
     }
 

--- a/src/com/android/calendar/widget/CalendarAppWidgetProvider.java
+++ b/src/com/android/calendar/widget/CalendarAppWidgetProvider.java
@@ -29,7 +29,6 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.net.Uri;
-import android.os.Build;
 import android.provider.CalendarContract;
 import android.text.format.DateUtils;
 import android.text.format.Time;
@@ -56,8 +55,6 @@ public class CalendarAppWidgetProvider extends AppWidgetProvider {
     // TODO Move these to Calendar.java
     static final String EXTRA_EVENT_IDS = "com.android.calendar.EXTRA_EVENT_IDS";
 
-    private static final int PI_FLAG_IMMUTABLE = Build.VERSION.SDK_INT >= 23 ? PendingIntent.FLAG_IMMUTABLE : 0;
-
     /**
      * Build {@link ComponentName} describing this specific
      * {@link AppWidgetProvider}
@@ -79,7 +76,7 @@ public class CalendarAppWidgetProvider extends AppWidgetProvider {
         intent.setClass(context, CalendarAppWidgetService.CalendarFactory.class);
         intent.setDataAndType(CalendarContract.CONTENT_URI, Utils.APPWIDGET_DATA_TYPE);
         return PendingIntent.getBroadcast(context, 0 /* no requestCode */, intent,
-                PI_FLAG_IMMUTABLE);
+                Utils.PI_FLAG_IMMUTABLE);
     }
 
     /**
@@ -93,7 +90,7 @@ public class CalendarAppWidgetProvider extends AppWidgetProvider {
                 Intent.FLAG_ACTIVITY_TASK_ON_HOME);
         launchIntent.setClass(context, AllInOneActivity.class);
         return PendingIntent.getActivity(context, 0 /* no requestCode */, launchIntent,
-                PendingIntent.FLAG_UPDATE_CURRENT | PI_FLAG_IMMUTABLE);
+                PendingIntent.FLAG_UPDATE_CURRENT | Utils.PI_FLAG_IMMUTABLE);
     }
 
     /**
@@ -234,7 +231,7 @@ public class CalendarAppWidgetProvider extends AppWidgetProvider {
             launchCalendarIntent
                     .setData(Uri.parse("content://com.android.calendar/time/" + millis));
             final PendingIntent launchCalendarPendingIntent = PendingIntent.getActivity(
-                    context, 0 /* no requestCode */, launchCalendarIntent, PI_FLAG_IMMUTABLE);
+                    context, 0 /* no requestCode */, launchCalendarIntent, Utils.PI_FLAG_IMMUTABLE);
             views.setOnClickPendingIntent(R.id.header, launchCalendarPendingIntent);
 
             // Each list item will call setOnClickExtra() to let the list know


### PR DESCRIPTION
Some were missed in #1038. This fixes crashes like:

```
01-03 13:37:14.347  6732 20592 E AndroidRuntime: FATAL EXCEPTION: AlertService
01-03 13:37:14.347  6732 20592 E AndroidRuntime: Process: li.zhaofeng.etar, PID: 6732
01-03 13:37:14.347  6732 20592 E AndroidRuntime: java.lang.IllegalArgumentException: li.zhaofeng.etar: Targeting S+ (version 31 and above) requires that one of FLAG_IMMUTABLE or FLAG_MUTABLE be specified when creating a PendingIntent.
01-03 13:37:14.347  6732 20592 E AndroidRuntime: Strongly consider using FLAG_IMMUTABLE, only use FLAG_MUTABLE if some functionality depends on the PendingIntent being mutable, e.g. if it needs to be used with inline replies or bubbles.
01-03 13:37:14.347  6732 20592 E AndroidRuntime: 	at android.app.PendingIntent.checkFlags(PendingIntent.java:375)
01-03 13:37:14.347  6732 20592 E AndroidRuntime: 	at android.app.PendingIntent.getBroadcastAsUser(PendingIntent.java:645)
01-03 13:37:14.347  6732 20592 E AndroidRuntime: 	at android.app.PendingIntent.getBroadcast(PendingIntent.java:632)
01-03 13:37:14.347  6732 20592 E AndroidRuntime: 	at com.android.calendar.alerts.AlarmScheduler.scheduleAlarm(AlarmScheduler.java:326)
01-03 13:37:14.347  6732 20592 E AndroidRuntime: 	at com.android.calendar.alerts.AlarmScheduler.queryNextReminderAndSchedule(AlarmScheduler.java:288)
01-03 13:37:14.347  6732 20592 E AndroidRuntime: 	at com.android.calendar.alerts.AlarmScheduler.scheduleNextAlarm(AlarmScheduler.java:113)
01-03 13:37:14.347  6732 20592 E AndroidRuntime: 	at com.android.calendar.alerts.AlarmScheduler.scheduleNextAlarm(AlarmScheduler.java:101)
01-03 13:37:14.347  6732 20592 E AndroidRuntime: 	at com.android.calendar.alerts.AlertService.processMessage(AlertService.java:897)
01-03 13:37:14.347  6732 20592 E AndroidRuntime: 	at com.android.calendar.alerts.AlertService$ServiceHandler.handleMessage(AlertService.java:1112)
01-03 13:37:14.347  6732 20592 E AndroidRuntime: 	at android.os.Handler.dispatchMessage(Handler.java:106)
01-03 13:37:14.347  6732 20592 E AndroidRuntime: 	at android.os.Looper.loopOnce(Looper.java:201)
01-03 13:37:14.347  6732 20592 E AndroidRuntime: 	at android.os.Looper.loop(Looper.java:288)
01-03 13:37:14.347  6732 20592 E AndroidRuntime: 	at android.os.HandlerThread.run(HandlerThread.java:67)
```