### PR TITLE
Set individual reminder, before or after start of event

### DIFF
--- a/res/layout/manual_reminder.xml
+++ b/res/layout/manual_reminder.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+    <EditText
+        android:id="@+id/EditMinutes"
+        android:layout_width="match_parent"
+        android:gravity="center"
+        android:inputType="number"
+        android:layout_height="wrap_content"/>
+
+    <CheckBox
+        android:id="@+id/CheckAfterStart"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/after_begin_of_event"/>
+
+</LinearLayout>

--- a/res/values-af/strings.xml
+++ b/res/values-af/strings.xml
@@ -243,4 +243,7 @@
     <string name="preferences_default_snooze_delay_title">Standaard sluimer vertragings tyd</string>
     <string name="preferences_default_snooze_delay_dialog">Standaard sluimer vertraging</string>
     <string name="no_reminder_label">Geen</string>
+    <string name="manual_reminder_label">Manual</string>
+    <string name="time_in_minutes">Time in minutes</string>
+    <string name="after_begin_of_event">after begin of event</string>
 </resources>

--- a/res/values-am/strings.xml
+++ b/res/values-am/strings.xml
@@ -237,4 +237,7 @@
     <string name="visibility_private">የግል</string>
     <string name="visibility_public">ሕዝብ</string>
     <string name="no_reminder_label">የለም</string>
+    <string name="manual_reminder_label">Manual</string>
+    <string name="time_in_minutes">Time in minutes</string>
+    <string name="after_begin_of_event">after begin of event</string>
 </resources>

--- a/res/values-ar/strings.xml
+++ b/res/values-ar/strings.xml
@@ -343,4 +343,7 @@
     <string name="rsvp_declined">تمت الإجابة بلا.</string>
     <string name="rsvp_tentative">تمت الإحابة بمحتمل.</string>
     <string name="no_reminder_label">لا شيء</string>
+    <string name="manual_reminder_label">Manual</string>
+    <string name="time_in_minutes">Time in minutes</string>
+    <string name="after_begin_of_event">after begin of event</string>
 </resources>

--- a/res/values-be/strings.xml
+++ b/res/values-be/strings.xml
@@ -292,4 +292,7 @@
     <string name="one_and_a_half_hours">1.5 гадзіны</string>
     <string name="two_hours">2 гадзіны</string>
     <string name="no_reminder_label">Няма</string>
+    <string name="manual_reminder_label">Manual</string>
+    <string name="time_in_minutes">Time in minutes</string>
+    <string name="after_begin_of_event">after begin of event</string>
 </resources>

--- a/res/values-bg/strings.xml
+++ b/res/values-bg/strings.xml
@@ -237,4 +237,7 @@
     <string name="visibility_private">Частно</string>
     <string name="visibility_public">Обществено</string>
     <string name="no_reminder_label">Няма</string>
+    <string name="manual_reminder_label">Manual</string>
+    <string name="time_in_minutes">Time in minutes</string>
+    <string name="after_begin_of_event">after begin of event</string>
 </resources>

--- a/res/values-bn-rBD/strings.xml
+++ b/res/values-bn-rBD/strings.xml
@@ -147,4 +147,7 @@
     <string name="preferences_title">সেটিংস</string>
     <string name="yearly_plain">বার্ষিক</string>
     <string name="monthly">মাসিক</string>
+    <string name="manual_reminder_label">Manual</string>
+    <string name="time_in_minutes">Time in minutes</string>
+    <string name="after_begin_of_event">after begin of event</string>
 </resources>

--- a/res/values-ca/strings.xml
+++ b/res/values-ca/strings.xml
@@ -339,6 +339,9 @@
     <string name="preferences_list_add_remote">Afegeix un calendari CalDAV</string>
     <string name="no_reminder_label">Cap</string>
     <string name="foreground_notification_title">Planificant nous recordatoris…</string>
+    <string name="manual_reminder_label">Manual</string>
+    <string name="time_in_minutes">Time in minutes</string>
+    <string name="after_begin_of_event">after begin of event</string>
     <plurals name="Nweeks">
         <item quantity="one">1 setmana</item>
         <item quantity="other"><xliff:g id="count">%d</xliff:g> setmanes</item>

--- a/res/values-cs/strings.xml
+++ b/res/values-cs/strings.xml
@@ -243,4 +243,7 @@
     <string name="preferences_default_snooze_delay_title">Výchozí délka odložení</string>
     <string name="preferences_default_snooze_delay_dialog">Výchozí délka odložení</string>
     <string name="no_reminder_label">Žádný</string>
