### PR TITLE
when user changes event timezone, start/end same time in new timezone

### DIFF
--- a/app/src/main/java/com/android/calendar/Utils.java
+++ b/app/src/main/java/com/android/calendar/Utils.java
@@ -2246,4 +2246,18 @@ public class Utils {
         }
     }
 
+    /**
+     * Change a Time object to be the same (year, month, day, hour, minute, second) tuple
+     * but in another timezone
+     *
+     * @param t The Time object to modify
+     * @param timezone the new timezone
+     */
+    public static void changeTimezoneOnly(Time t, String timezone) {
+        Time pivot = new Time(timezone);
+        pivot.set(t.getSecond(), t.getMinute(), t.getHour(),
+                  t.getDay(), t.getMonth(), t.getYear());
+        t.set(pivot);
+    }
+
 }

--- a/app/src/main/java/com/android/calendar/event/EditEventView.java
+++ b/app/src/main/java/com/android/calendar/event/EditEventView.java
@@ -424,12 +424,12 @@ public class EditEventView implements View.OnClickListener, DialogInterface.OnCa
 
     private void setTimezone(String timeZone) {
         mTimezone = timeZone;
-        mStartTime.setTimezone(mTimezone);
-        long timeMillis = mStartTime.normalize();
-        mEndTime.setTimezone(mTimezone);
+        Utils.changeTimezoneOnly(mStartTime, mTimezone);
+        Utils.changeTimezoneOnly(mEndTime, mTimezone);
+        long startMillis = mStartTime.normalize();
         mEndTime.normalize();
 
-        populateTimezone(timeMillis);
+        populateTimezone(startMillis);
     }
 
     private void populateTimezone(long eventStartTime) {


### PR DESCRIPTION
as opposed to silently and invisibly converting the absolute datetime to new timezine.

E.g. if the event was:

start: 14 February 19:00 (invisibly: UTC+2)
end:   14 February 23:00 (invisibly: UTC+2)
tz:    UTC+2

and the users changes the tz to UTC+3, the times must be changed to:

start: 14 February 19:00 (invisibly: UTC+3)
end:   14 February 23:00 (invisibly: UTC+3)

as opposed to remaining:

start: 14 February 19:00 (invisibly: UTC+2)
end:   14 February 23:00 (invisibly: UTC+2)

and thus becoming on save:

start: 14 February 20:00 UTC+3
end:   15 February 00:00 UTC+3


which is not what the user meant...