### PR TITLE
Follow system accent color in the black Material You theme

### DIFF
--- a/res/values-v31/themes.xml
+++ b/res/values-v31/themes.xml
@@ -82,9 +82,9 @@
         <item name="iconCalendarAccount">@android:color/white</item>
     </style>
     <style name="CalendarAppThemeBlackMonet" parent="Theme.AppCompat.NoActionBar">
-        <item name="colorPrimary">@color/colorPrimary</item>
+        <item name="colorPrimary">@android:color/system_accent1_500</item>
         <item name="colorPrimaryDark">@color/bg_black</item>
-        <item name="colorAccent">@color/colorAccent</item>
+        <item name="colorAccent">@android:color/system_accent2_400</item>
         <item name="light_dark">@android:color/white</item>
         <item name="android:windowBackground">@color/bg_black</item>
         <item name="actionBarPopupTheme">@style/ThemeOverlay.AppCompat.Dark</item>


### PR DESCRIPTION
Fixes the black theme problem in #1080. Now it should use the correct system accent color with the black theme enabled, though in the reporter's situation the color will still not be customizable.

![Screenshot_1641764543](https://user-images.githubusercontent.com/2189609/148702139-ed9e8b02-71b9-4787-8065-1d515ab97a4a.png)