+    <string name="manual_reminder_label">Manual</string>
+    <string name="time_in_minutes">Time in minutes</string>
+    <string name="after_begin_of_event">after begin of event</string>
 </resources>

--- a/res/values-cy/strings.xml
+++ b/res/values-cy/strings.xml
@@ -360,4 +360,7 @@
     <string name="maximum_number_of_lines">Uchafswm o linellau ar gyfer digwyddiad</string>
     <string name="foreground_notification_channel_name">Cydamseriad Hysbysiadau</string>
     <string name="foreground_notification_channel_description">Hysbysiad blaendir angenrheidiol er cydamseru hysbysiadau mewnol. I\'w ddistewi.</string>
+    <string name="manual_reminder_label">Manual</string>
+    <string name="time_in_minutes">Time in minutes</string>
+    <string name="after_begin_of_event">after begin of event</string>
 </resources>

--- a/res/values-da/strings.xml
+++ b/res/values-da/strings.xml
@@ -319,4 +319,7 @@
     <string name="preferences_calendar_number_of_events">%1d begivenheder</string>
     <string name="preferences_calendar_info_category">Kalendar information</string>
     <string name="no_reminder_label">Ingen</string>
+    <string name="manual_reminder_label">Manual</string>
+    <string name="time_in_minutes">Time in minutes</string>
+    <string name="after_begin_of_event">after begin of event</string>
 </resources>

--- a/res/values-de/strings.xml
+++ b/res/values-de/strings.xml
@@ -343,4 +343,7 @@
     <string name="preferences_pure_black_night_mode">Rein schwarzer Nachtmodus</string>
     <string name="no_reminder_label">Keine</string>
     <string name="foreground_notification_title">Neue Erinnerungen planen…</string>
+    <string name="manual_reminder_label">Manual</string>
+    <string name="time_in_minutes">Time in minutes</string>
+    <string name="after_begin_of_event">after begin of event</string>
 </resources>

--- a/res/values-el/strings.xml
+++ b/res/values-el/strings.xml
@@ -337,4 +337,7 @@
     <string name="goto_date">Μετάβαση…</string>
     <string name="share_label">Μοιράσου</string>
     <string name="no_reminder_label">Κανένα</string>
+    <string name="manual_reminder_label">Manual</string>
+    <string name="time_in_minutes">Time in minutes</string>
+    <string name="after_begin_of_event">after begin of event</string>
 </resources>

--- a/res/values-en-rGB/strings.xml
+++ b/res/values-en-rGB/strings.xml
@@ -338,4 +338,7 @@
     <string name="preferences_system_theme">System default</string>
     <string name="preferences_pure_black_night_mode">Pure black night mode</string>
     <string name="no_reminder_label">None</string>
+    <string name="manual_reminder_label">Manual</string>
+    <string name="time_in_minutes">Time in minutes</string>
+    <string name="after_begin_of_event">after begin of event</string>
 </resources>

--- a/res/values-eo/strings.xml
+++ b/res/values-eo/strings.xml
@@ -220,4 +220,7 @@
     <string name="event_info_title_invite">Invito al renkontiĝo</string>
     <string name="change_response_title">Ŝanĝi respondon</string>
     <string name="no_reminder_label">Nenio</string>
+    <string name="manual_reminder_label">Manual</string>
+    <string name="time_in_minutes">Time in minutes</string>
+    <string name="after_begin_of_event">after begin of event</string>
 </resources>

--- a/res/values-es-rUS/strings.xml
+++ b/res/values-es-rUS/strings.xml
@@ -260,4 +260,7 @@
     <string name="display_time">Mostrar horario</string>
     <string name="display_location">Mostrar ubicación</string>
     <string name="no_reminder_label">Ninguno</string>
+    <string name="manual_reminder_label">Manual</string>
+    <string name="time_in_minutes">Time in minutes</string>
+    <string name="after_begin_of_event">after begin of event</string>
 </resources>

--- a/res/values-es/strings.xml
+++ b/res/values-es/strings.xml
@@ -343,4 +343,7 @@
         <item quantity="other"><xliff:g id="count">%d</xliff:g> semanas</item>
     </plurals>
     <string name="foreground_notification_title">Planificando nuevos recordatorios…</string>
+    <string name="manual_reminder_label">Manual</string>
+    <string name="time_in_minutes">Time in minutes</string>
+    <string name="after_begin_of_event">after begin of event</string>
 </resources>

--- a/res/values-et/strings.xml
+++ b/res/values-et/strings.xml
@@ -237,4 +237,7 @@
     <string name="visibility_private">Privaatne</string>
     <string name="visibility_public">Avalik</string>
     <string name="no_reminder_label">Puudub</string>
