### PR TITLE
.github: Update artifact path

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -43,4 +43,4 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: Etar_apk
-          path: /home/runner/work/Etar-Calendar/Etar-Calendar/build/outputs/apk/debug/**.apk
+          path: app/build/outputs/apk/debug/app-debug.apk


### PR DESCRIPTION
## Summary

This MR updates the artifact path, which got changed due to #1189.

## Issue(s)

https://github.com/Etar-Group/Etar-Calendar/commit/e178372438b02a4799583b0b02b772cc4dd9d7fe#commitcomment-79119294

## Test

Ensure artifact is available in CI actions after this change