### PR TITLE
allow editing calendar on existing events

### DIFF
--- a/app/src/main/java/com/android/calendar/CalendarEventModel.java
+++ b/app/src/main/java/com/android/calendar/CalendarEventModel.java
@@ -111,9 +111,6 @@ public class CalendarEventModel implements Serializable {
     public boolean mOrganizerCanRespond = false;
     public int mCalendarAccessLevel = Calendars.CAL_ACCESS_CONTRIBUTOR;
     public int mEventStatus = Events.STATUS_CONFIRMED;
-    // The model can't be updated with a calendar cursor until it has been
-    // updated with an event cursor.
-    public boolean mModelUpdatedWithEventCursor;
     public int mAccessLevel = 0;
     public ArrayList<ReminderEntry> mReminders;
     public ArrayList<ReminderEntry> mDefaultReminders;
@@ -291,7 +288,6 @@ public class CalendarEventModel implements Serializable {
         mEventStatus = Events.STATUS_CONFIRMED;
         mOrganizerCanRespond = false;
         mCalendarAccessLevel = Calendars.CAL_ACCESS_CONTRIBUTOR;
-        mModelUpdatedWithEventCursor = false;
         mCalendarAllowedReminders = null;
         mCalendarAllowedAttendeeTypes = null;
         mCalendarAllowedAvailability = null;
@@ -350,7 +346,6 @@ public class CalendarEventModel implements Serializable {
         result = prime * result + (mGuestsCanModify ? 1231 : 1237);
         result = prime * result + (mGuestsCanSeeGuests ? 1231 : 1237);
         result = prime * result + (mOrganizerCanRespond ? 1231 : 1237);
-        result = prime * result + (mModelUpdatedWithEventCursor ? 1231 : 1237);
         result = prime * result + mCalendarAccessLevel;
         result = prime * result + (mHasAlarm ? 1231 : 1237);
         result = prime * result + (mHasAttendeeData ? 1231 : 1237);
@@ -613,9 +608,6 @@ public class CalendarEventModel implements Serializable {
             return false;
         }
         if (mCalendarAccessLevel != originalModel.mCalendarAccessLevel) {
-            return false;
-        }
-        if (mModelUpdatedWithEventCursor != originalModel.mModelUpdatedWithEventCursor) {
             return false;
         }
         if (mHasAlarm != originalModel.mHasAlarm) {

--- a/app/src/main/java/com/android/calendar/CalendarEventModel.java
+++ b/app/src/main/java/com/android/calendar/CalendarEventModel.java
@@ -74,6 +74,7 @@ public class CalendarEventModel implements Serializable {
     public String mDescription = null;
     public String mUrl = null;
     public String mRrule = null;
+    public String exdate = null;
     public String mOrganizer = null;
     public String mOrganizerDisplayName = null;
     /**

--- a/app/src/main/java/com/android/calendar/CalendarEventModel.java
+++ b/app/src/main/java/com/android/calendar/CalendarEventModel.java
@@ -74,7 +74,7 @@ public class CalendarEventModel implements Serializable {
     public String mDescription = null;
     public String mUrl = null;
     public String mRrule = null;
-    public String exdate = null;
+    public String mExDate = null;
     public String mOrganizer = null;
     public String mOrganizerDisplayName = null;
     /**

--- a/app/src/main/java/com/android/calendar/DeleteEventHelper.java
+++ b/app/src/main/java/com/android/calendar/DeleteEventHelper.java
@@ -99,25 +99,7 @@ public class DeleteEventHelper {
             new DialogInterface.OnClickListener() {
         public void onClick(DialogInterface dialog, int button) {
             deleteStarted();
-            long id = mModel.mId; // mCursor.getInt(mEventIndexId);
-
-            // If this event is part of a local calendar, really remove it from the database
-            //
-            // "There are two versions of delete: as an app and as a sync adapter.
-            // An app delete will set the deleted column on an event and remove all instances of that event.
-            // A sync adapter delete will remove the event from the database and all associated data."
-            // from https://developer.android.com/reference/android/provider/CalendarContract.Events
-            boolean isLocal = mModel.mSyncAccountType.equals(CalendarContract.ACCOUNT_TYPE_LOCAL);
-            Uri deleteContentUri = isLocal ? CalendarRepository.asLocalCalendarSyncAdapter(mModel.mSyncAccountName, Events.CONTENT_URI) : Events.CONTENT_URI;
-
-            Uri uri = ContentUris.withAppendedId(deleteContentUri, id);
-            mService.startDelete(mService.getNextToken(), null, uri, null, null, Utils.UNDO_DELAY);
-            if (mCallback != null) {
-                mCallback.run();
-            }
-            if (mExitWhenDone) {
-                mParent.finish();
-            }
+            deleteNormalEvent();
         }
     };
     /**
@@ -164,7 +146,7 @@ public class DeleteEventHelper {
         }
     };
 
-    public DeleteEventHelper(Context context, Activity parentActivity, boolean exitWhenDone) {
+    public DeleteEventHelper(Context context, Activity parentActivity, boolean exitWhenDone, boolean prompt) {
         if (exitWhenDone && parentActivity == null) {
             throw new IllegalArgumentException("parentActivity is required to exit when done");
         }
@@ -182,10 +164,18 @@ public class DeleteEventHelper {
                 CalendarEventModel mModel = new CalendarEventModel();
                 EditEventHelper.setModelFromCursor(mModel, cursor, mContext);
                 cursor.close();
-                DeleteEventHelper.this.delete(mStartMillis, mEndMillis, mModel, mWhichDelete);
+                if (prompt) {
+                    delete(mStartMillis, mEndMillis, mModel, mWhichDelete);
+                } else {
+                    deleteUnprompted(mStartMillis, mEndMillis, mModel, mWhichDelete);
+                }
             }
         };
         mExitWhenDone = exitWhenDone;
+    }
+
+    public DeleteEventHelper(Context context, Activity parentActivity, boolean exitWhenDone) {
+        this(context, parentActivity, exitWhenDone, true);
     }
 
     public void setExitWhenDone(boolean exitWhenDone) {
@@ -336,6 +326,47 @@ public class DeleteEventHelper {
                 Button ok = dialog.getButton(DialogInterface.BUTTON_POSITIVE);
                 ok.setEnabled(false);
             }
+        }
+    }
+
+    private void deleteUnprompted(long begin, long end, CalendarEventModel model, int which) {
+        mWhichDelete = which;
+        mStartMillis = begin;
+        mEndMillis = end;
+        mModel = model;
+        mSyncId = model.mSyncId;
+
+        if (TextUtils.isEmpty(model.mRrule)) {
+            String originalEvent = model.mOriginalSyncId;
+            if (originalEvent == null) {
+                deleteNormalEvent();
+            } else {
+                deleteExceptionEvent();
+            }
+        } else {
+            deleteRepeatingEvent(which);
+        }
+    }
+
+    private void deleteNormalEvent() {
+        long id = mModel.mId; // mCursor.getInt(mEventIndexId);
+
+        // If this event is part of a local calendar, really remove it from the database
+        //
+        // "There are two versions of delete: as an app and as a sync adapter.
+        // An app delete will set the deleted column on an event and remove all instances of that event.
+        // A sync adapter delete will remove the event from the database and all associated data."
+        // from https://developer.android.com/reference/android/provider/CalendarContract.Events
+        boolean isLocal = mModel.mSyncAccountType.equals(CalendarContract.ACCOUNT_TYPE_LOCAL);
+        Uri deleteContentUri = isLocal ? CalendarRepository.asLocalCalendarSyncAdapter(mModel.mSyncAccountName, Events.CONTENT_URI) : Events.CONTENT_URI;
+
+        Uri uri = ContentUris.withAppendedId(deleteContentUri, id);
+        mService.startDelete(mService.getNextToken(), null, uri, null, null, Utils.UNDO_DELAY);
+        if (mCallback != null) {
+            mCallback.run();
+        }
+        if (mExitWhenDone) {
+            mParent.finish();
         }
     }
 

--- a/app/src/main/java/com/android/calendar/event/EditEventFragment.java
+++ b/app/src/main/java/com/android/calendar/event/EditEventFragment.java
@@ -734,11 +734,31 @@ public class EditEventFragment extends Fragment implements EventHandler, OnColor
                         setModelIfDone(TOKEN_REMINDERS);
                     }
 
+                    // disable non-synced calendars for recurring events
+                    // disable all calendars for recurring events and sdk<30
+                    final String selection;
+                    final String[] selectionArgs;
+                    if (!TextUtils.isEmpty(mModel.mRrule)
+                            && Build.VERSION.SDK_INT < Build.VERSION_CODES.R) {
+                        // recurring event, api level < 30. disable changing calendars.
+                        selection = EditEventHelper.CALENDARS_WHERE;
+                        selectionArgs = new String[] { Long.toString(mModel.mCalendarId) };
+                    } else if (!TextUtils.isEmpty(mModel.mRrule)) {
+                        // recurring event, api level >= 30. enable changing calendars to synced calendars.
+                        selection = EditEventHelper.CALENDARS_WHERE_SYNCED_WRITEABLE_VISIBLE;
+                        selectionArgs = null;
+                    } else {
+                        // non recurring event. enable changing calendars to all calendars.
+                        selection = EditEventHelper.CALENDARS_WHERE_WRITEABLE_VISIBLE;
+                        selectionArgs = null;
+                    }
+
                     // TOKEN_CALENDARS
                     mHandler.startQuery(TOKEN_CALENDARS, null, Calendars.CONTENT_URI,
                             EditEventHelper.CALENDARS_PROJECTION,
-                            EditEventHelper.CALENDARS_WHERE_WRITEABLE_VISIBLE,
-                            null /* selection args */, null /* sort order */);
+                            selection,
+                            selectionArgs,
+                            null /* sort order */);
 
                     // TOKEN_COLORS
                     mHandler.startQuery(TOKEN_COLORS, null, Colors.CONTENT_URI,

--- a/app/src/main/java/com/android/calendar/event/EditEventFragment.java
+++ b/app/src/main/java/com/android/calendar/event/EditEventFragment.java
@@ -738,11 +738,11 @@ public class EditEventFragment extends Fragment implements EventHandler, OnColor
                     final String[] selectionArgs;
                     final boolean isRecurring = !TextUtils.isEmpty(mModel.mRrule);
                     if (isRecurring && Build.VERSION.SDK_INT < Build.VERSION_CODES.R) {
-                        // recurring event, api level < 30. disable changing calendars.
+                        // recurring event AND api level < 30. disable changing calendars.
                         selection = EditEventHelper.CALENDARS_WHERE;
                         selectionArgs = new String[] { Long.toString(mModel.mCalendarId) };
                     } else if (isRecurring) {
-                        // recurring event, api level >= 30. enable changing calendars to synced calendars.
+                        // recurring event AND api level >= 30. enable changing calendars to synced calendars.
                         selection = EditEventHelper.CALENDARS_WHERE_SYNCED_WRITEABLE_VISIBLE;
                         selectionArgs = null;
                     } else {

--- a/app/src/main/java/com/android/calendar/event/EditEventFragment.java
+++ b/app/src/main/java/com/android/calendar/event/EditEventFragment.java
@@ -308,7 +308,7 @@ public class EditEventFragment extends Fragment implements EventHandler, OnColor
         super.onAttach(activity);
         mActivity = (AppCompatActivity) activity;
 
-        mHelper = new EditEventHelper(activity, null);
+        mHelper = new EditEventHelper(activity);
         mHandler = new QueryHandler(activity.getContentResolver());
         mModel = new CalendarEventModel(activity, mIntent);
         mInputMethodManager = (InputMethodManager)
@@ -735,12 +735,10 @@ public class EditEventFragment extends Fragment implements EventHandler, OnColor
                     }
 
                     // TOKEN_CALENDARS
-                    String[] selArgs = {
-                            Long.toString(mModel.mCalendarId)
-                    };
                     mHandler.startQuery(TOKEN_CALENDARS, null, Calendars.CONTENT_URI,
-                            EditEventHelper.CALENDARS_PROJECTION, EditEventHelper.CALENDARS_WHERE,
-                            selArgs /* selection args */, null /* sort order */);
+                            EditEventHelper.CALENDARS_PROJECTION,
+                            EditEventHelper.CALENDARS_WHERE_WRITEABLE_VISIBLE,
+                            null /* selection args */, null /* sort order */);
 
                     // TOKEN_COLORS
                     mHandler.startQuery(TOKEN_COLORS, null, Colors.CONTENT_URI,
@@ -752,9 +750,7 @@ public class EditEventFragment extends Fragment implements EventHandler, OnColor
                             mModel.mCalendarAccountName,
                             mModel.mCalendarAccountType
                     );
-                    selArgs = new String[]{
-                            Long.toString(eventId)
-                    };
+                    String[] selArgs = new String[]{ Long.toString(eventId) };
                     mHandler.startQuery(TOKEN_EXTENDED, null, extendedPropUri,
                             EditEventHelper.EXTENDED_PROJECTION,
                             EditEventHelper.EXTENDED_WHERE_EVENT, selArgs, null);
@@ -762,7 +758,7 @@ public class EditEventFragment extends Fragment implements EventHandler, OnColor
                     setModelIfDone(TOKEN_EVENT);
                     break;
                 case TOKEN_ATTENDEES:
-                    try {
+                    try (cursor) {
                         while (cursor.moveToNext()) {
                             String name = cursor.getString(EditEventHelper.ATTENDEES_INDEX_NAME);
                             String email = cursor.getString(EditEventHelper.ATTENDEES_INDEX_EMAIL);
@@ -806,14 +802,12 @@ public class EditEventFragment extends Fragment implements EventHandler, OnColor
                             mModel.addAttendee(attendee);
                             mOriginalModel.addAttendee(attendee);
                         }
-                    } finally {
-                        cursor.close();
                     }
 
                     setModelIfDone(TOKEN_ATTENDEES);
                     break;
                 case TOKEN_REMINDERS:
-                    try {
+                    try (cursor) {
                         // Add all reminders to the models
                         while (cursor.moveToNext()) {
                             int minutes = cursor.getInt(EditEventHelper.REMINDERS_INDEX_MINUTES);
@@ -826,55 +820,45 @@ public class EditEventFragment extends Fragment implements EventHandler, OnColor
                         // Sort appropriately for display
                         Collections.sort(mModel.mReminders);
                         Collections.sort(mOriginalModel.mReminders);
-                    } finally {
-                        cursor.close();
                     }
 
                     setModelIfDone(TOKEN_REMINDERS);
                     break;
                 case TOKEN_CALENDARS:
-                    try {
-                        if (mModel.mId == -1) {
-                            // Populate Calendar spinner only if no event id is set.
-                            MatrixCursor matrixCursor = Utils.matrixCursorFromCursor(cursor);
-                            if (DEBUG) {
-                                Log.d(TAG, "onQueryComplete: setting cursor with "
-                                        + matrixCursor.getCount() + " calendars");
-                            }
-                            mView.setCalendarsCursor(matrixCursor, isAdded() && isResumed(),
-                                    mCalendarId);
-                        } else {
+                    try (cursor) {
+                        MatrixCursor matrixCursor = Utils.matrixCursorFromCursor(cursor);
+                        if (DEBUG) {
+                            Log.d(TAG, "onQueryComplete: setting cursor with " + matrixCursor.getCount() + " calendars");
+                        }
+                        if (mModel.mId != -1) {
                             // Populate model for an existing event
                             EditEventHelper.setModelFromCalendarCursor(mModel, cursor, activity);
                             EditEventHelper.setModelFromCalendarCursor(mOriginalModel, cursor, activity);
                         }
-                    } finally {
-                        cursor.close();
+                        mView.setCalendarsCursor(matrixCursor, isAdded() && isResumed(), mModel.mCalendarId);
                     }
                     setModelIfDone(TOKEN_CALENDARS);
                     break;
                 case TOKEN_COLORS:
-                    if (cursor.moveToFirst()) {
-                        EventColorCache cache = new EventColorCache();
-                        do {
-                            String colorKey = cursor.getString(EditEventHelper.COLORS_INDEX_COLOR_KEY);
-                            int rawColor = cursor.getInt(EditEventHelper.COLORS_INDEX_COLOR);
-                            int displayColor = Utils.getDisplayColorFromColor(activity, rawColor);
-                            String accountName = cursor
-                                    .getString(EditEventHelper.COLORS_INDEX_ACCOUNT_NAME);
-                            String accountType = cursor
-                                    .getString(EditEventHelper.COLORS_INDEX_ACCOUNT_TYPE);
-                            cache.insertColor(accountName, accountType,
-                                    displayColor, colorKey);
-                        } while (cursor.moveToNext());
-                        cache.sortPalettes(new HsvColorComparator());
+                    try (cursor) {
+                        if (cursor.moveToFirst()) {
+                            EventColorCache cache = new EventColorCache();
+                            do {
+                                String colorKey = cursor.getString(EditEventHelper.COLORS_INDEX_COLOR_KEY);
+                                int rawColor = cursor.getInt(EditEventHelper.COLORS_INDEX_COLOR);
+                                int displayColor = Utils.getDisplayColorFromColor(activity, rawColor);
+                                String accountName = cursor
+                                        .getString(EditEventHelper.COLORS_INDEX_ACCOUNT_NAME);
+                                String accountType = cursor
+                                        .getString(EditEventHelper.COLORS_INDEX_ACCOUNT_TYPE);
+                                cache.insertColor(accountName, accountType,
+                                        displayColor, colorKey);
+                            } while (cursor.moveToNext());
+                            cache.sortPalettes(new HsvColorComparator());
 
-                        mModel.mEventColorCache = cache;
-                        mView.mColorPickerNewEvent.setOnClickListener(mOnColorPickerClicked);
-                        mView.mColorPickerExistingEvent.setOnClickListener(mOnColorPickerClicked);
-                    }
-                    if (cursor != null) {
-                        cursor.close();
+                            mModel.mEventColorCache = cache;
+                            mView.mColorPicker.setOnClickListener(mOnColorPickerClicked);
+                        }
                     }
 
                     // If the account name/type is null, the calendar event colors cannot be

--- a/app/src/main/java/com/android/calendar/event/EditEventFragment.java
+++ b/app/src/main/java/com/android/calendar/event/EditEventFragment.java
@@ -734,16 +734,14 @@ public class EditEventFragment extends Fragment implements EventHandler, OnColor
                         setModelIfDone(TOKEN_REMINDERS);
                     }
 
-                    // disable non-synced calendars for recurring events
-                    // disable all calendars for recurring events and sdk<30
                     final String selection;
                     final String[] selectionArgs;
-                    if (!TextUtils.isEmpty(mModel.mRrule)
-                            && Build.VERSION.SDK_INT < Build.VERSION_CODES.R) {
+                    final boolean isRecurring = !TextUtils.isEmpty(mModel.mRrule);
+                    if (isRecurring && Build.VERSION.SDK_INT < Build.VERSION_CODES.R) {
                         // recurring event, api level < 30. disable changing calendars.
                         selection = EditEventHelper.CALENDARS_WHERE;
                         selectionArgs = new String[] { Long.toString(mModel.mCalendarId) };
-                    } else if (!TextUtils.isEmpty(mModel.mRrule)) {
+                    } else if (isRecurring) {
                         // recurring event, api level >= 30. enable changing calendars to synced calendars.
                         selection = EditEventHelper.CALENDARS_WHERE_SYNCED_WRITEABLE_VISIBLE;
                         selectionArgs = null;

--- a/app/src/main/java/com/android/calendar/event/EditEventFragment.java
+++ b/app/src/main/java/com/android/calendar/event/EditEventFragment.java
@@ -738,11 +738,14 @@ public class EditEventFragment extends Fragment implements EventHandler, OnColor
                     final String[] selectionArgs;
                     final boolean isRecurring = !TextUtils.isEmpty(mModel.mRrule);
                     if (isRecurring && Build.VERSION.SDK_INT < Build.VERSION_CODES.R) {
-                        // recurring event AND api level < 30. disable changing calendars.
+                        // recurring event AND api level < 30. disable changing calendars as moving
+                        // recurrences is currently only possible for api level 30+
                         selection = EditEventHelper.CALENDARS_WHERE;
                         selectionArgs = new String[] { Long.toString(mModel.mCalendarId) };
                     } else if (isRecurring) {
-                        // recurring event AND api level >= 30. enable changing calendars to synced calendars.
+                        // recurring event AND api level >= 30. enable changing calendars to synced
+                        // calendars only, as we currently don't allow recurrence exceptions in local calendars
+                        // and would lose them when moving the recurrence between calendars
                         selection = EditEventHelper.CALENDARS_WHERE_SYNCED_WRITEABLE_VISIBLE;
                         selectionArgs = null;
                     } else {

--- a/app/src/main/java/com/android/calendar/event/EditEventFragment.java
+++ b/app/src/main/java/com/android/calendar/event/EditEventFragment.java
@@ -670,7 +670,7 @@ public class EditEventFragment extends Fragment implements EventHandler, OnColor
             long eventId;
             switch (token) {
                 case TOKEN_EVENT:
-                    if (cursor.getCount() == 0) {
+                    if (!cursor.moveToFirst()) {
                         // The cursor is empty. This can happen if the event
                         // was deleted.
                         cursor.close();

--- a/app/src/main/java/com/android/calendar/event/EditEventHelper.java
+++ b/app/src/main/java/com/android/calendar/event/EditEventHelper.java
@@ -651,6 +651,8 @@ public class EditEventHelper {
             setModelFromCursor(model, cursor, mContext);
             final ContentValues values = getContentValuesFromModel(model);
             values.put(Events.CALENDAR_ID, newCalendarId);
+            values.remove(Events.ORGANIZER);
+
             syncId = model.mSyncId;
 
             // set eventIdIndex for back referencing when inserting exceptions
@@ -682,6 +684,7 @@ public class EditEventHelper {
                 final ContentValues values = getContentValuesFromModel(model);
                 values.put(Events.CALENDAR_ID, newCalendarId);
                 values.put(Events.ORIGINAL_INSTANCE_TIME, model.mOriginalTime);
+                values.remove(Events.ORGANIZER);
 
                 ops.add(ContentProviderOperation.newInsert(Events.CONTENT_URI)
                         .withValues(values)

--- a/app/src/main/java/com/android/calendar/event/EditEventHelper.java
+++ b/app/src/main/java/com/android/calendar/event/EditEventHelper.java
@@ -98,6 +98,7 @@ public class EditEventHelper {
             Events.EVENT_COLOR_KEY, // 24
             Events.ACCOUNT_NAME, // 25
             Events.ACCOUNT_TYPE, // 26
+            Events.EXDATE, // 27
             Events.ORIGINAL_INSTANCE_TIME // 28
     };
     protected static final int EVENT_INDEX_ID = 0;
@@ -127,7 +128,8 @@ public class EditEventHelper {
     protected static final int EVENT_INDEX_EVENT_COLOR_KEY = 24;
     protected static final int EVENT_INDEX_ACCOUNT_NAME = 25;
     protected static final int EVENT_INDEX_ACCOUNT_TYPE = 26;
-    protected static final int EVENT_INDEX_ORIGINAL_INSTANCE_TIME = 27;
+    protected static final int EVENT_INDEX_EXDATE = 27;
+    protected static final int EVENT_INDEX_ORIGINAL_INSTANCE_TIME = 28;
 
     public static final String[] REMINDERS_PROJECTION = new String[] {
             Reminders._ID, // 0
@@ -1168,6 +1170,7 @@ public class EditEventHelper {
         }
         String rRule = cursor.getString(EVENT_INDEX_RRULE);
         model.mRrule = rRule;
+        model.exdate = cursor.getString(EVENT_INDEX_EXDATE);
         model.mSyncId = cursor.getString(EVENT_INDEX_SYNC_ID);
         model.mSyncAccountName = cursor.getString(EVENT_INDEX_ACCOUNT_NAME);
         model.mSyncAccountType = cursor.getString(EVENT_INDEX_ACCOUNT_TYPE);
@@ -1357,6 +1360,7 @@ public class EditEventHelper {
         values.put(Events.TITLE, title);
         values.put(Events.ALL_DAY, isAllDay ? 1 : 0);
         values.put(Events.DTSTART, startMillis);
+        values.put(Events.EXDATE, model.exdate);
         values.put(Events.RRULE, rrule);
         if (!TextUtils.isEmpty(rrule)) {
             addRecurrenceRule(values, model);

--- a/app/src/main/java/com/android/calendar/event/EditEventHelper.java
+++ b/app/src/main/java/com/android/calendar/event/EditEventHelper.java
@@ -525,7 +525,9 @@ public class EditEventHelper {
                 }
                 ops.add(b.build());
             }
-        } else if (hasAttendeeData && model.mSelfAttendeeStatus != originalModel.mSelfAttendeeStatus) {
+        } else if (hasAttendeeData &&
+                model.mSelfAttendeeStatus != originalModel.mSelfAttendeeStatus &&
+                model.mOwnerAttendeeId != -1) {
             if (DEBUG) {
                 Log.d(TAG, "Setting attendee status to " + model.mSelfAttendeeStatus);
             }
@@ -563,6 +565,7 @@ public class EditEventHelper {
                 // new events (being inserted into the Events table) won't
                 // have any existing attendees.
                 if (!newEvent) {
+                    removedAttendees.clear();
                     HashMap<String, Attendee> originalAttendees = originalModel.mAttendeesList;
                     for (String originalEmail : originalAttendees.keySet()) {
                         if (newAttendees.containsKey(originalEmail)) {
@@ -1173,7 +1176,7 @@ public class EditEventHelper {
         }
         String rRule = cursor.getString(EVENT_INDEX_RRULE);
         model.mRrule = rRule;
-        model.exdate = cursor.getString(EVENT_INDEX_EXDATE);
+        model.mExDate = cursor.getString(EVENT_INDEX_EXDATE);
         model.mSyncId = cursor.getString(EVENT_INDEX_SYNC_ID);
         model.mSyncAccountName = cursor.getString(EVENT_INDEX_ACCOUNT_NAME);
         model.mSyncAccountType = cursor.getString(EVENT_INDEX_ACCOUNT_TYPE);
@@ -1363,7 +1366,7 @@ public class EditEventHelper {
         values.put(Events.TITLE, title);
         values.put(Events.ALL_DAY, isAllDay ? 1 : 0);
         values.put(Events.DTSTART, startMillis);
-        values.put(Events.EXDATE, model.exdate);
+        values.put(Events.EXDATE, model.mExDate);
         values.put(Events.RRULE, rrule);
         if (!TextUtils.isEmpty(rrule)) {
             addRecurrenceRule(values, model);

--- a/app/src/main/java/com/android/calendar/event/EditEventHelper.java
+++ b/app/src/main/java/com/android/calendar/event/EditEventHelper.java
@@ -362,9 +362,15 @@ public class EditEventHelper {
             // event calendar has changed
             eventIdIndex = ops.size();
 
-            ops.addAll(moveEventToCalendar(
-                    String.valueOf(model.mId),
-                    String.valueOf(model.mCalendarId)));
+            // when moving recurrences between calendars, we must use the start time of the whole
+            // recurrence and not the start time of the currently opened instance.
+            if (!TextUtils.isEmpty(model.mRrule)) {
+                long recurrenceStartTime = getStartTimeForRecurrence(
+                    model.mOriginalStart, model.mStart, originalModel.mStart, model.mAllDay);
+                values.put(Events.DTSTART, recurrenceStartTime);
+            }
+
+            ops.addAll(moveEventToCalendar(model.mId, model.mSyncId, values));
 
             forceSaveReminders = true;
         } else if (TextUtils.isEmpty(model.mRrule) && TextUtils.isEmpty(originalModel.mRrule)) {
@@ -457,8 +463,9 @@ public class EditEventHelper {
             }
         }
 
-        // New Event or New Exception to an existing event
+        // New event or new exception to an existing event or event moved to different calendar
         boolean newEvent = (eventIdIndex != -1);
+
         ArrayList<ReminderEntry> originalReminders;
         if (originalModel != null) {
             originalReminders = originalModel.mReminders;
@@ -630,76 +637,71 @@ public class EditEventHelper {
         return true;
     }
 
-    private List<ContentProviderOperation> moveEventToCalendar(
-            final String eventId, final String newCalendarId) {
+    /**
+     * Moves an existing event to a different calendar provider by deleting the event from its old
+     * calendar and creating the same event in the new calendar.
+     *
+     * @param eventId    the id of the event in the old calendar which should be moved. this is used
+     *                   to delete the event from the old calendars, and in case of a recurrence,
+     *                   its exceptions.
+     * @param syncId     sync-id of the event to be moved. used the find recurrence exceptions if
+     *                   provided.
+     * @param eventValues the new values of the event. the id of the new calendar should be set here
+     *                   via {@link Events#CALENDAR_ID}. if this is a recurrence, please see
+     *                   {@link #getStartTimeForRecurrence(long, long, long, boolean)} for getting
+     *                   the DTSTART value correct.
+     * @return a list of content provider operations which have to be performed in order to move the
+     * event to the new calendar.
+     */
+    private List<ContentProviderOperation> moveEventToCalendar(long eventId, String syncId,
+        ContentValues eventValues) {
 
         final List<ContentProviderOperation> ops = new ArrayList<>();
-        final String syncId;
-        int eventIdIndex;
 
-        // retrieve event, create it in target calendar, delete from source calendar
-        try (Cursor cursor = mContextResolver.query(
-                Events.CONTENT_URI,
-                EVENT_PROJECTION,
-                Events._ID + "= ?",
-                new String[]{String.valueOf(eventId)},
-                null
-        )) {
-            if (cursor == null || cursor.getCount() != 1 || !cursor.moveToFirst()) {
-                final String count = cursor == null ? "no cursor" : String.valueOf(cursor.getCount());
-                throw new IllegalStateException("expected exactly 1 event, but got " + count);
-            }
+        // set eventIdIndex for back referencing when inserting recurrence exceptions later
+        int eventIdIndex = ops.size();
 
-            final CalendarEventModel model = new CalendarEventModel();
-            setModelFromCursor(model, cursor, mContext);
-            final ContentValues values = getContentValuesFromModel(model);
-            values.put(Events.CALENDAR_ID, newCalendarId);
-            values.remove(Events.ORGANIZER);
+        // create event in new calendar and delete the event from the old calendar
+        // insert of the new event must always be the first operation, as calling code may depend on this!
+        ops.add(ContentProviderOperation.newInsert(Events.CONTENT_URI)
+            .withValues(eventValues)
+            .build());
 
-            syncId = model.mSyncId;
+        ops.add(ContentProviderOperation.newDelete(
+            ContentUris.withAppendedId(Events.CONTENT_URI, eventId)).build());
 
-            // set eventIdIndex for back referencing when inserting exceptions
-            eventIdIndex = ops.size();
-            ops.add(ContentProviderOperation.newInsert(Events.CONTENT_URI)
-                    .withValues(values)
-                    .build());
-
-            ops.add(ContentProviderOperation.newDelete(
-                    ContentUris.withAppendedId(Events.CONTENT_URI, model.mId)).build());
-        }
-
-        // moving event exceptions is currently ony supported for api level 30 and above
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R) {
+        // if syncId is not provided, or api level is < 30, return here before trying to move exceptions
+        if (TextUtils.isEmpty(syncId) || Build.VERSION.SDK_INT < Build.VERSION_CODES.R) {
             return ops;
         }
 
         // retrieve events exceptions, create them in target calendar, delete them from source calendar
         try (Cursor cursor = mContextResolver.query(
-                Events.CONTENT_URI,
-                EVENT_PROJECTION,
-                Events.ORIGINAL_SYNC_ID + "= ? AND " + Events._SYNC_ID + " IS NULL",
-                new String[]{String.valueOf(syncId)},
-                null
+            Events.CONTENT_URI,
+            EVENT_PROJECTION,
+            Events.ORIGINAL_SYNC_ID + "= ? AND " + Events._SYNC_ID + " IS NULL",
+            new String[]{syncId},
+            null
         )) {
             while (cursor != null && cursor.moveToNext()) {
                 final CalendarEventModel model = new CalendarEventModel();
                 setModelFromCursor(model, cursor, mContext);
                 final ContentValues values = getContentValuesFromModel(model);
-                values.put(Events.CALENDAR_ID, newCalendarId);
+                values.put(Events.CALENDAR_ID, eventValues.getAsString(Events.CALENDAR_ID));
                 values.put(Events.ORIGINAL_INSTANCE_TIME, model.mOriginalTime);
                 values.remove(Events.ORGANIZER);
 
                 ops.add(ContentProviderOperation.newInsert(Events.CONTENT_URI)
-                        .withValues(values)
-                        // note: this call requires API level 30
-                        .withValueBackReference(Events.ORIGINAL_ID, eventIdIndex, Events._ID)
-                        .build());
+                    .withValues(values)
+                    // note: this call requires API level 30
+                    .withValueBackReference(Events.ORIGINAL_ID, eventIdIndex, Events._ID)
+                    .build());
 
-                Uri.Builder b = Events.CONTENT_EXCEPTION_URI.buildUpon();
-                ContentUris.appendId(b, Long.parseLong(eventId));
-                ContentUris.appendId(b, model.mId);
+                Uri.Builder exceptionUriBuilder = Events.CONTENT_EXCEPTION_URI.buildUpon();
+                ContentUris.appendId(exceptionUriBuilder, eventId); // original event id
+                ContentUris.appendId(exceptionUriBuilder, model.mId); // exception event id
 
-                ops.add(ContentProviderOperation.newDelete(b.build()).build());
+                ops.add(ContentProviderOperation.newDelete(exceptionUriBuilder.build()).build());
             }
         }
 
@@ -791,30 +793,50 @@ public class EditEventHelper {
             return;
         }
 
-        // If we are modifying all events then we need to set DTSTART to the
-        // start time of the first event in the series, not the current
-        // date and time. If the start time of the event was changed
-        // (from, say, 3pm to 4pm), then we want to add the time difference
-        // to the start time of the first event in the series (the DTSTART
-        // value). If we are modifying one instance or all following instances,
-        // then we leave the DTSTART field alone.
+        // If we are modifying all events in then we need to set DTSTART to the
+        // start time of the first event in the series, not the current date and time.
         if (modifyWhich == MODIFY_ALL) {
-            long oldStartMillis = originalModel.mStart;
-            if (oldBegin != newBegin) {
-                // The user changed the start time of this event
-                long offset = newBegin - oldBegin;
-                oldStartMillis += offset;
-            }
-            if (newAllDay) {
-                Time time = new Time(Time.TIMEZONE_UTC);
-                time.set(oldStartMillis);
-                time.setHour(0);
-                time.setMinute(0);
-                time.setSecond(0);
-                oldStartMillis = time.toMillis();
-            }
-            values.put(Events.DTSTART, oldStartMillis);
+            values.put(Events.DTSTART,
+                    getStartTimeForRecurrence(oldBegin, newBegin, originalModel.mStart, newAllDay));
         }
+    }
+
+    /**
+     * If we are modifying all events in a recurrence, then we need to set DTSTART to the start time
+     * of the first event in the recurrence, not to the date and time of the event currently being
+     * modified. If the start time of the event was changed (from, say, 3pm to 4pm), then we need to
+     * add the time difference to the start time of the first event in the recurrence (the DTSTART
+     * value).
+     * <p>
+     * If we are modifying one instance or if we are modifying all following instances of a
+     * recurrence then we leave the DTSTART field alone. This method should not be used to get the
+     * start time for these cases!
+     *
+     * @param oldStartTime    the start time of the currently opened event, before user
+     *                        modification
+     * @param newStartTime    the start time of the currently opened event, after user modification
+     * @param seriesStartTime the start time of the recurring series
+     * @param isAllDay        whether the event is an all-day event, after user modification
+     */
+    private long getStartTimeForRecurrence(long oldStartTime, long newStartTime,
+        long seriesStartTime, boolean isAllDay) {
+
+        if (oldStartTime != newStartTime) {
+            // The user changed the start time of this event
+            long offset = newStartTime - oldStartTime;
+            seriesStartTime += offset;
+        }
+
+        if (isAllDay) {
+            Time time = new Time(Time.TIMEZONE_UTC);
+            time.set(seriesStartTime);
+            time.setHour(0);
+            time.setMinute(0);
+            time.setSecond(0);
+            seriesStartTime = time.toMillis();
+        }
+
+        return seriesStartTime;
     }
 
     /**

--- a/app/src/main/java/com/android/calendar/event/EditEventView.java
+++ b/app/src/main/java/com/android/calendar/event/EditEventView.java
@@ -1224,6 +1224,8 @@ public class EditEventView implements View.OnClickListener, DialogInterface.OnCa
             mLocationGroup.setVisibility(View.VISIBLE);
             mDescriptionGroup.setVisibility(View.VISIBLE);
             mUrlGroup.setVisibility(View.VISIBLE);
+
+            // disallow changing calendar for recurrences when not modifying all instances
             mCalendarsSpinner.setEnabled(mode == Utils.MODIFY_ALL);
         }
         setAllDayViewsVisibility(mAllDayCheckBox.isChecked());

--- a/app/src/main/java/com/android/calendar/event/EditEventView.java
+++ b/app/src/main/java/com/android/calendar/event/EditEventView.java
@@ -1197,6 +1197,7 @@ public class EditEventView implements View.OnClickListener, DialogInterface.OnCa
             if (TextUtils.isEmpty(mUrlTextView.getText())) {
                 mUrlGroup.setVisibility(View.GONE);
             }
+            mCalendarsSpinner.setEnabled(false);
         } else {
             for (View v : mViewOnlyList) {
                 v.setVisibility(View.GONE);
@@ -1223,6 +1224,7 @@ public class EditEventView implements View.OnClickListener, DialogInterface.OnCa
             mLocationGroup.setVisibility(View.VISIBLE);
             mDescriptionGroup.setVisibility(View.VISIBLE);
             mUrlGroup.setVisibility(View.VISIBLE);
+            mCalendarsSpinner.setEnabled(mode == Utils.MODIFY_ALL);
         }
         setAllDayViewsVisibility(mAllDayCheckBox.isChecked());
     }

--- a/app/src/main/res/color/calendar_spinner_item_colors.xml
+++ b/app/src/main/res/color/calendar_spinner_item_colors.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:color="#61000000" android:state_enabled="false" />
+    <item android:color="#000000" />
+</selector>

--- a/app/src/main/res/color/calendar_spinner_item_colors.xml
+++ b/app/src/main/res/color/calendar_spinner_item_colors.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
-    <item android:color="#61000000" android:state_enabled="false" />
-    <item android:color="#000000" />
+    <item android:color="?attr/calendarSpinnerDisabledTextColor" android:state_enabled="false" />
+    <item android:color="?android:attr/textColorPrimary" />
 </selector>

--- a/app/src/main/res/layout/calendars_spinner_item.xml
+++ b/app/src/main/res/layout/calendars_spinner_item.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- Copyright (C) 2008 The Android Open Source Project
+<?xml version="1.0" encoding="utf-8"?><!-- Copyright (C) 2008 The Android Open Source Project
 
      Licensed under the Apache License, Version 2.0 (the "License");
      you may not use this file except in compliance with the License.
@@ -15,27 +14,28 @@
 -->
 
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:orientation="vertical"
+    android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:layout_width="match_parent">
+    android:orientation="vertical">
 
-    <TextView android:id="@+id/calendar_name"
-        style="?android:attr/spinnerItemStyle"
+    <TextView
+        android:id="@+id/calendar_name"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:singleLine="true"
+        android:duplicateParentState="true"
         android:ellipsize="end"
-        android:textColor="?attr/light_dark"
+        android:singleLine="true"
+        android:textColor="@color/calendar_spinner_item_colors"
         android:textSize="18sp" />
 
     <TextView
         android:id="@+id/account_name"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:duplicateParentState="true"
         android:ellipsize="marquee"
         android:singleLine="true"
-        style="?android:attr/spinnerItemStyle"
-        android:textColor="?attr/light_dark"
+        android:textColor="@color/calendar_spinner_item_colors"
         android:textSize="14sp" />
 
 </LinearLayout>

--- a/app/src/main/res/layout/calendars_spinner_item.xml
+++ b/app/src/main/res/layout/calendars_spinner_item.xml
@@ -1,4 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?><!-- Copyright (C) 2008 The Android Open Source Project
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (C) 2008 The Android Open Source Project
 
      Licensed under the Apache License, Version 2.0 (the "License");
      you may not use this file except in compliance with the License.

--- a/app/src/main/res/layout/edit_event_all.xml
+++ b/app/src/main/res/layout/edit_event_all.xml
@@ -26,19 +26,6 @@
         android:layout_height="wrap_content"
         android:gravity="center_vertical">
 
-        <!-- CALENDAR DISPLAY for existing events -->
-        <androidx.constraintlayout.widget.Group
-            android:id="@+id/calendar_group"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            app:constraint_referenced_ids="calendar_textview,calendar_textview_secondary,change_color_new_event" />
-
-        <androidx.constraintlayout.widget.Group
-            android:id="@+id/calendar_selector_group"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            app:constraint_referenced_ids="calendars_spinner,change_color_new_event" />
-
         <androidx.constraintlayout.widget.Group
             android:id="@+id/timezone_button_row"
             android:layout_width="wrap_content"
@@ -104,37 +91,8 @@
             app:layout_constraintStart_toEndOf="@+id/calendar_selector_group_icon"
             app:layout_constraintTop_toTopOf="@+id/calendar_selector_group_icon" />
 
-        <TextView
-            android:id="@+id/calendar_textview"
-            style="@style/TextAppearance.EditEvent"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="12dp"
-            android:layout_marginTop="8dp"
-            android:textColor="?attr/light_dark"
-            app:layout_constraintStart_toEndOf="@+id/calendar_selector_group_icon"
-            app:layout_constraintTop_toBottomOf="@id/view"
-            tools:layout_conversion_absoluteHeight="24dp"
-            tools:layout_conversion_absoluteWidth="363dp" />
-
-        <TextView
-            android:id="@+id/calendar_textview_secondary"
-            style="@style/TextAppearance.EditEvent"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="12dp"
-            android:layout_marginTop="2dp"
-            android:layout_marginBottom="4dp"
-            android:textColor="?attr/light_dark"
-            android:textSize="14sp"
-            app:layout_constraintBottom_toTopOf="@+id/view1"
-            app:layout_constraintStart_toEndOf="@+id/calendar_selector_group_icon"
-            app:layout_constraintTop_toBottomOf="@+id/calendar_textview"
-            tools:layout_conversion_absoluteHeight="19dp"
-            tools:layout_conversion_absoluteWidth="363dp" />
-
         <ImageButton
-            android:id="@+id/change_color_new_event"
+            android:id="@+id/change_color"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginEnd="24dp"

--- a/app/src/main/res/layout/edit_event_all.xml
+++ b/app/src/main/res/layout/edit_event_all.xml
@@ -80,32 +80,34 @@
 
         <Spinner
             android:id="@+id/calendars_spinner"
-            android:layout_width="0dp"
+            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginStart="4dp"
+            android:layout_marginStart="12dp"
+            android:layout_marginEnd="32dp"
             android:gravity="center_vertical"
-            android:prompt="@string/edit_event_calendar_label"
             android:paddingStart="0dp"
             android:paddingEnd="2dp"
+            android:prompt="@string/edit_event_calendar_label"
             app:layout_constraintBottom_toBottomOf="@+id/calendar_selector_group_icon"
+            app:layout_constraintEnd_toStartOf="@+id/change_color"
+            app:layout_constraintHorizontal_bias="0.0"
             app:layout_constraintStart_toEndOf="@+id/calendar_selector_group_icon"
             app:layout_constraintTop_toTopOf="@+id/calendar_selector_group_icon" />
 
         <ImageButton
             android:id="@+id/change_color"
-            android:layout_width="0dp"
+            android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginEnd="24dp"
-            android:layout_marginTop="20dp"
-            android:background="?android:attr/selectableItemBackground"
+            android:layout_marginEnd="32dp"
+            android:background="?android:attr/selectableItemBackgroundBorderless"
             android:contentDescription="@string/choose_event_color_label"
             android:enabled="false"
             android:scaleType="center"
             android:src="@drawable/ic_colorpicker"
-            android:visibility="invisible"
-            app:layout_constraintBottom_toBottomOf="@+id/calendar_selector_group_icon"
+            app:layout_constraintBottom_toBottomOf="@+id/calendars_spinner"
             app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintTop_toTopOf="@+id/view" />
+            app:layout_constraintTop_toTopOf="@+id/calendars_spinner"
+            tools:visibility="visible" />
 
         <View
             android:id="@+id/view1"

--- a/app/src/main/res/values-v31/themes.xml
+++ b/app/src/main/res/values-v31/themes.xml
@@ -40,6 +40,7 @@
         <item name="iconSettingsGeneral">@android:color/black</item>
         <item name="iconAddCalendar">@android:color/black</item>
         <item name="iconCalendarAccount">@android:color/black</item>
+       <item name="calendarSpinnerDisabledTextColor">@color/calendar_item_disabled</item>
     </style>
     <style name="CalendarAppThemeDarkMonet" parent="Theme.AppCompat.NoActionBar">
         <item name="colorPrimary">@android:color/system_accent1_500</item>
@@ -80,6 +81,7 @@
         <item name="iconSettingsGeneral">@android:color/white</item>
         <item name="iconAddCalendar">@android:color/white</item>
         <item name="iconCalendarAccount">@android:color/white</item>
+        <item name="calendarSpinnerDisabledTextColor">@color/calendar_item_disabled_dark</item>
     </style>
     <style name="CalendarAppThemeBlackMonet" parent="Theme.AppCompat.NoActionBar">
         <item name="colorPrimary">@android:color/system_accent1_500</item>
@@ -120,5 +122,6 @@
         <item name="iconSettingsGeneral">@android:color/white</item>
         <item name="iconAddCalendar">@android:color/white</item>
         <item name="iconCalendarAccount">@android:color/white</item>
+        <item name="calendarSpinnerDisabledTextColor">@color/calendar_item_disabled_black</item>
     </style>
 </resources>

--- a/app/src/main/res/values/attrs.xml
+++ b/app/src/main/res/values/attrs.xml
@@ -49,5 +49,6 @@
         <attr name="iconAddCalendar" format="reference" />
         <attr name="iconCalendarAccount" format="reference" />
         <attr name="divider_select_calendars" format="color"/>
+        <attr name="calendarSpinnerDisabledTextColor" format="color" />
     </declare-styleable>
 </resources>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -109,6 +109,7 @@
     <color name="calendar_hidden">#ff808080</color>
     <color name="calendar_secondary_visible">#ff323232</color>
     <color name="calendar_secondary_hidden">#ff808080</color>
+    <color name="calendar_item_disabled">#61000000</color>
 
     <!-- Text color of the date in the Calendar widget -->
 
@@ -294,6 +295,7 @@
     <color name="calendar_hidden_black">#757575</color>
     <color name="calendar_secondary_visible_black">#ffffff</color>
     <color name="calendar_secondary_hidden_black">#757575</color>
+    <color name="calendar_item_disabled_black">#61ffffff</color>
 
     <!-- timezone_GMT_background_color -->
     <color name="calendar_date_banner_background_black">#212121</color>
@@ -399,6 +401,7 @@
     <color name="calendar_hidden_dark">#757575</color>
     <color name="calendar_secondary_visible_dark">#ffffff</color>
     <color name="calendar_secondary_hidden_dark">#757575</color>
+    <color name="calendar_item_disabled_dark">#61ffffff</color>
 
     <!-- timezone_GMT_background_color -->
     <color name="calendar_date_banner_background_dark">#212121</color>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -40,6 +40,7 @@
         <item name="iconAddCalendar">@android:color/black</item>
         <item name="iconCalendarAccount">@android:color/black</item>
         <item name="divider_select_calendars">@color/divider_select_calendars</item>
+        <item name="calendarSpinnerDisabledTextColor">@color/calendar_item_disabled</item>
     </style>
 
     <style name="CalendarAppThemeDark" parent="Theme.AppCompat.NoActionBar">
@@ -82,6 +83,7 @@
         <item name="iconAddCalendar">@android:color/white</item>
         <item name="iconCalendarAccount">@android:color/white</item>
         <item name="divider_select_calendars">@color/divider_select_calendars_dark</item>
+        <item name="calendarSpinnerDisabledTextColor">@color/calendar_item_disabled_dark</item>
     </style>
 
     <style name="CalendarAppThemeBlack" parent="Theme.AppCompat.NoActionBar">
@@ -124,6 +126,7 @@
         <item name="iconAddCalendar">@android:color/white</item>
         <item name="iconCalendarAccount">@android:color/white</item>
         <item name="divider_select_calendars">@color/divider_select_calendars_black</item>
+        <item name="calendarSpinnerDisabledTextColor">@color/calendar_item_disabled_black</item>
     </style>
 
 


### PR DESCRIPTION
these changes have been lying around for some time, finally found the time to finalize them and create this merge request.

in essence, this will just delete the old event and recreate it with a new id in the new calendar.
please test thoroughly and let me know if something is unclear.

fixes a bunch of open (duplicated) issues, here a few i found while quickly scanning the backlog:
fixes #62 
fixes #101
fixes #812
fixes #1266 
fixes #1400
fixes #1410

and also fixes #1351 and fixes #1134: the color picker is now hidden if the calendar does not provide any colors.