+    <string name="manual_reminder_label">Manual</string>
+    <string name="time_in_minutes">Time in minutes</string>
+    <string name="after_begin_of_event">after begin of event</string>
 </resources>

--- a/res/values-eu/strings.xml
+++ b/res/values-eu/strings.xml
@@ -321,6 +321,9 @@
     <string name="preferences_system_theme">Sistemaren lehenetsia</string>
     <string name="no_reminder_label">Bat ere ez</string>
     <string name="foreground_notification_title">Gogorarazle berriak planifikatzen…</string>
+    <string name="manual_reminder_label">Manual</string>
+    <string name="time_in_minutes">Time in minutes</string>
+    <string name="after_begin_of_event">after begin of event</string>
     <plurals name="Nweeks">
         <item quantity="one">Aste 1</item>
         <item quantity="other"><xliff:g id="count">%d</xliff:g> aste</item>

--- a/res/values-fa/strings.xml
+++ b/res/values-fa/strings.xml
@@ -237,4 +237,7 @@
     <string name="visibility_private">خصوصی</string>
     <string name="visibility_public">عمومی</string>
     <string name="no_reminder_label">هیچکدام</string>
+    <string name="manual_reminder_label">Manual</string>
+    <string name="time_in_minutes">Time in minutes</string>
+    <string name="after_begin_of_event">after begin of event</string>
 </resources>

--- a/res/values-fi/strings.xml
+++ b/res/values-fi/strings.xml
@@ -331,4 +331,7 @@
     <string name="foreground_notification_channel_description">Sisäisen hälytyksen synkronointiin tarvitaan tulosilmoitus.</string>
     <string name="foreground_notification_channel_name">Hälytyksen synkronointi</string>
     <string name="no_reminder_label">Ei mitään</string>
+    <string name="manual_reminder_label">Manual</string>
+    <string name="time_in_minutes">Time in minutes</string>
+    <string name="after_begin_of_event">after begin of event</string>
 </resources>

--- a/res/values-fr/strings.xml
+++ b/res/values-fr/strings.xml
@@ -343,4 +343,7 @@
         <item quantity="other"><xliff:g id="count">%d</xliff:g> sem.</item>
     </plurals>
     <string name="foreground_notification_title">Enregistrement des nouveaux rappels…</string>
+    <string name="manual_reminder_label">Manual</string>
+    <string name="time_in_minutes">Time in minutes</string>
+    <string name="after_begin_of_event">after begin of event</string>
 </resources>

--- a/res/values-gd/strings.xml
+++ b/res/values-gd/strings.xml
@@ -319,4 +319,7 @@
     <string name="date_time_fmt"><xliff:g id="date">%1$s</xliff:g>, <xliff:g id="time_interval">%2$s</xliff:g></string>
     <string name="tomorrow_at_time_fmt">A-màireach aig <xliff:g id="time_interval">%s</xliff:g></string>
     <string name="today_at_time_fmt">An-diugh aig <xliff:g id="time_interval">%s</xliff:g></string>
+    <string name="manual_reminder_label">Manual</string>
+    <string name="time_in_minutes">Time in minutes</string>
+    <string name="after_begin_of_event">after begin of event</string>
 </resources>

--- a/res/values-gl/strings.xml
+++ b/res/values-gl/strings.xml
@@ -318,4 +318,7 @@
     <string name="today">Hoxe</string>
     <string name="when_label">Cando</string>
     <string name="app_label">Calendario</string>
+    <string name="manual_reminder_label">Manual</string>
+    <string name="time_in_minutes">Time in minutes</string>
+    <string name="after_begin_of_event">after begin of event</string>
 </resources>

--- a/res/values-hi/strings.xml
+++ b/res/values-hi/strings.xml
@@ -238,4 +238,7 @@
     <string name="visibility_private">निजी</string>
     <string name="visibility_public">सार्वजनिक</string>
     <string name="no_reminder_label">कोई नहीं</string>
+    <string name="manual_reminder_label">Manual</string>
+    <string name="time_in_minutes">Time in minutes</string>
+    <string name="after_begin_of_event">after begin of event</string>
 </resources>

--- a/res/values-hr/strings.xml
+++ b/res/values-hr/strings.xml
@@ -360,4 +360,7 @@
         <item quantity="other"><xliff:g id="count">%d</xliff:g> tjedana</item>
     </plurals>
     <string name="foreground_notification_title">Planiranje novih podsjetnika …</string>
+    <string name="manual_reminder_label">Manual</string>
+    <string name="time_in_minutes">Time in minutes</string>
+    <string name="after_begin_of_event">after begin of event</string>
 </resources>

