### PR TITLE
check event color is initialized before using it

### DIFF
--- a/app/src/main/java/com/android/calendar/CalendarEventModel.java
+++ b/app/src/main/java/com/android/calendar/CalendarEventModel.java
@@ -772,6 +772,11 @@ public class CalendarEventModel implements Serializable {
         mEventColorInitialized = true;
     }
 
+    public void removeEventColor() {
+        mEventColorInitialized = false;
+        mEventColor = -1;
+    }
+
     @Nullable
     public int[] getCalendarEventColors() {
         if (mEventColorCache != null) {

--- a/app/src/main/java/com/android/calendar/event/EditEventView.java
+++ b/app/src/main/java/com/android/calendar/event/EditEventView.java
@@ -1484,16 +1484,18 @@ public class EditEventView implements View.OnClickListener, DialogInterface.OnCa
         mModel.setCalendarColor(displayCalendarColor);
         mModel.mCalendarAccountName = c.getString(EditEventHelper.CALENDARS_INDEX_ACCOUNT_NAME);
         mModel.mCalendarAccountType = c.getString(EditEventHelper.CALENDARS_INDEX_ACCOUNT_TYPE);
-        // TODO: try to find a similar color within the new event colors before falling back to the calendar color
-        if (mModel.getCalendarEventColors() != null) {
-            mModel.setEventColor(Arrays.stream(mModel.getCalendarEventColors())
+
+        // try to find the event color in the new calendar, remove it otherwise
+        if (mModel.isEventColorInitialized() && mModel.getCalendarEventColors() != null) {
+            Arrays.stream(mModel.getCalendarEventColors())
                     .filter(color -> color == mModel.getEventColor())
                     .findFirst()
-                    .orElse(mModel.getCalendarColor()));
+                    .ifPresentOrElse(mModel::setEventColor, mModel::removeEventColor);
         } else {
-            mModel.setEventColor(mModel.getCalendarColor());
+            mModel.removeEventColor();
         }
-        setSpinnerBackgroundColor(mModel.getEventColor());
+        setSpinnerBackgroundColor(mModel.isEventColorInitialized()
+                ? mModel.getEventColor() : mModel.getCalendarColor());
         setColorPickerButtonStates(mModel.getCalendarEventColors());
 
         // Update the max/allowed reminders with the new calendar properties.


### PR DESCRIPTION
if we use the event color while its not initialized, the color is still a valid color int (-1, white).
in this case we tried to find the uninitialized color inside the available event colors and when the calendar provided the white color, we used it erroneously instead of the calendar color for new events.

fixes #1294