### PR TITLE
Create and show reminders after start of event using a checkbox

### DIFF
--- a/res/layout/edit_reminder_item.xml
+++ b/res/layout/edit_reminder_item.xml
@@ -29,6 +29,15 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
+    <CheckBox
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="fill"
+        android:text="@string/after_start_of_event"
+        app:layout_constraintStart_toEndOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/reminder_minutes_value"
+        android:id="@+id/reminder_minutes_sign" />
+
     <Spinner
         android:id="@+id/reminder_method_value"
         android:layout_width="0dp"

--- a/res/values-af/strings.xml
+++ b/res/values-af/strings.xml
@@ -243,4 +243,5 @@
     <string name="preferences_default_snooze_delay_title">Standaard sluimer vertragings tyd</string>
     <string name="preferences_default_snooze_delay_dialog">Standaard sluimer vertraging</string>
     <string name="no_reminder_label">Geen</string>
+    <string name="after_start_of_event">after start of event</string>
 </resources>

--- a/res/values-am/strings.xml
+++ b/res/values-am/strings.xml
@@ -237,4 +237,5 @@
     <string name="visibility_private">የግል</string>
     <string name="visibility_public">ሕዝብ</string>
     <string name="no_reminder_label">የለም</string>
+    <string name="after_start_of_event">after start of event</string>
 </resources>

--- a/res/values-ar/strings.xml
+++ b/res/values-ar/strings.xml
@@ -343,4 +343,5 @@
     <string name="rsvp_declined">تمت الإجابة بلا.</string>
     <string name="rsvp_tentative">تمت الإحابة بمحتمل.</string>
     <string name="no_reminder_label">لا شيء</string>
+    <string name="after_start_of_event">after start of event</string>
 </resources>

--- a/res/values-be/strings.xml
+++ b/res/values-be/strings.xml
@@ -292,4 +292,5 @@
     <string name="one_and_a_half_hours">1.5 гадзіны</string>
     <string name="two_hours">2 гадзіны</string>
     <string name="no_reminder_label">Няма</string>
+    <string name="after_start_of_event">after start of event</string>
 </resources>

--- a/res/values-bg/strings.xml
+++ b/res/values-bg/strings.xml
@@ -237,4 +237,5 @@
     <string name="visibility_private">Частно</string>
     <string name="visibility_public">Обществено</string>
     <string name="no_reminder_label">Няма</string>
+    <string name="after_start_of_event">after start of event</string>
 </resources>

--- a/res/values-bn-rBD/strings.xml
+++ b/res/values-bn-rBD/strings.xml
@@ -147,4 +147,5 @@
     <string name="preferences_title">সেটিংস</string>
     <string name="yearly_plain">বার্ষিক</string>
     <string name="monthly">মাসিক</string>
+    <string name="after_start_of_event">after start of event</string>
 </resources>

--- a/res/values-ca/strings.xml
+++ b/res/values-ca/strings.xml
@@ -339,6 +339,7 @@
     <string name="preferences_list_add_remote">Afegeix un calendari CalDAV</string>
     <string name="no_reminder_label">Cap</string>
     <string name="foreground_notification_title">Planificant nous recordatoris…</string>
+    <string name="after_start_of_event">after start of event</string>
     <plurals name="Nweeks">
         <item quantity="one">1 setmana</item>
         <item quantity="other"><xliff:g id="count">%d</xliff:g> setmanes</item>

--- a/res/values-cs/strings.xml
+++ b/res/values-cs/strings.xml
@@ -243,4 +243,5 @@
     <string name="preferences_default_snooze_delay_title">Výchozí délka odložení</string>
     <string name="preferences_default_snooze_delay_dialog">Výchozí délka odložení</string>
     <string name="no_reminder_label">Žádný</string>
+    <string name="after_start_of_event">after start of event</string>
 </resources>

--- a/res/values-cy/strings.xml
+++ b/res/values-cy/strings.xml
@@ -360,4 +360,5 @@
     <string name="maximum_number_of_lines">Uchafswm o linellau ar gyfer digwyddiad</string>
     <string name="foreground_notification_channel_name">Cydamseriad Hysbysiadau</string>
     <string name="foreground_notification_channel_description">Hysbysiad blaendir angenrheidiol er cydamseru hysbysiadau mewnol. I\'w ddistewi.</string>
+    <string name="after_start_of_event">after start of event</string>
 </resources>