--- a/res/values-hu/strings.xml
+++ b/res/values-hu/strings.xml
@@ -338,4 +338,7 @@
     <string name="foreground_notification_channel_description">Előtérbeli értesítés szükséges a belső riasztásszinkronizálásához.</string>
     <string name="foreground_notification_channel_name">Riasztások szinkronizálása</string>
     <string name="no_reminder_label">Semelyik</string>
+    <string name="manual_reminder_label">Manual</string>
+    <string name="time_in_minutes">Time in minutes</string>
+    <string name="after_begin_of_event">after begin of event</string>
 </resources>

--- a/res/values-in/strings.xml
+++ b/res/values-in/strings.xml
@@ -326,4 +326,7 @@
         <item quantity="other"><xliff:g id="count">%d</xliff:g> minggu</item>
     </plurals>
     <string name="foreground_notification_title">Menjadwalkan pengingat baru…</string>
+    <string name="manual_reminder_label">Manual</string>
+    <string name="time_in_minutes">Time in minutes</string>
+    <string name="after_begin_of_event">after begin of event</string>
 </resources>

--- a/res/values-it/strings.xml
+++ b/res/values-it/strings.xml
@@ -339,6 +339,9 @@
     <string name="preferences_pure_black_night_mode">Modalità notte nera pura</string>
     <string name="no_reminder_label">Nessuno</string>
     <string name="foreground_notification_title">Pianificazione nuovi promemoria…</string>
+    <string name="manual_reminder_label">Manual</string>
+    <string name="time_in_minutes">Time in minutes</string>
+    <string name="after_begin_of_event">after begin of event</string>
     <plurals name="Nweeks">
         <item quantity="one">1 settimana</item>
         <item quantity="other"><xliff:g id="count">%d</xliff:g> settimane</item>

--- a/res/values-iw/strings.xml
+++ b/res/values-iw/strings.xml
@@ -377,4 +377,7 @@
         <item quantity="other"><xliff:g id="count">%d</xliff:g> שבועות</item>
     </plurals>
     <string name="foreground_notification_title">תזכורות חדשות מתוזמנות…</string>
+    <string name="manual_reminder_label">Manual</string>
+    <string name="time_in_minutes">Time in minutes</string>
+    <string name="after_begin_of_event">after begin of event</string>
 </resources>

--- a/res/values-ja/strings.xml
+++ b/res/values-ja/strings.xml
@@ -254,4 +254,7 @@
     <string name="goto_date">移動…</string>
     <string name="share_label">共有する</string>
     <string name="no_reminder_label">なし</string>
+    <string name="manual_reminder_label">Manual</string>
+    <string name="time_in_minutes">Time in minutes</string>
+    <string name="after_begin_of_event">after begin of event</string>
 </resources>

--- a/res/values-kk/strings.xml
+++ b/res/values-kk/strings.xml
@@ -159,4 +159,7 @@
     <string name="hide_controls">Бүйірлік тақтаны жасыру</string>
     <string name="event_view">Оқиғаны қарау</string>
     <string name="show_day_view">Күнді көрсету</string>
+    <string name="manual_reminder_label">Manual</string>
+    <string name="time_in_minutes">Time in minutes</string>
+    <string name="after_begin_of_event">after begin of event</string>
 </resources>

--- a/res/values-ko/strings.xml
+++ b/res/values-ko/strings.xml
@@ -290,4 +290,7 @@
     <string name="foreground_notification_channel_name">동기화 경고</string>
     <string name="foreground_notification_channel_description">Foreground 알림 내부 경계 태세를 동기화에 필요하다. 음소거 해달라</string>
     <string name="no_reminder_label">없음</string>
+    <string name="manual_reminder_label">Manual</string>
+    <string name="time_in_minutes">Time in minutes</string>
+    <string name="after_begin_of_event">after begin of event</string>
 </resources>

--- a/res/values-lt/strings.xml
+++ b/res/values-lt/strings.xml
@@ -360,4 +360,7 @@
         <item quantity="other"><xliff:g id="count">%d</xliff:g> savaičių</item>
     </plurals>
     <string name="foreground_notification_title">Planuojami nauji priminimai…</string>
+    <string name="manual_reminder_label">Manual</string>
+    <string name="time_in_minutes">Time in minutes</string>
+    <string name="after_begin_of_event">after begin of event</string>
 </resources>

--- a/res/values-lv/strings.xml
+++ b/res/values-lv/strings.xml
@@ -237,4 +237,7 @@
     <string name="visibility_private">Privāts</string>
     <string name="visibility_public">Publisks</string>
     <string name="no_reminder_label">Nav</string>
