### PR TITLE
Repair display of reminders with negative values

### DIFF
--- a/src/com/android/calendar/event/EventViewUtils.java
+++ b/src/com/android/calendar/event/EventViewUtils.java
@@ -49,14 +49,7 @@ public class EventViewUtils {
         Resources resources = context.getResources();
         int value, resId;
 
-        if (minutes < 0) {
-            value = 0;
-            resId = R.string.no_reminder_label;
-
-            String format = resources.getString(resId, value);
-            return String.format(format, value);
-
-        } else if (minutes % 60 != 0 || minutes == 0) {
+        if (minutes % 60 != 0 || minutes == 0) {
             value = minutes;
             if (abbrev) {
                 resId = R.plurals.Nmins;


### PR DESCRIPTION
E.g. for birthdays (whole day event) I have set a reminder at 9:00am, so after the start of the event.
The reminder works, but is not displayed currently because if
minutes < 0 reminders are ignored in EventViewUtils.java
(in the past that worked but it was changed with commit 032913f87c4256909d1911a9f1959849232d93a1)


