### PR TITLE
Fix crash when opening an event with very large ID

### DIFF
--- a/app/src/main/java/com/android/calendar/EventInfoFragment.java
+++ b/app/src/main/java/com/android/calendar/EventInfoFragment.java
@@ -922,7 +922,7 @@ public class EventInfoFragment extends DialogFragment implements OnCheckedChange
             return false;
         }
         mEventCursor.moveToFirst();
-        mEventId = mEventCursor.getInt(EVENT_INDEX_ID);
+        mEventId = mEventCursor.getLong(EVENT_INDEX_ID);
         String rRule = mEventCursor.getString(EVENT_INDEX_RRULE);
         mIsRepeating = !TextUtils.isEmpty(rRule);
         // mHasAlarm will be true if it was saved in the event already, or if


### PR DESCRIPTION
Event IDs may be very large, eg. `637907256000038305`, and opening such event leads to crash

```
java.lang.NumberFormatException: For input string: "637907256000038305"
```