### PR TITLE
Use real calendar colors with adaptive text color (dark/light)

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -471,6 +471,8 @@
     <string name="preferences_color_purple" translatable="false">Purple</string>
     <string name="preferences_color_pick">Primary color</string>
 
+    <string name="preferences_real_event_colors">Use real event colors</string>
+
     <string name="preferences_pure_black_night_mode">Pure black night mode</string>
 
     <!-- This is the title of a section in the Settings screen for settings

--- a/res/xml-v26/general_preferences.xml
+++ b/res/xml-v26/general_preferences.xml
@@ -33,6 +33,10 @@
             app:entries="@array/pref_color_entries"
             app:entryValues="@array/pref_color_values"
             app:defaultValue="teal" />
+        <SwitchPreference
+            app:key="pref_real_event_colors"
+            app:defaultValue="false"
+            app:title="@string/preferences_real_event_colors" />
         <ListPreference
             app:key="preferences_default_start"
             app:defaultValue="-2"

--- a/res/xml/general_preferences.xml
+++ b/res/xml/general_preferences.xml
@@ -33,6 +33,10 @@
             app:entries="@array/pref_color_entries"
             app:entryValues="@array/pref_color_values"
             app:defaultValue="teal" />
+        <SwitchPreference
+            app:key="pref_real_event_colors"
+            app:defaultValue="false"
+            app:title="@string/preferences_real_event_colors" />
         <ListPreference
             app:key="preferences_default_start"
             app:defaultValue="-2"

--- a/src/com/android/calendar/CalendarColorPickerDialog.java
+++ b/src/com/android/calendar/CalendarColorPickerDialog.java
@@ -178,7 +178,7 @@ public class CalendarColorPickerDialog extends ColorPickerDialog {
                         dismiss();
                         break;
                     }
-                    mSelectedColor = Utils.getDisplayColorFromColor(
+                    mSelectedColor = Utils.getDisplayColorFromColor(activity,
                             cursor.getInt(CALENDARS_INDEX_CALENDAR_COLOR));
                     Uri uri = Colors.CONTENT_URI;
                     String[] args = new String[]{
@@ -199,7 +199,7 @@ public class CalendarColorPickerDialog extends ColorPickerDialog {
                     do {
                         int colorKey = cursor.getInt(COLORS_INDEX_COLOR_KEY);
                         int rawColor = cursor.getInt(COLORS_INDEX_COLOR);
-                        int displayColor = Utils.getDisplayColorFromColor(rawColor);
+                        int displayColor = Utils.getDisplayColorFromColor(activity, rawColor);
                         mColorKeyMap.put(displayColor, colorKey);
                         colors.add(displayColor);
                     } while (cursor.moveToNext());

--- a/src/com/android/calendar/DayView.java
+++ b/src/com/android/calendar/DayView.java
@@ -2861,7 +2861,7 @@ public class DayView extends View implements View.OnCreateContextMenuListener,
                 case Attendees.ATTENDEE_STATUS_ACCEPTED:
                 case Attendees.ATTENDEE_STATUS_TENTATIVE:
                 default:
-                    paint.setColor(Utils.getAdaptiveTextColor(this.getContext(), mEventTextColor, event.color));
+                    paint.setColor(Utils.getAdaptiveTextColor(mContext, mEventTextColor, event.color));
                     break;
             }
 

--- a/src/com/android/calendar/DayView.java
+++ b/src/com/android/calendar/DayView.java
@@ -2856,14 +2856,12 @@ public class DayView extends View implements View.OnCreateContextMenuListener,
                     paint.setColor(event.color);
                     break;
                 case Attendees.ATTENDEE_STATUS_DECLINED:
-                    paint.setColor(mEventTextColor);
                     paint.setAlpha(Utils.DECLINED_EVENT_TEXT_ALPHA);
-                    break;
                 case Attendees.ATTENDEE_STATUS_NONE: // Your own events
                 case Attendees.ATTENDEE_STATUS_ACCEPTED:
                 case Attendees.ATTENDEE_STATUS_TENTATIVE:
                 default:
-                    paint.setColor(mEventTextColor);
+                    paint.setColor(Utils.getAdaptiveTextColor(this.getContext(), mEventTextColor, event.color));
                     break;
             }
 
@@ -2880,7 +2878,7 @@ public class DayView extends View implements View.OnCreateContextMenuListener,
 
             layouts[i] = layout;
         }
