### PR TITLE
[Android 13] Request Runtime Notification Permission

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@
 # Java class files
 *.class
 
+# MAC OSX system files
+*.DS_Store
+
 # Generated files
 bin/
 gen/

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,11 +10,11 @@ editorconfig {
 }
 
 android {
-    compileSdk 31
+    compileSdk 33
 
     defaultConfig {
         minSdk 21
-        targetSdk 31
+        targetSdk 33
         versionCode 32
         versionName "1.0.30"
         applicationId "ws.xsoh.etar"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -32,6 +32,7 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
     <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS"/>
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
 
     <queries>
         <package android:name="at.bitfire.davdroid" />

--- a/app/src/main/java/com/android/calendar/AllInOneActivity.java
+++ b/app/src/main/java/com/android/calendar/AllInOneActivity.java
@@ -89,11 +89,12 @@ import com.android.calendar.settings.SettingsActivity;
 import com.android.calendar.settings.SettingsActivityKt;
 import com.android.calendar.settings.ViewDetailsPreferences;
 import com.android.calendarcommon2.Time;
-
 import com.google.android.material.floatingactionbutton.FloatingActionButton;
 import com.google.android.material.navigation.NavigationView;
 
 import java.io.File;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Calendar;
 import java.util.List;
 import java.util.Locale;
@@ -113,6 +114,7 @@ public class AllInOneActivity extends AbstractCalendarActivity implements EventH
     private static final String BUNDLE_KEY_RESTORE_VIEW = "key_restore_view";
     private static final int HANDLER_KEY = 0;
     private static final int PERMISSIONS_REQUEST_WRITE_CALENDAR = 0;
+    private static final int PERMISSIONS_REQUEST_POST_NOTIFICATIONS = 1;
 
     // Indices of buttons for the drop down menu (tabs replacement)
     // Must match the strings in the array buttons_list in arrays.xml and the
@@ -398,10 +400,24 @@ public class AllInOneActivity extends AbstractCalendarActivity implements EventH
                 Manifest.permission.WRITE_EXTERNAL_STORAGE)
                 != PackageManager.PERMISSION_GRANTED)) {
 
-            // No explanation needed, we can request the permission.
+            ArrayList<String> permissionsList = new ArrayList<>(Arrays.asList(
+                    Manifest.permission.WRITE_CALENDAR,
+                    Manifest.permission.READ_CALENDAR,
+                    Manifest.permission.WRITE_EXTERNAL_STORAGE)
+            );
 
+            // Permission for calendar notifications
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU &&
+                    (ContextCompat.checkSelfPermission(this,
+                            Manifest.permission.POST_NOTIFICATIONS)
+                            != PackageManager.PERMISSION_GRANTED)) {
+                permissionsList.add(Manifest.permission.POST_NOTIFICATIONS);
+            }
+
+            // No explanation needed, we can request the permission.
+            String[] permissionsArray = new String[permissionsList.size()];
             ActivityCompat.requestPermissions(this,
-                    new String[]{Manifest.permission.WRITE_CALENDAR, Manifest.permission.READ_CALENDAR, Manifest.permission.WRITE_EXTERNAL_STORAGE},
+                    permissionsList.toArray(permissionsArray),
                     PERMISSIONS_REQUEST_WRITE_CALENDAR);
         }
     }

--- a/app/src/main/java/com/android/calendar/alerts/AlertService.java
+++ b/app/src/main/java/com/android/calendar/alerts/AlertService.java
@@ -47,6 +47,7 @@ import android.text.format.DateUtils;
 import android.util.Log;
 
 import androidx.core.app.NotificationCompat;
+import androidx.core.app.NotificationManagerCompat;
 import androidx.core.content.ContextCompat;
 
 import com.android.calendar.Utils;
@@ -298,7 +299,7 @@ public class AlertService extends Service {
           }
 
             // Post the new notification for the group.
-            nm.notify(AlertUtils.EXPIRED_GROUP_NOTIFICATION_ID, notification);
+            nm.notify(context, AlertUtils.EXPIRED_GROUP_NOTIFICATION_ID, notification);
         } else {
             nm.cancel(AlertUtils.EXPIRED_GROUP_NOTIFICATION_ID);
             if (DEBUG) {
@@ -719,7 +720,7 @@ public class AlertService extends Service {
                 true); /* Show the LED for these non-expired events */
 
         // Post the notification.
-        notificationMgr.notify(notificationId, notification);
+        notificationMgr.notify(context, notificationId, notification);
 
         if (DEBUG) {
             Log.d(TAG, "Posting individual alarm notification, eventId:" + info.eventId
@@ -1026,8 +1027,12 @@ public class AlertService extends Service {
         }
 
         @Override
-        public void notify(int id, NotificationWrapper nw) {
-            mNm.notify(id, nw.mNotification);
+        public void notify(Context context, int id, NotificationWrapper nw) {
+            if (NotificationManagerCompat.from(context).areNotificationsEnabled()) {
+                mNm.notify(id, nw.mNotification);
+            } else {
+                Log.d(TAG, "Notifications are disabled!");
+            }
         }
     }
 

--- a/app/src/main/java/com/android/calendar/alerts/NotificationMgr.java
+++ b/app/src/main/java/com/android/calendar/alerts/NotificationMgr.java
@@ -17,11 +17,12 @@
 package com.android.calendar.alerts;
 
 import android.app.NotificationChannel;
+import android.content.Context;
 
 import com.android.calendar.alerts.AlertService.NotificationWrapper;
 
 public abstract class NotificationMgr {
-    public abstract void notify(int id, NotificationWrapper notification);
+    public abstract void notify(Context context, int id, NotificationWrapper notification);
     public abstract void cancel(int id);
     public abstract void createNotificationChannel(NotificationChannel channel);
 


### PR DESCRIPTION
## Summary

This MR supports requesting runtime notification permission on Android 13 and guards the `notify` method to check if notifications are enabled before posting the notification.

## Issue(s)

https://github.com/Etar-Group/Etar-Calendar/issues/1209

## Screenshots

<details>
  <summary>Click to expand!</summary>
  
![image](https://user-images.githubusercontent.com/46414010/181443810-5f0aefa3-0c32-4509-825d-1385a507d64c.png)
</details>

## Test

Ensure that Etar asks for notification permission and functionality works as expected with the permission state.

Command line compilation instructions:

```shell
git clone https://github.com/Etar-Group/Etar-Calendar.git && cd ./Etar-Calendar
git fetch upstream pull/1210/head && git checkout FETCH_HEAD
./gradlew aarGen
./gradlew :app:assembleDebug
```