+    <string name="manual_reminder_label">Manual</string>
+    <string name="time_in_minutes">Time in minutes</string>
+    <string name="after_begin_of_event">after begin of event</string>
 </resources>

--- a/res/values-ml/strings.xml
+++ b/res/values-ml/strings.xml
@@ -60,4 +60,7 @@
     <string name="app_label">കലണ്ടർ</string>
     <string name="empty_event">ശൂന്യമായ ഇവന്റ് സൃഷ്ടിച്ചിട്ടില്ല.</string>
     <string name="select_synced_calendars_button">സമന്വയിപ്പിക്കാനുള്ള കലണ്ടറുകൾ</string>
+    <string name="manual_reminder_label">Manual</string>
+    <string name="time_in_minutes">Time in minutes</string>
+    <string name="after_begin_of_event">after begin of event</string>
 </resources>

--- a/res/values-ms/strings.xml
+++ b/res/values-ms/strings.xml
@@ -237,4 +237,7 @@
     <string name="visibility_private">Peribadi</string>
     <string name="visibility_public">Awam</string>
     <string name="no_reminder_label">Tiada</string>
+    <string name="manual_reminder_label">Manual</string>
+    <string name="time_in_minutes">Time in minutes</string>
+    <string name="after_begin_of_event">after begin of event</string>
 </resources>

--- a/res/values-nb/strings.xml
+++ b/res/values-nb/strings.xml
@@ -338,4 +338,7 @@
     <string name="preferences_system_theme">Systemforvalg</string>
     <string name="preferences_pure_black_night_mode">Beksvart nattmodus</string>
     <string name="no_reminder_label">Ingen</string>
+    <string name="manual_reminder_label">Manual</string>
+    <string name="time_in_minutes">Time in minutes</string>
+    <string name="after_begin_of_event">after begin of event</string>
 </resources>

--- a/res/values-nl/strings.xml
+++ b/res/values-nl/strings.xml
@@ -342,4 +342,7 @@
         <item quantity="other">&lt;xliff:g xmlns:xliff=\"urn:oasis:names:tc:xliff:document:1.2\" id=\"count\"&gt; weken</item>
     </plurals>
     <string name="foreground_notification_title">Bezig met inplannen van nieuwe herinneringen…</string>
+    <string name="manual_reminder_label">Manual</string>
+    <string name="time_in_minutes">Time in minutes</string>
+    <string name="after_begin_of_event">after begin of event</string>
 </resources>

--- a/res/values-pa/strings.xml
+++ b/res/values-pa/strings.xml
@@ -71,4 +71,7 @@
     <string name="saving_event_with_guest">ਨਵੀਂ ਜਾਣਕਾਰੀ ਭੇਜੀ ਜਾਵੇਗੀ।</string>
     <string name="creating_event_with_guest">ਸੱਦੇ ਭੇਜੇ ਜਾਣਗੇ।</string>
     <string name="empty_event">ਵਰਤਾਰਾ ਖਾਲੀ ਨਹੀਂ ਹੋਣਾ ਚਾਹੀਦਾ।</string>
+    <string name="manual_reminder_label">Manual</string>
+    <string name="time_in_minutes">Time in minutes</string>
+    <string name="after_begin_of_event">after begin of event</string>
 </resources>

--- a/res/values-pl/strings.xml
+++ b/res/values-pl/strings.xml
@@ -373,4 +373,7 @@
         <item quantity="other"><xliff:g id="count">%d</xliff:g> tygodni</item>
     </plurals>
     <string name="foreground_notification_title">Planowanie nowych przypomnień…</string>
+    <string name="manual_reminder_label">Manual</string>
+    <string name="time_in_minutes">Time in minutes</string>
+    <string name="after_begin_of_event">after begin of event</string>
 </resources>

--- a/res/values-pt-rBR/strings.xml
+++ b/res/values-pt-rBR/strings.xml
@@ -324,4 +324,7 @@
         <item quantity="other"><xliff:g id="count">%d</xliff:g> semanas</item>
     </plurals>
     <string name="foreground_notification_title">Agendando novos lembretes…</string>
+    <string name="manual_reminder_label">Manual</string>
+    <string name="time_in_minutes">Time in minutes</string>
+    <string name="after_begin_of_event">after begin of event</string>
 </resources>

--- a/res/values-pt-rPT/strings.xml
+++ b/res/values-pt-rPT/strings.xml
@@ -343,4 +343,7 @@
         <item quantity="other"><xliff:g id="count">%d</xliff:g> semanas</item>
     </plurals>
     <string name="foreground_notification_title">A agendar novos lembretes…</string>
+    <string name="manual_reminder_label">Manual</string>
+    <string name="time_in_minutes">Time in minutes</string>
+    <string name="after_begin_of_event">after begin of event</string>
 </resources>

