### PR TITLE
Application can't close system dialogs on 12 and above

### DIFF
--- a/app/src/main/java/com/android/calendar/alerts/AlertReceiver.java
+++ b/app/src/main/java/com/android/calendar/alerts/AlertReceiver.java
@@ -840,7 +840,10 @@ public class AlertReceiver extends BroadcastReceiver {
     }
 
     private void closeNotificationShade(Context context) {
-        Intent closeNotificationShadeIntent = new Intent(Intent.ACTION_CLOSE_SYSTEM_DIALOGS);
-        context.sendBroadcast(closeNotificationShadeIntent);
+        // https://developer.android.com/about/versions/12/behavior-changes-all#close-system-dialogs
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) {
+            Intent closeNotificationShadeIntent = new Intent(Intent.ACTION_CLOSE_SYSTEM_DIALOGS);
+            context.sendBroadcast(closeNotificationShadeIntent);
+        }
     }
 }


### PR DESCRIPTION
Crashing due to permission issue

`09-15 12:19:59.147  5734  5734 E AndroidRuntime: java.lang.RuntimeException: Unable to start receiver com.android.calendar.alerts.AlertReceiver: java.lang.SecurityException: Permission Denial: android.intent.action.CLOSE_SYSTEM_DIALOGS broadcast from ws.xsoh.etar (pid=5734, uid=10186) requires android.permission.BROADCAST_CLOSE_SYSTEM_DIALOGS.`