### PR TITLE
Add 9h as option for reminder

### DIFF
--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -78,6 +78,7 @@
         <item>120</item>
         <item>180</item>
         <item>360</item>
+        <item>540</item>
         <item>720</item> <!-- 12 hours -->
         <item>1440</item> <!-- 24 hours -->
         <item>2880</item> <!-- 2 days -->
@@ -101,6 +102,7 @@
         <item>"120"</item>
         <item>"180"</item>
         <item>"360"</item>
+        <item>"540"</item>
         <item>"720"</item>
         <item>"1440"</item>
         <item>"2880"</item>


### PR DESCRIPTION
For birthdays I would like to get a reminder at 9 in the morning.
At 6 is too early, at 12 may be too late.