### PR TITLE
Etar: Request user to disable battery optimizations

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -31,6 +31,7 @@
     <uses-permission android:name="android.permission.READ_SYNC_SETTINGS" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
+    <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS"/>
 
     <queries>
         <package android:name="at.bitfire.davdroid" />

--- a/res/drawable/ic_info_outline.xml
+++ b/res/drawable/ic_info_outline.xml
@@ -1,5 +1,26 @@
-<vector android:height="24dp" android:tint="?attr/iconSettingsAbout"
-    android:viewportHeight="24.0" android:viewportWidth="24.0"
-    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
-    <path android:fillColor="#FF000000" android:pathData="M11,17h2v-6h-2v6zM12,2C6.48,2 2,6.48 2,12s4.48,10 10,10 10,-4.48 10,-10S17.52,2 12,2zM12,20c-4.41,0 -8,-3.59 -8,-8s3.59,-8 8,-8 8,3.59 8,8 -3.59,8 -8,8zM11,9h2L13,7h-2v2z"/>
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (C) 2022 The Calyx Institute
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:tint="?attr/colorControlNormal"
+    android:viewportWidth="24.0"
+    android:viewportHeight="24.0">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M11,17h2v-6h-2v6zM12,2C6.48,2 2,6.48 2,12s4.48,10 10,10 10,-4.48 10,-10S17.52,2 12,2zM12,20c-4.41,0 -8,-3.59 -8,-8s3.59,-8 8,-8 8,3.59 8,8 -3.59,8 -8,8zM11,9h2L13,7h-2v2z" />
 </vector>

--- a/res/layout/about.xml
+++ b/res/layout/about.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:orientation="vertical"
     android:layout_height="fill_parent"
     android:layout_width="fill_parent">
@@ -111,7 +112,8 @@
                     android:src="@drawable/ic_info_outline"
                     android:layout_width="24dp"
                     android:layout_height="24dp"
-                    android:layout_gravity="center" />
+                    android:layout_gravity="center"
+                    app:tint="?attr/iconSettingsAbout" />
 
                 <LinearLayout
                     android:layout_width="fill_parent"

--- a/res/menu-land/all_in_one_title_bar.xml
+++ b/res/menu-land/all_in_one_title_bar.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Copyright (C) 2010 The Android Open Source Project
+     Copyright (C) 2022 The Calyx Institute
 
      Licensed under the Apache License, Version 2.0 (the "License");
      you may not use this file except in compliance with the License.
@@ -21,6 +22,12 @@
         android:alphabeticShortcut="t"
         android:icon="@drawable/today_icon"
         android:title="@string/goto_today"
+        app:showAsAction="withText|ifRoom" />
+    <item
+        android:id="@+id/action_info"
+        android:alphabeticShortcut="i"
+        android:icon="@drawable/ic_info_outline"
+        android:title="@string/menu_info"
         app:showAsAction="withText|ifRoom" />
     <item
         android:id="@+id/action_goto"

--- a/res/menu-sw600dp-land/all_in_one_title_bar.xml
+++ b/res/menu-sw600dp-land/all_in_one_title_bar.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Copyright (C) 2010 The Android Open Source Project
+     Copyright (C) 2022 The Calyx Institute
 
      Licensed under the Apache License, Version 2.0 (the "License");
      you may not use this file except in compliance with the License.
@@ -21,6 +22,12 @@
         android:alphabeticShortcut="t"
         android:icon="@drawable/today_icon"
         android:title="@string/goto_today"
+        app:showAsAction="always|withText" />
+    <item
+        android:id="@+id/action_info"
+        android:alphabeticShortcut="i"
+        android:icon="@drawable/ic_info_outline"
+        android:title="@string/menu_info"
         app:showAsAction="always|withText" />
     <item
         android:id="@+id/action_goto"

--- a/res/menu-sw600dp/all_in_one_title_bar.xml
+++ b/res/menu-sw600dp/all_in_one_title_bar.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Copyright (C) 2010 The Android Open Source Project
+     Copyright (C) 2022 The Calyx Institute
 
      Licensed under the Apache License, Version 2.0 (the "License");
      you may not use this file except in compliance with the License.