--- a/res/values-da/strings.xml
+++ b/res/values-da/strings.xml
@@ -319,4 +319,5 @@
     <string name="preferences_calendar_number_of_events">%1d begivenheder</string>
     <string name="preferences_calendar_info_category">Kalendar information</string>
     <string name="no_reminder_label">Ingen</string>
+    <string name="after_start_of_event">after start of event</string>
 </resources>

--- a/res/values-de/strings.xml
+++ b/res/values-de/strings.xml
@@ -343,4 +343,5 @@
     <string name="preferences_pure_black_night_mode">Rein schwarzer Nachtmodus</string>
     <string name="no_reminder_label">Keine</string>
     <string name="foreground_notification_title">Neue Erinnerungen planen…</string>
+    <string name="after_start_of_event">after start of event</string>
 </resources>

--- a/res/values-el/strings.xml
+++ b/res/values-el/strings.xml
@@ -337,4 +337,5 @@
     <string name="goto_date">Μετάβαση…</string>
     <string name="share_label">Μοιράσου</string>
     <string name="no_reminder_label">Κανένα</string>
+    <string name="after_start_of_event">after start of event</string>
 </resources>

--- a/res/values-en-rGB/strings.xml
+++ b/res/values-en-rGB/strings.xml
@@ -338,4 +338,5 @@
     <string name="preferences_system_theme">System default</string>
     <string name="preferences_pure_black_night_mode">Pure black night mode</string>
     <string name="no_reminder_label">None</string>
+    <string name="after_start_of_event">after start of event</string>
 </resources>

--- a/res/values-eo/strings.xml
+++ b/res/values-eo/strings.xml
@@ -220,4 +220,5 @@
     <string name="event_info_title_invite">Invito al renkontiĝo</string>
     <string name="change_response_title">Ŝanĝi respondon</string>
     <string name="no_reminder_label">Nenio</string>
+    <string name="after_start_of_event">after start of event</string>
 </resources>

--- a/res/values-es-rUS/strings.xml
+++ b/res/values-es-rUS/strings.xml
@@ -260,4 +260,5 @@
     <string name="display_time">Mostrar horario</string>
     <string name="display_location">Mostrar ubicación</string>
     <string name="no_reminder_label">Ninguno</string>
+    <string name="after_start_of_event">after start of event</string>
 </resources>

--- a/res/values-es/strings.xml
+++ b/res/values-es/strings.xml
@@ -343,4 +343,5 @@
         <item quantity="other"><xliff:g id="count">%d</xliff:g> semanas</item>
     </plurals>
     <string name="foreground_notification_title">Planificando nuevos recordatorios…</string>
+    <string name="after_start_of_event">after start of event</string>
 </resources>

--- a/res/values-et/strings.xml
+++ b/res/values-et/strings.xml
@@ -237,4 +237,5 @@
     <string name="visibility_private">Privaatne</string>
     <string name="visibility_public">Avalik</string>
     <string name="no_reminder_label">Puudub</string>
+    <string name="after_start_of_event">after start of event</string>
 </resources>

--- a/res/values-eu/strings.xml
+++ b/res/values-eu/strings.xml
@@ -321,6 +321,7 @@
     <string name="preferences_system_theme">Sistemaren lehenetsia</string>
     <string name="no_reminder_label">Bat ere ez</string>
     <string name="foreground_notification_title">Gogorarazle berriak planifikatzen…</string>
+    <string name="after_start_of_event">after start of event</string>
     <plurals name="Nweeks">
         <item quantity="one">Aste 1</item>
         <item quantity="other"><xliff:g id="count">%d</xliff:g> aste</item>

--- a/res/values-fa/strings.xml
+++ b/res/values-fa/strings.xml
@@ -237,4 +237,5 @@
     <string name="visibility_private">خصوصی</string>
     <string name="visibility_public">عمومی</string>
     <string name="no_reminder_label">هیچکدام</string>
+    <string name="after_start_of_event">after start of event</string>
 </resources>

--- a/res/values-fi/strings.xml
+++ b/res/values-fi/strings.xml
@@ -331,4 +331,5 @@
     <string name="foreground_notification_channel_description">Sisäisen hälytyksen synkronointiin tarvitaan tulosilmoitus.</string>
     <string name="foreground_notification_channel_name">Hälytyksen synkronointi</string>
     <string name="no_reminder_label">Ei mitään</string>