--- a/res/values-pt/strings.xml
+++ b/res/values-pt/strings.xml
@@ -343,4 +343,7 @@
         <item quantity="other"><xliff:g id="count">%d</xliff:g> semanas</item>
     </plurals>
     <string name="foreground_notification_title">A agendar novos lembretes…</string>
+    <string name="manual_reminder_label">Manual</string>
+    <string name="time_in_minutes">Time in minutes</string>
+    <string name="after_begin_of_event">after begin of event</string>
 </resources>

--- a/res/values-ro/strings.xml
+++ b/res/values-ro/strings.xml
@@ -360,4 +360,7 @@
     <string name="preferences_list_add_offline_message">Calendarele offline NU sunt sincronizate şi sunt disponibile pe telefonul dumnoeavostră.</string>
     <string name="preferences_list_add_offline_cancel">Anulare</string>
     <string name="source_code">Sursă</string>
+    <string name="manual_reminder_label">Manual</string>
+    <string name="time_in_minutes">Time in minutes</string>
+    <string name="after_begin_of_event">after begin of event</string>
 </resources>

--- a/res/values-ru/strings.xml
+++ b/res/values-ru/strings.xml
@@ -361,4 +361,7 @@
         <item quantity="other"><xliff:g id="count">%d</xliff:g> недель</item>
     </plurals>
     <string name="foreground_notification_title">Планирование новых напоминаний…</string>
+    <string name="manual_reminder_label">Manual</string>
+    <string name="time_in_minutes">Time in minutes</string>
+    <string name="after_begin_of_event">after begin of event</string>
 </resources>

--- a/res/values-sk/strings.xml
+++ b/res/values-sk/strings.xml
@@ -290,4 +290,7 @@
     <string name="show_time_start_end_below">Počiatočný a koncový čas pod udalosťou</string>
     <string name="maximum_number_of_lines">Maximálny počet riadkov v udalosti</string>
     <string name="no_reminder_label">Žiadne</string>
+    <string name="manual_reminder_label">Manual</string>
+    <string name="time_in_minutes">Time in minutes</string>
+    <string name="after_begin_of_event">after begin of event</string>
 </resources>

--- a/res/values-sl/strings.xml
+++ b/res/values-sl/strings.xml
@@ -237,4 +237,7 @@
     <string name="visibility_private">Zasebno</string>
     <string name="visibility_public">Javno</string>
     <string name="no_reminder_label">Brez</string>
+    <string name="manual_reminder_label">Manual</string>
+    <string name="time_in_minutes">Time in minutes</string>
+    <string name="after_begin_of_event">after begin of event</string>
 </resources>

--- a/res/values-sr/strings.xml
+++ b/res/values-sr/strings.xml
@@ -256,4 +256,7 @@
     <string name="display_time">Прикажи Време</string>
     <string name="display_location">Прикажи Локацију</string>
     <string name="no_reminder_label">Ништа</string>
+    <string name="manual_reminder_label">Manual</string>
+    <string name="time_in_minutes">Time in minutes</string>
+    <string name="after_begin_of_event">after begin of event</string>
 </resources>

--- a/res/values-sv/strings.xml
+++ b/res/values-sv/strings.xml
@@ -338,6 +338,9 @@
     <string name="app_copyright">© 2015-<xliff:g>%1$s</xliff:g>Etar-projektet. Portioner © 2005-<xliff:g>%1$s</xliff:g>Android\'s öppna källkodprojekt.</string>
     <string name="preferences_pure_black_night_mode">Rent svart natt-läge</string>
     <string name="foreground_notification_title">Schemalägger nya påminnelser…</string>
+    <string name="manual_reminder_label">Manual</string>
+    <string name="time_in_minutes">Time in minutes</string>
+    <string name="after_begin_of_event">after begin of event</string>
     <plurals name="Nweeks">
         <item quantity="one">1 vecka</item>
         <item quantity="other"><xliff:g id="count">%d</xliff:g> veckor</item>

--- a/res/values-sw/strings.xml
+++ b/res/values-sw/strings.xml
@@ -237,4 +237,7 @@
     <string name="visibility_private">Faragha</string>
     <string name="visibility_public">Umma</string>
     <string name="no_reminder_label">Hamna</string>
+    <string name="manual_reminder_label">Manual</string>
+    <string name="time_in_minutes">Time in minutes</string>
+    <string name="after_begin_of_event">after begin of event</string>
 </resources>