@@ -21,6 +22,12 @@
         android:alphabeticShortcut="t"
         android:icon="@drawable/today_icon"
         android:title="@string/goto_today"
+        app:showAsAction="always|withText" />
+    <item
+        android:id="@+id/action_info"
+        android:alphabeticShortcut="i"
+        android:icon="@drawable/ic_info_outline"
+        android:title="@string/menu_info"
         app:showAsAction="always|withText" />
     <item
         android:id="@+id/action_goto"

--- a/res/menu/all_in_one_title_bar.xml
+++ b/res/menu/all_in_one_title_bar.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Copyright (C) 2010 The Android Open Source Project
+     Copyright (C) 2022 The Calyx Institute
 
      Licensed under the Apache License, Version 2.0 (the "License");
      you may not use this file except in compliance with the License.
@@ -23,6 +24,13 @@
         android:icon="@drawable/today_icon"
         android:orderInCategory="1"
         android:title="@string/goto_today"
+        app:showAsAction="ifRoom" />
+    <item
+        android:id="@+id/action_info"
+        android:alphabeticShortcut="i"
+        android:icon="@drawable/ic_info_outline"
+        android:orderInCategory="1"
+        android:title="@string/menu_info"
         app:showAsAction="ifRoom" />
     <item
         android:id="@+id/action_goto"

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -141,8 +141,9 @@
     <!-- This is a label on a menu item. Pressing this menu item allows the
          user to view and edit his Settings (or Preferences) -->
     <string name="menu_preferences">"Settings"</string>
-    <!-- This is a label on a menu item. Pressing this menu item allows the
-         user to select the calendars to display [CHAR LIMIT=20] -->
+    <!-- This is a label on a menu item. Pressing this menu item shows users
+         a warning -->
+    <string name="menu_info">Info</string>
     <!-- This is a label on a menu item. Pressing this menu item allows the
          user to select the calendars to display [CHAR LIMIT=20] -->
     <string name="search">"Search"</string>

--- a/src/com/android/calendar/alerts/AlertReceiver.java
+++ b/src/com/android/calendar/alerts/AlertReceiver.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2007 The Android Open Source Project
+ * Copyright (C) 2022 The Calyx Institute
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -122,20 +123,24 @@ public class AlertReceiver extends BroadcastReceiver {
      */
     public static void beginStartingService(Context context, Intent intent) {
         synchronized (mStartingServiceSync) {
+            PowerManager pm = (PowerManager) context.getSystemService(Context.POWER_SERVICE);
+
             if (mStartingService == null) {
-                PowerManager pm =
-                    (PowerManager)context.getSystemService(Context.POWER_SERVICE);
                 mStartingService = pm.newWakeLock(PowerManager.PARTIAL_WAKE_LOCK,
                         "Etar:StartingAlertService");
                 mStartingService.setReferenceCounted(false);
             }
             mStartingService.acquire();
-            if (Utils.isOreoOrLater()) {
-                context.startForegroundService(intent);
-            } else {
-                context.startService(intent);
-            }
 
+            if (pm.isIgnoringBatteryOptimizations(context.getPackageName())) {
+                if (Utils.isOreoOrLater()) {
+                    context.startForegroundService(intent);
+                } else {
+                    context.startService(intent);
+                }
+            } else {
+                Log.d(TAG, "Battery optimizations are not disabled");
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

This MR:

- Prompts users to disable battery optimizations aka doze for Etar to allow it to operate freely in the background,
- Guards the service to ensure it only runs if optimizations are disabled

Disabling battery optimizations makes sense considering we are seeing numerous issues even after using exact alarms complaining about notifications delay or missing completely. This also allows Etar to work properly on Android 12 due to new foreground service restrictions.

## Issue(s)

- #1142,
- #1181,
- #1179,
- #1026,
- #1163,
- #789

## Test

Install build with this MR, ensure that:
- New installs prompt the user to disable optimizations once permissions have been granted,
- Existing installs show an info icon on the toolbar which prompts the user to disable the optimizations.

Ensure Etar no longer crashes on Android 12 and can send event notifications if battery optimizations are disabled.