### PR TITLE
CalendarEventModel: Mark getCalendarEventColors method as nullable

### DIFF
--- a/app/src/main/java/com/android/calendar/CalendarEventModel.java
+++ b/app/src/main/java/com/android/calendar/CalendarEventModel.java
@@ -26,6 +26,8 @@ import android.provider.CalendarContract.Reminders;
 import android.text.TextUtils;
 import android.text.util.Rfc822Token;
 
+import androidx.annotation.Nullable;
+
 import com.android.calendar.event.EditEventHelper;
 import com.android.calendar.event.EventColorCache;
 import com.android.calendar.settings.GeneralPreferences;
@@ -770,6 +772,7 @@ public class CalendarEventModel implements Serializable {
         mEventColorInitialized = true;
     }
 
+    @Nullable
     public int[] getCalendarEventColors() {
         if (mEventColorCache != null) {
             return mEventColorCache.getColorArray(mCalendarAccountName, mCalendarAccountType);

--- a/app/src/main/java/com/android/calendar/event/EditEventView.java
+++ b/app/src/main/java/com/android/calendar/event/EditEventView.java
@@ -1485,10 +1485,14 @@ public class EditEventView implements View.OnClickListener, DialogInterface.OnCa
         mModel.mCalendarAccountName = c.getString(EditEventHelper.CALENDARS_INDEX_ACCOUNT_NAME);
         mModel.mCalendarAccountType = c.getString(EditEventHelper.CALENDARS_INDEX_ACCOUNT_TYPE);
         // TODO: try to find a similar color within the new event colors before falling back to the calendar color
-        mModel.setEventColor(Arrays.stream(mModel.getCalendarEventColors())
-                .filter(color -> color == mModel.getEventColor())
-                .findFirst()
-                .orElse(mModel.getCalendarColor()));
+        if (mModel.getCalendarEventColors() != null) {
+            mModel.setEventColor(Arrays.stream(mModel.getCalendarEventColors())
+                    .filter(color -> color == mModel.getEventColor())
+                    .findFirst()
+                    .orElse(mModel.getCalendarColor()));
+        } else {
+            mModel.setEventColor(mModel.getCalendarColor());
+        }
         setSpinnerBackgroundColor(mModel.getEventColor());
         setColorPickerButtonStates(mModel.getCalendarEventColors());
 


### PR DESCRIPTION
## Summary

This fixes #1271

## Test

Install a build with this patch. Ensure Etar no longer crashes on trying to create a new event.