### PR TITLE
ImportActivity: Treat start date as end date if latter is un-specified

### DIFF
--- a/app/src/main/java/com/android/calendar/ImportActivity.java
+++ b/app/src/main/java/com/android/calendar/ImportActivity.java
@@ -181,9 +181,13 @@ public class ImportActivity extends Activity {
 
         String dtEnd = firstEvent.getProperty(VEvent.DTEND);
         String dtEndParam = firstEvent.getPropertyParameters(VEvent.DTEND);
-        if (!TextUtils.isEmpty(dtEnd)) {
+        if (dtEnd != null && !TextUtils.isEmpty(dtEnd)) {
             calIntent.putExtra(CalendarContract.EXTRA_EVENT_END_TIME,
                     getLocalTimeFromString(dtEnd, dtEndParam));
+        } else {
+            // Treat start date as end date if un-specified
+            dtEnd = dtStart;
+            dtEndParam = dtStartParam;
         }
 
         boolean isAllDay = getLocalTimeFromString(dtEnd, dtEndParam)


### PR DESCRIPTION
## Summary

This PR addresses an issue where the end date for imported events might be unspecified. In that case, we should use the start date as the end date as people might be using such events for reminders (events not having a specific end time).

Originally reported at: https://gitlab.com/CalyxOS/calyxos/-/issues/1800

## Stack trace

```
--------- beginning of crash
08-25 17:26:43.030  8545  8545 E AndroidRuntime: FATAL EXCEPTION: main
08-25 17:26:43.030  8545  8545 E AndroidRuntime: Process: ws.xsoh.etar, PID: 8545
08-25 17:26:43.030  8545  8545 E AndroidRuntime: java.lang.RuntimeException: Unable to start activity ComponentInfo{ws.xsoh.etar/com.android.calendar.ImportActivity}: java.lang.NullPointerException: Attempt to invoke virtual method 'boolean java.lang.String.endsWith(java.lang.String)' on a null object reference
08-25 17:26:43.030  8545  8545 E AndroidRuntime:        at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:3644)
08-25 17:26:43.030  8545  8545 E AndroidRuntime:        at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:3781)
08-25 17:26:43.030  8545  8545 E AndroidRuntime:        at android.app.servertransaction.LaunchActivityItem.execute(LaunchActivityItem.java:101)
08-25 17:26:43.030  8545  8545 E AndroidRuntime:        at android.app.servertransaction.TransactionExecutor.executeCallbacks(TransactionExecutor.java:138)
08-25 17:26:43.030  8545  8545 E AndroidRuntime:        at android.app.servertransaction.TransactionExecutor.execute(TransactionExecutor.java:95)
08-25 17:26:43.030  8545  8545 E AndroidRuntime:        at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2306)
08-25 17:26:43.030  8545  8545 E AndroidRuntime:        at android.os.Handler.dispatchMessage(Handler.java:106)
08-25 17:26:43.030  8545  8545 E AndroidRuntime:        at android.os.Looper.loopOnce(Looper.java:201)
08-25 17:26:43.030  8545  8545 E AndroidRuntime:        at android.os.Looper.loop(Looper.java:288)
08-25 17:26:43.030  8545  8545 E AndroidRuntime:        at android.app.ActivityThread.main(ActivityThread.java:7918)
08-25 17:26:43.030  8545  8545 E AndroidRuntime:        at java.lang.reflect.Method.invoke(Native Method)
08-25 17:26:43.030  8545  8545 E AndroidRuntime:        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:548)
08-25 17:26:43.030  8545  8545 E AndroidRuntime:        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:936)
08-25 17:26:43.030  8545  8545 E AndroidRuntime: Caused by: java.lang.NullPointerException: Attempt to invoke virtual method 'boolean java.lang.String.endsWith(java.lang.String)' on a null object reference
08-25 17:26:43.030  8545  8545 E AndroidRuntime:        at com.android.calendar.ImportActivity.getLocalTimeFromString(ImportActivity.java:51)
08-25 17:26:43.030  8545  8545 E AndroidRuntime:        at com.android.calendar.ImportActivity.parseCalFile(ImportActivity.java:186)
08-25 17:26:43.030  8545  8545 E AndroidRuntime:        at com.android.calendar.ImportActivity.onCreate(ImportActivity.java:43)
08-25 17:26:43.030  8545  8545 E AndroidRuntime:        at android.app.Activity.performCreate(Activity.java:8342)
08-25 17:26:43.030  8545  8545 E AndroidRuntime:        at android.app.Activity.performCreate(Activity.java:8321)
08-25 17:26:43.030  8545  8545 E AndroidRuntime:        at android.app.Instrumentation.callActivityOnCreate(Instrumentation.java:1421)
08-25 17:26:43.030  8545  8545 E AndroidRuntime:        at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:3625)
08-25 17:26:43.030  8545  8545 E AndroidRuntime:        ... 12 more
08-25 17:26:43.031  1170  8577 I DropBoxManagerService: add tag=data_app_crash isTagEnabled=true flags=0x2
08-25 17:26:43.031  1170  8722 W ActivityTaskManager:   Force finishing activity ws.xsoh.etar/com.android.calendar.ImportActivity
08-25 17:26:43.041  8545  8545 I Process : Sending signal. PID: 8545 SIG: 9
08-25 17:26:43.043  7885  7885 E RippleDrawable: The RippleDrawable.STYLE_PATTERNED animation is not supported for a non-hardware accelerated Canvas. Skipping animation.
08-25 17:26:43.049  1170  8722 I ActivityManager: Process ws.xsoh.etar (pid 8545) has died: fg  TOP
```