+    <string name="after_start_of_event">after start of event</string>
 </resources>

--- a/res/values-fr/strings.xml
+++ b/res/values-fr/strings.xml
@@ -343,4 +343,5 @@
         <item quantity="other"><xliff:g id="count">%d</xliff:g> sem.</item>
     </plurals>
     <string name="foreground_notification_title">Enregistrement des nouveaux rappels…</string>
+    <string name="after_start_of_event">after start of event</string>
 </resources>

--- a/res/values-gd/strings.xml
+++ b/res/values-gd/strings.xml
@@ -319,4 +319,5 @@
     <string name="date_time_fmt"><xliff:g id="date">%1$s</xliff:g>, <xliff:g id="time_interval">%2$s</xliff:g></string>
     <string name="tomorrow_at_time_fmt">A-màireach aig <xliff:g id="time_interval">%s</xliff:g></string>
     <string name="today_at_time_fmt">An-diugh aig <xliff:g id="time_interval">%s</xliff:g></string>
+    <string name="after_start_of_event">after start of event</string>
 </resources>

--- a/res/values-gl/strings.xml
+++ b/res/values-gl/strings.xml
@@ -318,4 +318,5 @@
     <string name="today">Hoxe</string>
     <string name="when_label">Cando</string>
     <string name="app_label">Calendario</string>
+    <string name="after_start_of_event">after start of event</string>
 </resources>

--- a/res/values-hi/strings.xml
+++ b/res/values-hi/strings.xml
@@ -238,4 +238,5 @@
     <string name="visibility_private">निजी</string>
     <string name="visibility_public">सार्वजनिक</string>
     <string name="no_reminder_label">कोई नहीं</string>
+    <string name="after_start_of_event">after start of event</string>
 </resources>

--- a/res/values-hr/strings.xml
+++ b/res/values-hr/strings.xml
@@ -360,4 +360,5 @@
         <item quantity="other"><xliff:g id="count">%d</xliff:g> tjedana</item>
     </plurals>
     <string name="foreground_notification_title">Planiranje novih podsjetnika …</string>
+    <string name="after_start_of_event">after start of event</string>
 </resources>

--- a/res/values-hu/strings.xml
+++ b/res/values-hu/strings.xml
@@ -338,4 +338,5 @@
     <string name="foreground_notification_channel_description">Előtérbeli értesítés szükséges a belső riasztásszinkronizálásához.</string>
     <string name="foreground_notification_channel_name">Riasztások szinkronizálása</string>
     <string name="no_reminder_label">Semelyik</string>
+    <string name="after_start_of_event">after start of event</string>
 </resources>

--- a/res/values-in/strings.xml
+++ b/res/values-in/strings.xml
@@ -326,4 +326,5 @@
         <item quantity="other"><xliff:g id="count">%d</xliff:g> minggu</item>
     </plurals>
     <string name="foreground_notification_title">Menjadwalkan pengingat baru…</string>
+    <string name="after_start_of_event">after start of event</string>
 </resources>

--- a/res/values-it/strings.xml
+++ b/res/values-it/strings.xml
@@ -339,6 +339,7 @@
     <string name="preferences_pure_black_night_mode">Modalità notte nera pura</string>
     <string name="no_reminder_label">Nessuno</string>
     <string name="foreground_notification_title">Pianificazione nuovi promemoria…</string>
+    <string name="after_start_of_event">after start of event</string>
     <plurals name="Nweeks">
         <item quantity="one">1 settimana</item>
         <item quantity="other"><xliff:g id="count">%d</xliff:g> settimane</item>

--- a/res/values-iw/strings.xml
+++ b/res/values-iw/strings.xml
@@ -377,4 +377,5 @@
         <item quantity="other"><xliff:g id="count">%d</xliff:g> שבועות</item>
     </plurals>
     <string name="foreground_notification_title">תזכורות חדשות מתוזמנות…</string>
+    <string name="after_start_of_event">after start of event</string>
 </resources>

--- a/res/values-ja/strings.xml
+++ b/res/values-ja/strings.xml
@@ -254,4 +254,5 @@
     <string name="goto_date">移動…</string>
     <string name="share_label">共有する</string>
     <string name="no_reminder_label">なし</string>
+    <string name="after_start_of_event">after start of event</string>
 </resources>

