### PR TITLE
AlertReceiver: Return early if either context or intent is null

### DIFF
--- a/app/src/main/java/com/android/calendar/alerts/AlertReceiver.java
+++ b/app/src/main/java/com/android/calendar/alerts/AlertReceiver.java
@@ -763,6 +763,9 @@ public class AlertReceiver extends BroadcastReceiver {
 
     @Override
     public void onReceive(final Context context, final Intent intent) {
+        if (context == null || intent.getAction() == null)
+            return;
+
         if (AlertService.DEBUG) {
             Log.d(TAG, "onReceive: a=" + intent.getAction() + " " + intent.toString());
         }


### PR DESCRIPTION
## Summary

The intent and context can be null in a broadcast receiver. AlertReciever crashes the app if the intent is `null` for instance. This PR aims to fix that behavior by ensuring that all logic only runs if they are not null.

## Test

- Use the following command to send a broadcast without an intent action specified to crash Etar: `adb shell am broadcast -n ws.xsoh.etar.debug/com.android.calendar.alerts.AlertReceiver`
- Apply this patch and run the aforementioned command again
- Notice Etar no longer crashes