### PR TITLE
fix calendar and organizer text colors being barely visible sometimes

### DIFF
--- a/app/src/main/java/com/android/calendar/EventInfoFragment.java
+++ b/app/src/main/java/com/android/calendar/EventInfoFragment.java
@@ -366,6 +366,8 @@ public class EventInfoFragment extends DialogFragment implements OnCheckedChange
     private TextView mWhenDateTime;
     private TextView mWhere;
     private TextView mWhenRepeat;
+    private TextView mEventOrganizer;
+    private TextView mCalendarName;
     private ExpandableTextView mDesc;
     private AttendeesView mLongAttendees;
     private Button emailAttendeesButton;
@@ -791,6 +793,8 @@ public class EventInfoFragment extends DialogFragment implements OnCheckedChange
         mWhenDateTime = (TextView) mView.findViewById(R.id.when_datetime);
         mWhere = (TextView) mView.findViewById(R.id.where);
         mWhenRepeat = (TextView) mView.findViewById(R.id.when_repeat);
+        mEventOrganizer = (TextView) mView.findViewById(R.id.organizer);
+        mCalendarName = (TextView) mView.findViewById(R.id.calendar_name);
 
         mDesc =  mView.findViewById(R.id.description);
         mHeadlines = mView.findViewById(R.id.event_info_headline);
@@ -967,7 +971,7 @@ public class EventInfoFragment extends DialogFragment implements OnCheckedChange
                             mEventOrganizerDisplayName = name;
                             if (!mIsOrganizer) {
                                 setVisibilityCommon(view, R.id.organizer_container, View.VISIBLE);
-                                setTextCommon(view, R.id.organizer, mEventOrganizerDisplayName);
+                                mEventOrganizer.setText(mEventOrganizerDisplayName);
                             }
                         }
                     }
@@ -1819,7 +1823,7 @@ public class EventInfoFragment extends DialogFragment implements OnCheckedChange
             }
 
             if (!mIsOrganizer && !TextUtils.isEmpty(mEventOrganizerDisplayName)) {
-                setTextCommon(view, R.id.organizer, mEventOrganizerDisplayName);
+                mEventOrganizer.setText(mEventOrganizerDisplayName);
                 setVisibilityCommon(view, R.id.organizer_container, View.VISIBLE);
             } else {
                 setVisibilityCommon(view, R.id.organizer_container, View.GONE);
@@ -2496,7 +2500,7 @@ public class EventInfoFragment extends DialogFragment implements OnCheckedChange
                     }
 
                     setVisibilityCommon(mView, R.id.calendar_container, View.VISIBLE);
-                    setTextCommon(mView, R.id.calendar_name, sb);
+                    mCalendarName.setText(sb);
                     break;
             }
             cursor.close();

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -155,7 +155,7 @@
     <color name="event_info_headline_color">#FFFFFFFF</color>
     <color name="event_info_headline_transparent_color">#B3FFFFFF</color>
     <color name="event_info_headline_link_color">#FFFFFFFF</color>
-    <color name="event_info_organizer_color">#FF666666</color>
+    <color name="event_info_organizer_color">#99000000</color>
     <color name="event_info_description_color">#FF666666</color>
     <color name="event_info_body_color">#FF666666</color>
     <color name="event_info_label_color">#FF999999</color>
@@ -283,7 +283,7 @@
     <color name="event_info_headline_color_black">#FFFFFFFF</color>
     <color name="event_info_headline_transparent_color_black">#B3FFFFFF</color>
     <color name="event_info_headline_link_color_black">#FFFFFFFF</color>
-    <color name="event_info_organizer_color_black">#757575</color>
+    <color name="event_info_organizer_color_black">#DEFFFFFF</color>
     <color name="event_info_description_color_black">#bdbdbd</color>
     <color name="event_info_body_color_black">#bdbdbd</color>
     <color name="event_info_label_color_black">#ffffff</color>
@@ -388,7 +388,7 @@
     <color name="event_info_headline_color_dark">#FFFFFFFF</color>
     <color name="event_info_headline_transparent_color_dark">#B3FFFFFF</color>
     <color name="event_info_headline_link_color_dark">#FFFFFFFF</color>
-    <color name="event_info_organizer_color_dark">#757575</color>
+    <color name="event_info_organizer_color_dark">#DEFFFFFF</color>
     <color name="event_info_description_color_dark">#bdbdbd</color>
     <color name="event_info_body_color_dark">#bdbdbd</color>
     <color name="event_info_label_color_dark">#ffffff</color>


### PR DESCRIPTION
`setTextCommon(...)` changes the text color so its legible when being displayed on top of the event color, but neither the calendar name nor the organizer name is displayed on top of the event color. this makes the text unlegible when the event color is bright and the dark theme is selected or when the event color is darkish and the light theme is selected.

before:
![before](https://user-images.githubusercontent.com/37297474/213557793-27b305a4-9663-4c31-bec3-738c1572bbcc.png)

now:
![after](https://user-images.githubusercontent.com/37297474/213557800-1549e9b8-6ed3-45a6-a902-4b7175ba8d7e.png)