--- a/res/values-kk/strings.xml
+++ b/res/values-kk/strings.xml
@@ -159,4 +159,5 @@
     <string name="hide_controls">Бүйірлік тақтаны жасыру</string>
     <string name="event_view">Оқиғаны қарау</string>
     <string name="show_day_view">Күнді көрсету</string>
+    <string name="after_start_of_event">after start of event</string>
 </resources>

--- a/res/values-ko/strings.xml
+++ b/res/values-ko/strings.xml
@@ -290,4 +290,5 @@
     <string name="foreground_notification_channel_name">동기화 경고</string>
     <string name="foreground_notification_channel_description">Foreground 알림 내부 경계 태세를 동기화에 필요하다. 음소거 해달라</string>
     <string name="no_reminder_label">없음</string>
+    <string name="after_start_of_event">after start of event</string>
 </resources>

--- a/res/values-lt/strings.xml
+++ b/res/values-lt/strings.xml
@@ -360,4 +360,5 @@
         <item quantity="other"><xliff:g id="count">%d</xliff:g> savaičių</item>
     </plurals>
     <string name="foreground_notification_title">Planuojami nauji priminimai…</string>
+    <string name="after_start_of_event">after start of event</string>
 </resources>

--- a/res/values-lv/strings.xml
+++ b/res/values-lv/strings.xml
@@ -237,4 +237,5 @@
     <string name="visibility_private">Privāts</string>
     <string name="visibility_public">Publisks</string>
     <string name="no_reminder_label">Nav</string>
+    <string name="after_start_of_event">after start of event</string>
 </resources>

--- a/res/values-ml/strings.xml
+++ b/res/values-ml/strings.xml
@@ -60,4 +60,5 @@
     <string name="app_label">കലണ്ടർ</string>
     <string name="empty_event">ശൂന്യമായ ഇവന്റ് സൃഷ്ടിച്ചിട്ടില്ല.</string>
     <string name="select_synced_calendars_button">സമന്വയിപ്പിക്കാനുള്ള കലണ്ടറുകൾ</string>
+    <string name="after_start_of_event">after start of event</string>
 </resources>

--- a/res/values-ms/strings.xml
+++ b/res/values-ms/strings.xml
@@ -237,4 +237,5 @@
     <string name="visibility_private">Peribadi</string>
     <string name="visibility_public">Awam</string>
     <string name="no_reminder_label">Tiada</string>
+    <string name="after_start_of_event">after start of event</string>
 </resources>

--- a/res/values-nb/strings.xml
+++ b/res/values-nb/strings.xml
@@ -338,4 +338,5 @@
     <string name="preferences_system_theme">Systemforvalg</string>
     <string name="preferences_pure_black_night_mode">Beksvart nattmodus</string>
     <string name="no_reminder_label">Ingen</string>
+    <string name="after_start_of_event">after start of event</string>
 </resources>

--- a/res/values-nl/strings.xml
+++ b/res/values-nl/strings.xml
@@ -342,4 +342,5 @@
         <item quantity="other">&lt;xliff:g xmlns:xliff=\"urn:oasis:names:tc:xliff:document:1.2\" id=\"count\"&gt; weken</item>
     </plurals>
     <string name="foreground_notification_title">Bezig met inplannen van nieuwe herinneringen…</string>
+    <string name="after_start_of_event">after start of event</string>
 </resources>

--- a/res/values-pa/strings.xml
+++ b/res/values-pa/strings.xml
@@ -71,4 +71,5 @@
     <string name="saving_event_with_guest">ਨਵੀਂ ਜਾਣਕਾਰੀ ਭੇਜੀ ਜਾਵੇਗੀ।</string>
     <string name="creating_event_with_guest">ਸੱਦੇ ਭੇਜੇ ਜਾਣਗੇ।</string>
     <string name="empty_event">ਵਰਤਾਰਾ ਖਾਲੀ ਨਹੀਂ ਹੋਣਾ ਚਾਹੀਦਾ।</string>
+    <string name="after_start_of_event">after start of event</string>
 </resources>

--- a/res/values-pl/strings.xml
+++ b/res/values-pl/strings.xml
@@ -373,4 +373,5 @@
         <item quantity="other"><xliff:g id="count">%d</xliff:g> tygodni</item>
     </plurals>
     <string name="foreground_notification_title">Planowanie nowych przypomnień…</string>
