### PR TITLE
Show multiday events with corrent start and end points

### DIFF
--- a/app/src/main/java/com/android/calendar/DayView.java
+++ b/app/src/main/java/com/android/calendar/DayView.java
@@ -2940,6 +2940,7 @@ public class DayView extends View implements View.OnCreateContextMenuListener,
 
         int alpha = eventTextPaint.getAlpha();
         eventTextPaint.setAlpha(mEventsAlpha);
+        int cellWidth = (mViewWidth - mHoursWidth) / mNumDays - DAY_GAP;
         for (int i = 0; i < numEvents; i++) {
             Event event = events.get(i);
             int startDay = event.startDay;
@@ -2947,11 +2948,20 @@ public class DayView extends View implements View.OnCreateContextMenuListener,
             if (startDay > lastDay || endDay < firstDay) {
                 continue;
             }
+            int leftoffset;
+            int rightoffset;
             if (startDay < firstDay) {
                 startDay = firstDay;
+                leftoffset = 0;
+            } else {
+                leftoffset = (event.startTime * cellWidth) / MINUTES_PER_DAY;
             }
             if (endDay > lastDay) {
                 endDay = lastDay;
+                rightoffset = 0;
+            } else {
+                rightoffset =
+                    ((MINUTES_PER_DAY - event.endTime) * cellWidth) / MINUTES_PER_DAY;
             }
             int startIndex = startDay - firstDay;
             int endIndex = endDay - firstDay;
@@ -2965,8 +2975,8 @@ public class DayView extends View implements View.OnCreateContextMenuListener,
 
             // Leave a one-pixel space between the vertical day lines and the
             // event rectangle.
-            event.left = computeDayLeftPosition(startIndex);
-            event.right = computeDayLeftPosition(endIndex + 1) - DAY_GAP;
+            event.left = computeDayLeftPosition(startIndex) + leftoffset;
+            event.right = computeDayLeftPosition(endIndex + 1) - DAY_GAP - rightoffset;
             event.top = y + height * event.getColumn();
             event.bottom = event.top + height - ALL_DAY_EVENT_RECT_BOTTOM_MARGIN;
             if (mMaxAlldayEvents > mMaxUnexpandedAlldayEventCount) {


### PR DESCRIPTION
If a multiday event is shown in the all day region, show its actual start and end times rather than the beginning of the first day and the end of the last day