--- a/res/values-szl/strings.xml
+++ b/res/values-szl/strings.xml
@@ -288,4 +288,7 @@
     <string name="event_info_title">Pokoż zdarzynie</string>
     <string name="edit_event_label">Informacyje</string>
     <string name="email_guests_label">Napisz do gości</string>
+    <string name="manual_reminder_label">Manual</string>
+    <string name="time_in_minutes">Time in minutes</string>
+    <string name="after_begin_of_event">after begin of event</string>
 </resources>

--- a/res/values-th/strings.xml
+++ b/res/values-th/strings.xml
@@ -237,4 +237,7 @@
     <string name="visibility_private">ส่วนบุคคล</string>
     <string name="visibility_public">สาธารณะ</string>
     <string name="no_reminder_label">ไม่มี</string>
+    <string name="manual_reminder_label">Manual</string>
+    <string name="time_in_minutes">Time in minutes</string>
+    <string name="after_begin_of_event">after begin of event</string>
 </resources>

--- a/res/values-tl/strings.xml
+++ b/res/values-tl/strings.xml
@@ -237,4 +237,7 @@
     <string name="visibility_private">Pribado</string>
     <string name="visibility_public">Pampubliko</string>
     <string name="no_reminder_label">Wala</string>
+    <string name="manual_reminder_label">Manual</string>
+    <string name="time_in_minutes">Time in minutes</string>
+    <string name="after_begin_of_event">after begin of event</string>
 </resources>

--- a/res/values-tr/strings.xml
+++ b/res/values-tr/strings.xml
@@ -343,4 +343,7 @@
         <item quantity="other"><xliff:g id="count">%d</xliff:g> hafta</item>
     </plurals>
     <string name="foreground_notification_title">Yeni hatırlatıcılar planlanıyor…</string>
+    <string name="manual_reminder_label">Manual</string>
+    <string name="time_in_minutes">Time in minutes</string>
+    <string name="after_begin_of_event">after begin of event</string>
 </resources>

--- a/res/values-tt/strings.xml
+++ b/res/values-tt/strings.xml
@@ -30,4 +30,7 @@
     </plurals>
     <string name="tomorrow">Иртәгә</string>
     <string name="today">Бүген</string>
+    <string name="manual_reminder_label">Manual</string>
+    <string name="time_in_minutes">Time in minutes</string>
+    <string name="after_begin_of_event">after begin of event</string>
 </resources>

--- a/res/values-ug/strings.xml
+++ b/res/values-ug/strings.xml
@@ -243,4 +243,7 @@
     <string name="preferences_default_snooze_delay_title">كۆڭۈلدىكى ئەسكەرتىشنى ۋاقىتلىق توختىتىش ۋاقتىنىڭ ئۇزۇنلۇقى</string>
     <string name="preferences_default_snooze_delay_dialog">كۆڭۈلدىكى ئەسكەرتىشنى ۋاقىتلىق توختىتىش ۋاقتى</string>
     <string name="no_reminder_label">يوق</string>
+    <string name="manual_reminder_label">Manual</string>
+    <string name="time_in_minutes">Time in minutes</string>
+    <string name="after_begin_of_event">after begin of event</string>
 </resources>

--- a/res/values-uk/strings.xml
+++ b/res/values-uk/strings.xml
@@ -364,4 +364,7 @@
         <item quantity="other"><xliff:g id="count">%d</xliff:g> тижнів</item>
     </plurals>
     <string name="foreground_notification_title">Планування нових нагадувань…</string>
+    <string name="manual_reminder_label">Manual</string>
+    <string name="time_in_minutes">Time in minutes</string>
+    <string name="after_begin_of_event">after begin of event</string>
 </resources>

--- a/res/values-vi/strings.xml
+++ b/res/values-vi/strings.xml
@@ -331,4 +331,7 @@
         <item quantity="other"><xliff:g id="count">%d</xliff:g> tuần</item>
     </plurals>
     <string name="foreground_notification_title">Đang lên lịch những lời nhắc mới…</string>
+    <string name="manual_reminder_label">Manual</string>
+    <string name="time_in_minutes">Time in minutes</string>
+    <string name="after_begin_of_event">after begin of event</string>
 </resources>

--- a/res/values-zh-rCN/strings.xml
+++ b/res/values-zh-rCN/strings.xml
@@ -338,4 +338,7 @@
         <item quantity="other"><xliff:g id="count">%d</xliff:g> 周</item>
     </plurals>
     <string name="foreground_notification_title">安排新提醒中…</string>
+    <string name="manual_reminder_label">Manual</string>
+    <string name="time_in_minutes">Time in minutes</string>
+    <string name="after_begin_of_event">after begin of event</string>
 </resources>