-        layout.getPaint().setAlpha(mEventsAlpha);
+        layout.getPaint().setAlpha(Utils.getAdaptiveTextAlpha(mContext, mEventsAlpha, event.color));
         return layout;
     }
 

--- a/src/com/android/calendar/DeleteEventHelper.java
+++ b/src/com/android/calendar/DeleteEventHelper.java
@@ -180,7 +180,7 @@ public class DeleteEventHelper {
                 }
                 cursor.moveToFirst();
                 CalendarEventModel mModel = new CalendarEventModel();
-                EditEventHelper.setModelFromCursor(mModel, cursor);
+                EditEventHelper.setModelFromCursor(mModel, cursor, mContext);
                 cursor.close();
                 DeleteEventHelper.this.delete(mStartMillis, mEndMillis, mModel, mWhichDelete);
             }

--- a/src/com/android/calendar/Event.java
+++ b/src/com/android/calendar/Event.java
@@ -315,7 +315,7 @@ public class Event implements Cloneable {
         // get sorted in the correct order
         cEvents.moveToPosition(-1);
         while (cEvents.moveToNext()) {
-            Event e = generateEventFromCursor(cEvents);
+            Event e = generateEventFromCursor(cEvents, context);
             if (e.startDay > endDay || e.endDay < startDay) {
                 continue;
             }
@@ -327,7 +327,7 @@ public class Event implements Cloneable {
      * @param cEvents Cursor pointing at event
      * @return An event created from the cursor
      */
-    private static Event generateEventFromCursor(Cursor cEvents) {
+    private static Event generateEventFromCursor(Cursor cEvents, Context context) {
         Event e = new Event();
 
         e.id = cEvents.getLong(PROJECTION_EVENT_ID_INDEX);
@@ -343,7 +343,7 @@ public class Event implements Cloneable {
 
         if (!cEvents.isNull(PROJECTION_COLOR_INDEX)) {
             // Read the color from the database
-            e.color = Utils.getDisplayColorFromColor(cEvents.getInt(PROJECTION_COLOR_INDEX));
+            e.color = Utils.getDisplayColorFromColor(context, cEvents.getInt(PROJECTION_COLOR_INDEX));
         } else {
             e.color = mNoColorColor;
         }

--- a/src/com/android/calendar/EventInfoFragment.java
+++ b/src/com/android/calendar/EventInfoFragment.java
@@ -1297,6 +1297,7 @@ public class EventInfoFragment extends DialogFragment implements OnCheckedChange
             boolean eventColorSaved = saveEventColor();
             if (saveReminders() || responseSaved || eventColorSaved) {
                 Toast.makeText(getActivity(), R.string.saving_event, Toast.LENGTH_SHORT).show();
+                Utils.sendUpdateWidgetIntent(mContext);
             }
         }
         super.onStop();
@@ -1609,24 +1610,26 @@ public class EventInfoFragment extends DialogFragment implements OnCheckedChange
     }
 
     private void updateAdaptiveTextAndIconColors() {
-        // TextViews
-        int color = Utils.getAdaptiveTextColor(mContext,
-                mContext.getResources().getColor(R.color.event_info_headline_color), mCurrentColor);
+        if (Utils.getSharedPreference(mContext, GeneralPreferences.KEY_REAL_EVENT_COLORS, false)) {
+            // TextViews
+            int color = Utils.getAdaptiveTextColor(mContext,
+                    mContext.getResources().getColor(R.color.event_info_headline_color), mCurrentColor);
 
-        mWhenDateTime.setTextColor(color);
-        mTitle.setTextColor(color);
-        mWhere.setTextColor(color);
-        mWhenRepeat.setTextColor(color);
-        color = Utils.getAdaptiveTextColor(mContext,
-                mContext.getResources().getColor(R.color.event_info_headline_link_color), mCurrentColor);
-        mWhere.setLinkTextColor(color);
+            mWhenDateTime.setTextColor(color);
+            mTitle.setTextColor(color);
+            mWhere.setTextColor(color);
+            mWhenRepeat.setTextColor(color);
+            color = Utils.getAdaptiveTextColor(mContext,
+                    mContext.getResources().getColor(R.color.event_info_headline_link_color), mCurrentColor);
+            mWhere.setLinkTextColor(color);
 
-        // Icons on Tablet
-        if (mWindowStyle == DIALOG_WINDOW_STYLE) {
-            color = Utils.getAdaptiveTextColor(mContext, Color.WHITE, mCurrentColor);
-            ((ImageButton) mView.findViewById(R.id.edit)).setColorFilter(color);
-            ((ImageButton) mView.findViewById(R.id.delete)).setColorFilter(color);
-            ((ImageButton) mView.findViewById(R.id.change_color)).setColorFilter(color);
+            // Icons on Tablet
+            if (mWindowStyle == DIALOG_WINDOW_STYLE) {
+                color = Utils.getAdaptiveTextColor(mContext, Color.WHITE, mCurrentColor);
+                ((ImageButton) mView.findViewById(R.id.edit)).setColorFilter(color);
+                ((ImageButton) mView.findViewById(R.id.delete)).setColorFilter(color);
+                ((ImageButton) mView.findViewById(R.id.change_color)).setColorFilter(color);
+            }
         }
     }
 

--- a/src/com/android/calendar/EventInfoFragment.java
+++ b/src/com/android/calendar/EventInfoFragment.java
@@ -19,7 +19,6 @@ package com.android.calendar;
 import static android.provider.CalendarContract.EXTRA_EVENT_ALL_DAY;
 import static android.provider.CalendarContract.EXTRA_EVENT_BEGIN_TIME;
 import static android.provider.CalendarContract.EXTRA_EVENT_END_TIME;
-
 import static com.android.calendar.CalendarController.EVENT_EDIT_ON_LAUNCH;
 
 import android.animation.Animator;
@@ -1517,7 +1516,8 @@ public class EventInfoFragment extends DialogFragment implements OnCheckedChange
             displayedDatetime += "  " + displayedTimezone;
             SpannableStringBuilder sb = new SpannableStringBuilder(displayedDatetime);
             ForegroundColorSpan transparentColorSpan = new ForegroundColorSpan(
-                    resources.getColor(R.color.event_info_headline_transparent_color));
+                    Utils.getAdaptiveTextColor(context,
+                        resources.getColor(R.color.event_info_headline_transparent_color), mCurrentColor));
             sb.setSpan(transparentColorSpan, timezoneIndex, displayedDatetime.length(),
                     Spannable.SPAN_INCLUSIVE_INCLUSIVE);
             setTextCommon(view, R.id.when_datetime, sb);
@@ -1553,6 +1553,10 @@ public class EventInfoFragment extends DialogFragment implements OnCheckedChange
             final TextView textView = mWhere;
             if (textView != null) {
                 textView.setAutoLinkMask(0);
+                final int textColor = Utils.getAdaptiveTextColor(context,
+                        getResources().getColor(R.color.event_info_headline_color), mCurrentColor);
+                textView.setTextColor(textColor);
+                textView.setLinkTextColor(textColor);
                 textView.setText(location.trim());
                 try {
                     textView.setText(Utils.extendedLinkify(textView.getText().toString(), true));
@@ -1984,6 +1988,11 @@ public class EventInfoFragment extends DialogFragment implements OnCheckedChange
         TextView textView = (TextView) view.findViewById(id);
         if (textView == null)
             return;
+
+        final int textColor = Utils.getAdaptiveTextColor(mContext,
+                getResources().getColor(R.color.event_info_headline_color), mCurrentColor);
+        textView.setTextColor(textColor);
+        textView.setLinkTextColor(textColor);
         textView.setText(text);
     }
 
@@ -2246,7 +2255,7 @@ public class EventInfoFragment extends DialogFragment implements OnCheckedChange
     public void onColorSelected(int color) {
         mCurrentColor = color;
         mCurrentColorKey = mDisplayColorKeyMap.get(color);
-        mHeadlines.setBackgroundColor(color);
+        updateEvent(mView);
     }
 
     private class QueryHandler extends AsyncQueryService {
@@ -2273,14 +2282,14 @@ public class EventInfoFragment extends DialogFragment implements OnCheckedChange
                         return;
                     }
                     if (!mCalendarColorInitialized) {
-                        mCalendarColor = Utils.getDisplayColorFromColor(
+                        mCalendarColor = Utils.getDisplayColorFromColor(activity,
                                 mEventCursor.getInt(EVENT_INDEX_CALENDAR_COLOR));
                         mCalendarColorInitialized = true;
                     }
 
                     if (!mOriginalColorInitialized) {
                         mOriginalColor = mEventCursor.isNull(EVENT_INDEX_EVENT_COLOR)
-                                ? mCalendarColor : Utils.getDisplayColorFromColor(
+                                ? mCalendarColor : Utils.getDisplayColorFromColor(activity,
                                 mEventCursor.getInt(EVENT_INDEX_EVENT_COLOR));
                         mOriginalColorInitialized = true;
                     }
@@ -2339,7 +2348,7 @@ public class EventInfoFragment extends DialogFragment implements OnCheckedChange
                         do {
                             String colorKey = cursor.getString(COLORS_INDEX_COLOR_KEY);
                             int rawColor = cursor.getInt(COLORS_INDEX_COLOR);
-                            int displayColor = Utils.getDisplayColorFromColor(rawColor);
+                            int displayColor = Utils.getDisplayColorFromColor(activity, rawColor);
                             mDisplayColorKeyMap.put(displayColor, colorKey);
                             colors.add(displayColor);
                         } while (cursor.moveToNext());

--- a/src/com/android/calendar/Utils.java
+++ b/src/com/android/calendar/Utils.java
@@ -905,7 +905,7 @@ public class Utils {
     }
 
     /**
-     * If "real event colors" is enabled it returns an alpha value to dimm the event texts slightly.
+     * If "real event colors" is enabled it returns an alpha value to dim the event texts slightly.
      * Alphas are not the same for dark and light colors
      *
      * @param context

--- a/src/com/android/calendar/agenda/AgendaAdapter.java
+++ b/src/com/android/calendar/agenda/AgendaAdapter.java
@@ -165,7 +165,7 @@ public class AgendaAdapter extends ResourceCursorAdapter {
         holder.instanceId = cursor.getLong(AgendaWindowAdapter.INDEX_INSTANCE_ID);
 
         /* Calendar Color */
-        int color = Utils.getDisplayColorFromColor(cursor.getInt(AgendaWindowAdapter.INDEX_COLOR));
+        int color = Utils.getDisplayColorFromColor(context, cursor.getInt(AgendaWindowAdapter.INDEX_COLOR));
         holder.colorChip.setColor(color);
 
         // What

--- a/src/com/android/calendar/alerts/AlertAdapter.java
+++ b/src/com/android/calendar/alerts/AlertAdapter.java
@@ -117,7 +117,7 @@ public class AlertAdapter extends ResourceCursorAdapter {
     @Override
     public void bindView(View view, Context context, Cursor cursor) {
         View square = view.findViewById(R.id.color_square);
-        int color = Utils.getDisplayColorFromColor(cursor.getInt(AlertActivity.INDEX_COLOR));
+        int color = Utils.getDisplayColorFromColor(context, cursor.getInt(AlertActivity.INDEX_COLOR));
         square.setBackgroundColor(color);
 
         // Repeating info

--- a/src/com/android/calendar/event/CreateEventDialogFragment.java
+++ b/src/com/android/calendar/event/CreateEventDialogFragment.java
@@ -296,7 +296,7 @@ public class CreateEventDialogFragment extends DialogFragment implements TextWat
 
         mCalendarId = cursor.getLong(calendarIdIndex);
         mCalendarOwner = cursor.getString(calendarOwnerIndex);
-        mColor.setBackgroundColor(Utils.getDisplayColorFromColor(cursor
+        mColor.setBackgroundColor(Utils.getDisplayColorFromColor(getActivity(), cursor
                 .getInt(colorIndex)));
         String accountName = cursor.getString(accountNameIndex);
         String calendarName = cursor.getString(calendarNameIndex);

--- a/src/com/android/calendar/event/EditEventFragment.java
+++ b/src/com/android/calendar/event/EditEventFragment.java
@@ -676,8 +676,8 @@ public class EditEventFragment extends Fragment implements EventHandler, OnColor
                         return;
                     }
                     mOriginalModel = new CalendarEventModel();
-                    EditEventHelper.setModelFromCursor(mOriginalModel, cursor);
-                    EditEventHelper.setModelFromCursor(mModel, cursor);
+                    EditEventHelper.setModelFromCursor(mOriginalModel, cursor, activity);
+                    EditEventHelper.setModelFromCursor(mModel, cursor, activity);
                     cursor.close();
 
                     mOriginalModel.mUri = mUri.toString();
@@ -829,8 +829,8 @@ public class EditEventFragment extends Fragment implements EventHandler, OnColor
                                     mCalendarId);
                         } else {
                             // Populate model for an existing event
-                            EditEventHelper.setModelFromCalendarCursor(mModel, cursor);
-                            EditEventHelper.setModelFromCalendarCursor(mOriginalModel, cursor);
+                            EditEventHelper.setModelFromCalendarCursor(mModel, cursor, activity);
+                            EditEventHelper.setModelFromCalendarCursor(mOriginalModel, cursor, activity);
                         }
                     } finally {
                         cursor.close();
@@ -843,7 +843,7 @@ public class EditEventFragment extends Fragment implements EventHandler, OnColor
                         do {
                             String colorKey = cursor.getString(EditEventHelper.COLORS_INDEX_COLOR_KEY);
                             int rawColor = cursor.getInt(EditEventHelper.COLORS_INDEX_COLOR);
-                            int displayColor = Utils.getDisplayColorFromColor(rawColor);
+                            int displayColor = Utils.getDisplayColorFromColor(activity, rawColor);
                             String accountName = cursor
                                     .getString(EditEventHelper.COLORS_INDEX_ACCOUNT_NAME);
                             String accountType = cursor

--- a/src/com/android/calendar/event/EditEventHelper.java
+++ b/src/com/android/calendar/event/EditEventHelper.java
@@ -1042,7 +1042,7 @@ public class EditEventHelper {
      * @param model The model to fill in
      * @param cursor An event cursor that used {@link #EVENT_PROJECTION} for the query
      */
-    public static void setModelFromCursor(CalendarEventModel model, Cursor cursor) {
+    public static void setModelFromCursor(CalendarEventModel model, Cursor cursor, Context context) {
         if (model == null || cursor == null || cursor.getCount() != 1) {
             Log.wtf(TAG, "Attempted to build non-existent model or from an incorrect query.");
             return;
@@ -1087,7 +1087,7 @@ public class EditEventHelper {
         } else {
             rawEventColor = cursor.getInt(EVENT_INDEX_EVENT_COLOR);
         }
-        model.setEventColor(Utils.getDisplayColorFromColor(rawEventColor));
+        model.setEventColor(Utils.getDisplayColorFromColor(context, rawEventColor));
 
         model.mAccessLevel = accessLevel;
         model.mEventStatus = cursor.getInt(EVENT_INDEX_EVENT_STATUS);
@@ -1113,7 +1113,7 @@ public class EditEventHelper {
      * @param cursor An event cursor that used {@link #CALENDARS_PROJECTION} for the query
      * @return returns true if model was updated with the info in the cursor.
      */
-    public static boolean setModelFromCalendarCursor(CalendarEventModel model, Cursor cursor) {
+    public static boolean setModelFromCalendarCursor(CalendarEventModel model, Cursor cursor, Context context) {
         if (model == null || cursor == null) {
             Log.wtf(TAG, "Attempted to build non-existent model or from an incorrect query.");
             return false;
@@ -1139,7 +1139,7 @@ public class EditEventHelper {
 
             model.mCalendarAccessLevel = cursor.getInt(CALENDARS_INDEX_ACCESS_LEVEL);
             model.mCalendarDisplayName = cursor.getString(CALENDARS_INDEX_DISPLAY_NAME);
-            model.setCalendarColor(Utils.getDisplayColorFromColor(
+            model.setCalendarColor(Utils.getDisplayColorFromColor(context,
                     cursor.getInt(CALENDARS_INDEX_COLOR)));
 
             model.mCalendarAccountName = cursor.getString(CALENDARS_INDEX_ACCOUNT_NAME);

--- a/src/com/android/calendar/event/EditEventView.java
+++ b/src/com/android/calendar/event/EditEventView.java
@@ -1467,7 +1467,7 @@ public class EditEventView implements View.OnClickListener, DialogInterface.OnCa
         long calendarId = c.getLong(idColumn);
         int colorColumn = c.getColumnIndexOrThrow(Calendars.CALENDAR_COLOR);
         int color = c.getInt(colorColumn);
-        int displayColor = Utils.getDisplayColorFromColor(color);
+        int displayColor = Utils.getDisplayColorFromColor(mActivity, color);
 
         // Prevents resetting of data (reminders, etc.) on orientation change.
         if (calendarId == mModel.mCalendarId && mModel.isCalendarColorInitialized() &&
@@ -1597,8 +1597,8 @@ public class EditEventView implements View.OnClickListener, DialogInterface.OnCa
             int nameColumn = cursor.getColumnIndexOrThrow(Calendars.CALENDAR_DISPLAY_NAME);
             int ownerColumn = cursor.getColumnIndexOrThrow(Calendars.OWNER_ACCOUNT);
             if (colorBar != null) {
-                colorBar.setBackgroundColor(Utils.getDisplayColorFromColor(cursor
-                        .getInt(colorColumn)));
+                colorBar.setBackgroundColor(Utils.getDisplayColorFromColor(context,
+                        cursor.getInt(colorColumn)));
             }
 
             TextView name = (TextView) view.findViewById(R.id.calendar_name);

--- a/src/com/android/calendar/month/MonthWeekEventsView.java
+++ b/src/com/android/calendar/month/MonthWeekEventsView.java
@@ -1594,7 +1594,10 @@ public class MonthWeekEventsView extends SimpleWeekView {
 
             if (!isAttendeeStatusInvited() && mEvent.drawAsAllday()){
                 // Text color needs to contrast with solid background.
-                paint = mSolidBackgroundEventPaint;
+                // Make a copy of mSolidBackgroundEventPaint to apply the adaptive text color
+                TextPaint mEventTextPaint = new TextPaint(mSolidBackgroundEventPaint);
+                mEventTextPaint.setColor(Utils.getAdaptiveTextColor(mContext, mEventTextPaint.getColor(), mEvent.color));
+                paint = mEventTextPaint;
             } else if (isDeclined()) {
                 // Use "declined event" color.
                 paint = mDeclinedEventPaint;

--- a/src/com/android/calendar/selectcalendars/SelectCalendarsSimpleAdapter.java
+++ b/src/com/android/calendar/selectcalendars/SelectCalendarsSimpleAdapter.java
@@ -156,7 +156,7 @@ public class SelectCalendarsSimpleAdapter extends BaseAdapter implements ListAda
         String name = mData[position].displayName;
         boolean selected = mData[position].selected;
 
-        int color = Utils.getDisplayColorFromColor(mData[position].color);
+        int color = Utils.getDisplayColorFromColor(convertView.getContext(), mData[position].color);
         View view;
         if (convertView == null) {
             view = mInflater.inflate(mLayout, parent, false);

--- a/src/com/android/calendar/selectcalendars/SelectCalendarsSimpleAdapter.java
+++ b/src/com/android/calendar/selectcalendars/SelectCalendarsSimpleAdapter.java
@@ -156,7 +156,6 @@ public class SelectCalendarsSimpleAdapter extends BaseAdapter implements ListAda
         String name = mData[position].displayName;
         boolean selected = mData[position].selected;
 
-        int color = Utils.getDisplayColorFromColor(convertView.getContext(), mData[position].color);
         View view;
         if (convertView == null) {
             view = mInflater.inflate(mLayout, parent, false);
@@ -178,6 +177,7 @@ public class SelectCalendarsSimpleAdapter extends BaseAdapter implements ListAda
         } else {
             view = convertView;
         }
+        int color = Utils.getDisplayColorFromColor(view.getContext(), mData[position].color);
 
         TextView calendarName = (TextView) view.findViewById(R.id.calendar);
         calendarName.setText(name);

--- a/src/com/android/calendar/settings/CalendarColorPickerDialogX.kt
+++ b/src/com/android/calendar/settings/CalendarColorPickerDialogX.kt
@@ -156,7 +156,7 @@ class CalendarColorPickerDialogX : ColorPickerDialogX() {
                         dismiss()
                         return
                     }
-                    mSelectedColor = Utils.getDisplayColorFromColor(cursor.getInt(CALENDARS_INDEX_CALENDAR_COLOR))
+                    mSelectedColor = Utils.getDisplayColorFromColor(activity, cursor.getInt(CALENDARS_INDEX_CALENDAR_COLOR))
                     val account = Account(cursor.getString(CALENDARS_INDEX_ACCOUNT_NAME),
                             cursor.getString(CALENDARS_INDEX_ACCOUNT_TYPE))
                     cursor.close()
@@ -184,7 +184,7 @@ class CalendarColorPickerDialogX : ColorPickerDialogX() {
         do {
             val colorKey = cursor.getInt(COLORS_INDEX_COLOR_KEY)
             val rawColor = cursor.getInt(COLORS_INDEX_COLOR)
-            val displayColor = Utils.getDisplayColorFromColor(rawColor)
+            val displayColor = Utils.getDisplayColorFromColor(activity, rawColor)
             colorKeyMap.put(displayColor, colorKey)
             colors.add(displayColor)
         } while (cursor.moveToNext())

--- a/src/com/android/calendar/settings/GeneralPreferences.kt
+++ b/src/com/android/calendar/settings/GeneralPreferences.kt
@@ -292,6 +292,9 @@ class GeneralPreferences : PreferenceFragmentCompat(),
                     a.recreate()
                 }
             }
+            KEY_REAL_EVENT_COLORS -> {
+                Utils.sendUpdateWidgetIntent(a)
+            }
         }
     }
 

--- a/src/com/android/calendar/settings/GeneralPreferences.kt
+++ b/src/com/android/calendar/settings/GeneralPreferences.kt
@@ -62,6 +62,7 @@ class GeneralPreferences : PreferenceFragmentCompat(),
 
     private lateinit var themePref: ListPreference
     private lateinit var colorPref: Preference
+    private lateinit var realEventColors: SwitchPreference
     private lateinit var pureBlackNightModePref: SwitchPreference
     private lateinit var defaultStartPref: ListPreference
     private lateinit var hideDeclinedPref: SwitchPreference
@@ -105,6 +106,7 @@ class GeneralPreferences : PreferenceFragmentCompat(),
 
         themePref = preferenceScreen.findPreference(KEY_THEME_PREF)!!
         colorPref = preferenceScreen.findPreference(KEY_COLOR_PREF)!!
+        realEventColors = preferenceScreen.findPreference(KEY_REAL_EVENT_COLORS)!!
         pureBlackNightModePref = preferenceScreen.findPreference(KEY_PURE_BLACK_NIGHT_MODE)!!
         defaultStartPref = preferenceScreen.findPreference(KEY_DEFAULT_START)!!
         hideDeclinedPref = preferenceScreen.findPreference(KEY_HIDE_DECLINED)!!
@@ -506,6 +508,7 @@ class GeneralPreferences : PreferenceFragmentCompat(),
         // Preference keys
         const val KEY_THEME_PREF = "pref_theme"
         const val KEY_COLOR_PREF = "pref_color"
+        const val KEY_REAL_EVENT_COLORS = "pref_real_event_colors"
         const val KEY_PURE_BLACK_NIGHT_MODE = "pref_pure_black_night_mode"
         const val KEY_DEFAULT_START = "preferences_default_start"
         const val KEY_HIDE_DECLINED = "preferences_hide_declined"

--- a/src/com/android/calendar/widget/CalendarAppWidgetService.java
+++ b/src/com/android/calendar/widget/CalendarAppWidgetService.java
@@ -293,6 +293,7 @@ public class CalendarAppWidgetService extends RemoteViewsService {
                 }
                 int displayColor = Utils.getDisplayColorFromColor(mContext, eventInfo.color);
                 int adaptiveTextColor = Utils.getAdaptiveTextColor(mContext, mStandardColor, displayColor);
+                int adaptiveAllDayTextColor = Utils.getAdaptiveTextColor(mContext, mAllDayColor, displayColor);
 
                 final long now = System.currentTimeMillis();
                 if (!eventInfo.allDay && eventInfo.start <= now && now <= eventInfo.end) {
@@ -320,7 +321,7 @@ public class CalendarAppWidgetService extends RemoteViewsService {
                     } else {
                         views.setInt(R.id.agenda_item_color, "setImageResource",
                                 R.drawable.widget_chip_responded_bg);
-                        views.setInt(R.id.title, "setTextColor", mAllDayColor);
+                        views.setInt(R.id.title, "setTextColor", adaptiveAllDayTextColor);
                     }
                     if (selfAttendeeStatus == Attendees.ATTENDEE_STATUS_DECLINED) {
                         // 40% opacity

--- a/src/com/android/calendar/widget/CalendarAppWidgetService.java
+++ b/src/com/android/calendar/widget/CalendarAppWidgetService.java
@@ -291,7 +291,7 @@ public class CalendarAppWidgetService extends RemoteViewsService {
                 } else {
                     views = new RemoteViews(mContext.getPackageName(), R.layout.widget_item);
                 }
-                int displayColor = Utils.getDisplayColorFromColor(eventInfo.color);
+                int displayColor = Utils.getDisplayColorFromColor(mContext, eventInfo.color);
 
                 final long now = System.currentTimeMillis();
                 if (!eventInfo.allDay && eventInfo.start <= now && now <= eventInfo.end) {
@@ -348,9 +348,9 @@ public class CalendarAppWidgetService extends RemoteViewsService {
                     } else {
                         views.setInt(R.id.agenda_item_color, "setImageResource",
                                 R.drawable.widget_chip_responded_bg);
-                        views.setInt(R.id.title, "setTextColor", mStandardColor);
-                        views.setInt(R.id.when, "setTextColor", mStandardColor);
-                        views.setInt(R.id.where, "setTextColor", mStandardColor);
+                        views.setInt(R.id.title, "setTextColor", Utils.getAdaptiveTextColor(mContext, mStandardColor, displayColor));
+                        views.setInt(R.id.when, "setTextColor", Utils.getAdaptiveTextColor(mContext, mStandardColor, displayColor));
+                        views.setInt(R.id.where, "setTextColor", Utils.getAdaptiveTextColor(mContext, mStandardColor, displayColor));
                     }
                     views.setInt(R.id.agenda_item_color, "setColorFilter", displayColor);
                 }

--- a/src/com/android/calendar/widget/CalendarAppWidgetService.java
+++ b/src/com/android/calendar/widget/CalendarAppWidgetService.java
@@ -292,6 +292,7 @@ public class CalendarAppWidgetService extends RemoteViewsService {
                     views = new RemoteViews(mContext.getPackageName(), R.layout.widget_item);
                 }
                 int displayColor = Utils.getDisplayColorFromColor(mContext, eventInfo.color);
+                int adaptiveTextColor = Utils.getAdaptiveTextColor(mContext, mStandardColor, displayColor);
 
                 final long now = System.currentTimeMillis();
                 if (!eventInfo.allDay && eventInfo.start <= now && now <= eventInfo.end) {
@@ -348,9 +349,9 @@ public class CalendarAppWidgetService extends RemoteViewsService {
                     } else {
                         views.setInt(R.id.agenda_item_color, "setImageResource",
                                 R.drawable.widget_chip_responded_bg);
-                        views.setInt(R.id.title, "setTextColor", Utils.getAdaptiveTextColor(mContext, mStandardColor, displayColor));
-                        views.setInt(R.id.when, "setTextColor", Utils.getAdaptiveTextColor(mContext, mStandardColor, displayColor));
-                        views.setInt(R.id.where, "setTextColor", Utils.getAdaptiveTextColor(mContext, mStandardColor, displayColor));
+                        views.setInt(R.id.title, "setTextColor", adaptiveTextColor);
+                        views.setInt(R.id.when, "setTextColor", adaptiveTextColor);
+                        views.setInt(R.id.where, "setTextColor", adaptiveTextColor);
                     }
                     views.setInt(R.id.agenda_item_color, "setColorFilter", displayColor);
                 }


### PR DESCRIPTION
This adds the option to use the real calendar/event colors without the dark overlay. To make it work with light background colors it detects the brightness and switches to black text color.

Works on all views including the widget.

Solves this issue: #803 

Feel free to test it. Any feedback very much appreciated.

Don't know if it's better to remove the toggle switch entirely and make this the default behavior, but existing users might wanna stick to the classic rendering...

Before / After
![Screenshot_1642686103-small](https://user-images.githubusercontent.com/57636587/150360049-5d252140-cb92-408d-8b6b-5e964230c721.png)
![Screenshot_1642686145-small](https://user-images.githubusercontent.com/57636587/150360084-fe5f6cbe-60f2-46ed-9560-7ec0040a6306.png)

![Screenshot_1642686130-small](https://user-images.githubusercontent.com/57636587/150360122-c0c7dcc0-7b0b-469d-9638-245b7b6c88d0.png)
![Screenshot_1642686150-small](https://user-images.githubusercontent.com/57636587/150360145-34bef079-4b94-4d34-bc2b-2c1755d76732.png)

![Screenshot_1642687242-small](https://user-images.githubusercontent.com/57636587/150360167-f469b0a4-fc2b-4362-9a9c-520edbf82a85.png)