+    <string name="after_start_of_event">after start of event</string>
 </resources>

--- a/res/values-pt-rBR/strings.xml
+++ b/res/values-pt-rBR/strings.xml
@@ -324,4 +324,5 @@
         <item quantity="other"><xliff:g id="count">%d</xliff:g> semanas</item>
     </plurals>
     <string name="foreground_notification_title">Agendando novos lembretes…</string>
+    <string name="after_start_of_event">after start of event</string>
 </resources>

--- a/res/values-pt-rPT/strings.xml
+++ b/res/values-pt-rPT/strings.xml
@@ -343,4 +343,5 @@
         <item quantity="other"><xliff:g id="count">%d</xliff:g> semanas</item>
     </plurals>
     <string name="foreground_notification_title">A agendar novos lembretes…</string>
+    <string name="after_start_of_event">after start of event</string>
 </resources>

--- a/res/values-pt/strings.xml
+++ b/res/values-pt/strings.xml
@@ -343,4 +343,5 @@
         <item quantity="other"><xliff:g id="count">%d</xliff:g> semanas</item>
     </plurals>
     <string name="foreground_notification_title">A agendar novos lembretes…</string>
+    <string name="after_start_of_event">after start of event</string>
 </resources>

--- a/res/values-ro/strings.xml
+++ b/res/values-ro/strings.xml
@@ -360,4 +360,5 @@
     <string name="preferences_list_add_offline_message">Calendarele offline NU sunt sincronizate şi sunt disponibile pe telefonul dumnoeavostră.</string>
     <string name="preferences_list_add_offline_cancel">Anulare</string>
     <string name="source_code">Sursă</string>
+    <string name="after_start_of_event">after start of event</string>
 </resources>

--- a/res/values-ru/strings.xml
+++ b/res/values-ru/strings.xml
@@ -361,4 +361,5 @@
         <item quantity="other"><xliff:g id="count">%d</xliff:g> недель</item>
     </plurals>
     <string name="foreground_notification_title">Планирование новых напоминаний…</string>
+    <string name="after_start_of_event">after start of event</string>
 </resources>

--- a/res/values-sk/strings.xml
+++ b/res/values-sk/strings.xml
@@ -290,4 +290,5 @@
     <string name="show_time_start_end_below">Počiatočný a koncový čas pod udalosťou</string>
     <string name="maximum_number_of_lines">Maximálny počet riadkov v udalosti</string>
     <string name="no_reminder_label">Žiadne</string>
+    <string name="after_start_of_event">after start of event</string>
 </resources>

--- a/res/values-sl/strings.xml
+++ b/res/values-sl/strings.xml
@@ -237,4 +237,5 @@
     <string name="visibility_private">Zasebno</string>
     <string name="visibility_public">Javno</string>
     <string name="no_reminder_label">Brez</string>
+    <string name="after_start_of_event">after start of event</string>
 </resources>

--- a/res/values-sr/strings.xml
+++ b/res/values-sr/strings.xml
@@ -256,4 +256,5 @@
     <string name="display_time">Прикажи Време</string>
     <string name="display_location">Прикажи Локацију</string>
     <string name="no_reminder_label">Ништа</string>
+    <string name="after_start_of_event">after start of event</string>
 </resources>

--- a/res/values-sv/strings.xml
+++ b/res/values-sv/strings.xml
@@ -338,6 +338,7 @@
     <string name="app_copyright">© 2015-<xliff:g>%1$s</xliff:g>Etar-projektet. Portioner © 2005-<xliff:g>%1$s</xliff:g>Android\'s öppna källkodprojekt.</string>
     <string name="preferences_pure_black_night_mode">Rent svart natt-läge</string>
     <string name="foreground_notification_title">Schemalägger nya påminnelser…</string>
+    <string name="after_start_of_event">after start of event</string>
     <plurals name="Nweeks">
         <item quantity="one">1 vecka</item>
         <item quantity="other"><xliff:g id="count">%d</xliff:g> veckor</item>

--- a/res/values-sw/strings.xml
+++ b/res/values-sw/strings.xml
@@ -237,4 +237,5 @@
     <string name="visibility_private">Faragha</string>
     <string name="visibility_public">Umma</string>
     <string name="no_reminder_label">Hamna</string>
+    <string name="after_start_of_event">after start of event</string>
 </resources>