--- a/res/values-zh-rTW/strings.xml
+++ b/res/values-zh-rTW/strings.xml
@@ -243,4 +243,7 @@
     <string name="preferences_default_snooze_delay_title">預設重響延遲時間</string>
     <string name="preferences_default_snooze_delay_dialog">預設重響延遲</string>
     <string name="no_reminder_label">無</string>
+    <string name="manual_reminder_label">Manual</string>
+    <string name="time_in_minutes">Time in minutes</string>
+    <string name="after_begin_of_event">after begin of event</string>
 </resources>

--- a/res/values-zu/strings.xml
+++ b/res/values-zu/strings.xml
@@ -242,4 +242,7 @@
     <string name="visibility_private">Imfihlo</string>
     <string name="visibility_public">Okusesidlangalaleni</string>
     <string name="no_reminder_label">Lutho</string>
+    <string name="manual_reminder_label">Manual</string>
+    <string name="time_in_minutes">Time in minutes</string>
+    <string name="after_begin_of_event">after begin of event</string>
 </resources>

--- a/res/values/arrays.xml
+++ b/res/values/arrays.xml
@@ -83,6 +83,7 @@
         <item>10080</item> <!-- 1 week -->
         <item>20160</item> <!-- 2 weeks -->
         <item>40320</item> <!-- 4 weeks -->
+        <item>1000000</item> <!-- Manual -->
     </integer-array>
 
     <string-array name="preferences_default_reminder_values" translatable="false">
@@ -105,6 +106,7 @@
         <item>"10080"</item>
         <item>"20160"</item>
         <item>"40320"</item>
+        <item>"1000000"</item>
     </string-array>
 
     <string-array name="preferences_default_snooze_delay_values" translatable="false">

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -795,5 +795,8 @@
     <string name="preferences_menu_about">About Etar</string>
 
     <string name="offline_account_name">Offline Calendar</string>
+    <string name="manual_reminder_label">Manual</string>
+    <string name="time_in_minutes">Time in minutes</string>
+    <string name="after_begin_of_event">after begin of event</string>
 
 </resources>

--- a/src/com/android/calendar/CalendarEventModel.java
+++ b/src/com/android/calendar/CalendarEventModel.java
@@ -833,7 +833,7 @@ public class CalendarEventModel implements Serializable {
      * Instances of the class are immutable.
      */
     public static class ReminderEntry implements Comparable<ReminderEntry>, Serializable {
-        private final int mMinutes;
+        private int mMinutes;
         private final int mMethod;
 
         /**
@@ -919,6 +919,10 @@ public class CalendarEventModel implements Serializable {
         /** Returns the minutes. */
         public int getMinutes() {
             return mMinutes;
+        }
+
+        public void setMinutes(int minutes){
+            mMinutes=minutes;
         }
 
         /** Returns the alert method. */

--- a/src/com/android/calendar/event/EventViewUtils.java
+++ b/src/com/android/calendar/event/EventViewUtils.java
@@ -49,6 +49,10 @@ public class EventViewUtils {
         Resources resources = context.getResources();
         int value, resId;
 
+        if (minutes == 1000000) { //Set manual reminder
+            return resources.getString(R.string.manual_reminder_label);
+        }
+
         if (minutes % 60 != 0 || minutes == 0) {
             value = minutes;
             if (abbrev) {

--- a/src/com/android/calendar/event/EventViewUtils.java
+++ b/src/com/android/calendar/event/EventViewUtils.java
@@ -49,14 +49,7 @@ public class EventViewUtils {
         Resources resources = context.getResources();
         int value, resId;
 
-        if (minutes < 0) {
-            value = 0;
-            resId = R.string.no_reminder_label;
-
-            String format = resources.getString(resId, value);
-            return String.format(format, value);
-
-        } else if (minutes % 60 != 0 || minutes == 0) {
+        if (minutes % 60 != 0 || minutes == 0) {
             value = minutes;
             if (abbrev) {
                 resId = R.plurals.Nmins;


### PR DESCRIPTION
As discussed in #1113 and requested in #620 here is a draft for a possibility to manually add a reminder in minutes before or after start of the event.
So far it only works for events that already exist. Due to the mechanism of reading the reminder times from the labels in the dropdown box it is a bit complicated to realize.

What I have done is add another entry "Manual" to the dropdown list. When selected an alert dialog is opened which allows to set the time in minutes and set before/after start via a checkbox. Then the reminders are saved and the fragment is closed. After opening it again it will show the added reminder.

![Screenshot_20220307-131320_Etar](https://user-images.githubusercontent.com/68678880/157033374-ff89852e-7830-43ee-8db0-d53c15a881ce.png)

Maybe someone with more experience in the Etar source code can help improve and finalize it.