### PR TITLE
#1287 Fix drawing of all-day events.

### DIFF
--- a/app/src/main/java/com/android/calendar/DayView.java
+++ b/app/src/main/java/com/android/calendar/DayView.java
@@ -2943,18 +2943,20 @@ public class DayView extends View implements View.OnCreateContextMenuListener,
             if (startDay > lastDay || endDay < firstDay) {
                 continue;
             }
-            int leftoffset;
-            int rightoffset;
+            int leftoffset = 0;
+            int rightoffset = 0;
             if (startDay < firstDay) {
                 startDay = firstDay;
-                leftoffset = 0;
-            } else {
+            } else if (!event.allDay) {
+                // Only offset the drawing if it is not an all-day event (which
+                // does not have a time at all).
                 leftoffset = (event.startTime * cellWidth) / MINUTES_PER_DAY;
             }
             if (endDay > lastDay) {
                 endDay = lastDay;
-                rightoffset = 0;
-            } else {
+            } else if (!event.allDay) {
+                // Only offset the drawing it is not an all-day event (which
+                // does not have a time at all).
                 rightoffset =
                     ((MINUTES_PER_DAY - event.endTime) * cellWidth) / MINUTES_PER_DAY;
             }


### PR DESCRIPTION
`allDay` is the condition I was looking for, it allows to determine whether the event has a time at all.

Two points I'm unsure about:

 1. Did I place the comments correctly or would you prefer it *above* the `if` condition.
 2. Are there utility functions for determining whether it is the same day or not? Subtracting and checking the minutes works, but if you've got something better that would be it.