### PR TITLE
Fix default theme on API >= 29 devices

### DIFF
--- a/res/values-v29/strings.xml
+++ b/res/values-v29/strings.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (C) 2006 The Android Open Source Project
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+<resources>
+
+    <string name="pref_theme_default" translatable="false">system</string>
+
+</resources>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -800,4 +800,6 @@
     <string name="offline_account_name">Offline Calendar</string>
     <string name="after_start_of_event">after start of event</string>
 
+    <string name="pref_theme_default" translatable="false">light</string>
+
 </resources>

--- a/res/xml-v26/general_preferences.xml
+++ b/res/xml-v26/general_preferences.xml
@@ -22,7 +22,7 @@
             app:title="@string/preferences_theme"
             app:entries="@array/pref_theme_entries"
             app:entryValues="@array/pref_theme_values"
-            app:defaultValue="light" />
+            app:defaultValue="@string/pref_theme_default" />
         <SwitchPreference
             app:key="pref_pure_black_night_mode"
             app:defaultValue="false"

--- a/res/xml/general_preferences.xml
+++ b/res/xml/general_preferences.xml
@@ -22,7 +22,7 @@
             app:title="@string/preferences_theme"
             app:entries="@array/pref_theme_entries"
             app:entryValues="@array/pref_theme_values"
-            app:defaultValue="light" />
+            app:defaultValue="@string/pref_theme_default" />
         <SwitchPreference
             app:key="pref_pure_black_night_mode"
             app:defaultValue="false"


### PR DESCRIPTION
The original commit removed -v29 resources which resulted in
theme defaulting to light instead of system on API 29 devices.

Fixes commit e09d38660a2262bd795d3da5faaf90312a732498.

Change-Id: I2f0bd61eb774bfd14bb5a363bbbb859c1da65a49