--- a/res/values-szl/strings.xml
+++ b/res/values-szl/strings.xml
@@ -288,4 +288,5 @@
     <string name="event_info_title">Pokoż zdarzynie</string>
     <string name="edit_event_label">Informacyje</string>
     <string name="email_guests_label">Napisz do gości</string>
+    <string name="after_start_of_event">after start of event</string>
 </resources>

--- a/res/values-th/strings.xml
+++ b/res/values-th/strings.xml
@@ -237,4 +237,5 @@
     <string name="visibility_private">ส่วนบุคคล</string>
     <string name="visibility_public">สาธารณะ</string>
     <string name="no_reminder_label">ไม่มี</string>
+    <string name="after_start_of_event">after start of event</string>
 </resources>

--- a/res/values-tl/strings.xml
+++ b/res/values-tl/strings.xml
@@ -237,4 +237,5 @@
     <string name="visibility_private">Pribado</string>
     <string name="visibility_public">Pampubliko</string>
     <string name="no_reminder_label">Wala</string>
+    <string name="after_start_of_event">after start of event</string>
 </resources>

--- a/res/values-tr/strings.xml
+++ b/res/values-tr/strings.xml
@@ -343,4 +343,5 @@
         <item quantity="other"><xliff:g id="count">%d</xliff:g> hafta</item>
     </plurals>
     <string name="foreground_notification_title">Yeni hatırlatıcılar planlanıyor…</string>
+    <string name="after_start_of_event">after start of event</string>
 </resources>

--- a/res/values-tt/strings.xml
+++ b/res/values-tt/strings.xml
@@ -30,4 +30,5 @@
     </plurals>
     <string name="tomorrow">Иртәгә</string>
     <string name="today">Бүген</string>
+    <string name="after_start_of_event">after start of event</string>
 </resources>

--- a/res/values-ug/strings.xml
+++ b/res/values-ug/strings.xml
@@ -243,4 +243,5 @@
     <string name="preferences_default_snooze_delay_title">كۆڭۈلدىكى ئەسكەرتىشنى ۋاقىتلىق توختىتىش ۋاقتىنىڭ ئۇزۇنلۇقى</string>
     <string name="preferences_default_snooze_delay_dialog">كۆڭۈلدىكى ئەسكەرتىشنى ۋاقىتلىق توختىتىش ۋاقتى</string>
     <string name="no_reminder_label">يوق</string>
+    <string name="after_start_of_event">after start of event</string>
 </resources>

--- a/res/values-uk/strings.xml
+++ b/res/values-uk/strings.xml
@@ -364,4 +364,5 @@
         <item quantity="other"><xliff:g id="count">%d</xliff:g> тижнів</item>
     </plurals>
     <string name="foreground_notification_title">Планування нових нагадувань…</string>
+    <string name="after_start_of_event">after start of event</string>
 </resources>

--- a/res/values-vi/strings.xml
+++ b/res/values-vi/strings.xml
@@ -331,4 +331,5 @@
         <item quantity="other"><xliff:g id="count">%d</xliff:g> tuần</item>
     </plurals>
     <string name="foreground_notification_title">Đang lên lịch những lời nhắc mới…</string>
+    <string name="after_start_of_event">after start of event</string>
 </resources>

--- a/res/values-zh-rCN/strings.xml
+++ b/res/values-zh-rCN/strings.xml
@@ -338,4 +338,5 @@
         <item quantity="other"><xliff:g id="count">%d</xliff:g> 周</item>
     </plurals>
     <string name="foreground_notification_title">安排新提醒中…</string>
+    <string name="after_start_of_event">after start of event</string>
 </resources>

--- a/res/values-zh-rTW/strings.xml
+++ b/res/values-zh-rTW/strings.xml
@@ -243,4 +243,5 @@
     <string name="preferences_default_snooze_delay_title">預設重響延遲時間</string>
     <string name="preferences_default_snooze_delay_dialog">預設重響延遲</string>
     <string name="no_reminder_label">無</string>
+    <string name="after_start_of_event">after start of event</string>
 </resources>

--- a/res/values-zu/strings.xml
+++ b/res/values-zu/strings.xml
@@ -242,4 +242,5 @@
     <string name="visibility_private">Imfihlo</string>
     <string name="visibility_public">Okusesidlangalaleni</string>
     <string name="no_reminder_label">Lutho</string>
+    <string name="after_start_of_event">after start of event</string>
 </resources>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -795,5 +795,6 @@
     <string name="preferences_menu_about">About Etar</string>
 
     <string name="offline_account_name">Offline Calendar</string>
+    <string name="after_start_of_event">after start of event</string>
 
 </resources>

--- a/src/com/android/calendar/EventInfoFragment.java
+++ b/src/com/android/calendar/EventInfoFragment.java
@@ -1927,7 +1927,7 @@ public class EventInfoFragment extends DialogFragment implements OnCheckedChange
             // Insert any minute values that aren't represented in the minutes list.
             for (ReminderEntry re : reminders) {
                 EventViewUtils.addMinutesToList(
-                        mActivity, mReminderMinuteValues, mReminderMinuteLabels, re.getMinutes());
+                        mActivity, mReminderMinuteValues, mReminderMinuteLabels, Math.abs(re.getMinutes()));
             }
             // Create a UI element for each reminder.  We display all of the reminders we get
             // from the provider, even if the count exceeds the calendar maximum.  (Also, for

--- a/src/com/android/calendar/event/EventViewUtils.java
+++ b/src/com/android/calendar/event/EventViewUtils.java
@@ -23,6 +23,7 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.widget.AdapterView.OnItemSelectedListener;
 import android.widget.ArrayAdapter;
+import android.widget.CheckBox;
 import android.widget.ImageButton;
 import android.widget.LinearLayout;
 import android.widget.Spinner;
@@ -147,9 +148,11 @@ public class EventViewUtils {
             ConstraintLayout layout = reminderItems.get(index);
             Spinner minuteSpinner = (Spinner) layout.findViewById(R.id.reminder_minutes_value);
             Spinner methodSpinner = (Spinner) layout.findViewById(R.id.reminder_method_value);
+            CheckBox minuteSign = (CheckBox) layout.findViewById(R.id.reminder_minutes_sign);
+            int sign = minuteSign.isChecked() ? -1:1;
             int minutes = reminderMinuteValues.get(minuteSpinner.getSelectedItemPosition());
             int method = reminderMethodValues.get(methodSpinner.getSelectedItemPosition());
-            reminders.add(ReminderEntry.valueOf(minutes, method));
+            reminders.add(ReminderEntry.valueOf(sign*minutes, method));
         }
         return reminders;
     }
@@ -274,7 +277,7 @@ public class EventViewUtils {
         Spinner spinner = (Spinner) reminderItem.findViewById(R.id.reminder_minutes_value);
         setReminderSpinnerLabels(activity, spinner, minuteLabels);
 
-        int index = findMinutesInReminderList(minuteValues, newReminder.getMinutes());
+        int index = findMinutesInReminderList(minuteValues, Math.abs(newReminder.getMinutes()));
         spinner.setSelection(index);
 
         if (onItemSelected != null) {
@@ -282,6 +285,8 @@ public class EventViewUtils {
             spinner.setOnItemSelectedListener(onItemSelected);
         }
 
+        CheckBox checkBox = (CheckBox) reminderItem.findViewById(R.id.reminder_minutes_sign);
+        checkBox.setChecked(newReminder.getMinutes()<0);
         /*
          * Configure the alert-method spinner.  Methods not supported by the current Calendar
          * will not be shown.

--- a/src/com/android/calendar/event/EventViewUtils.java
+++ b/src/com/android/calendar/event/EventViewUtils.java
@@ -49,14 +49,7 @@ public class EventViewUtils {
         Resources resources = context.getResources();
         int value, resId;
 
-        if (minutes < 0) {
-            value = 0;
-            resId = R.string.no_reminder_label;
-
-            String format = resources.getString(resId, value);
-            return String.format(format, value);
-
-        } else if (minutes % 60 != 0 || minutes == 0) {
+        if (minutes % 60 != 0 || minutes == 0) {
             value = minutes;
             if (abbrev) {
                 resId = R.plurals.Nmins;


### PR DESCRIPTION
As discussed in #1113 and requested in #620 here is another proposal which also allows to create reminders after start of the event. I added a checkbox which allows to define the reminder "after start of event".
This is a much simpler approach than proposed in #1116. It is of course not as flexible but on the other hand a lot more consistent with the existing source code.
![Screenshot_20220307-164705_Etar](https://user-images.githubusercontent.com/68678880/157069935-edfa33ab-4da2-477a-a358-a60f896ae9f0.png)

