### PR TITLE
Fix recurring events with unsupported rrules.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -114,6 +114,9 @@ dependencies {
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutines_version"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$coroutines_version"
 
+    // https://mvnrepository.com/artifact/org.dmfs/lib-recur
+    implementation 'org.dmfs:lib-recur:0.15.0'
+
 }
 
 preBuild.dependsOn (":aarGen")

--- a/app/src/main/java/com/android/calendar/Event.java
+++ b/app/src/main/java/com/android/calendar/Event.java
@@ -400,7 +400,7 @@ public class Event implements Cloneable {
     }
 
     /** Android's RRULE code is broken in a way the creates additional events in certain
-     *  circumstances (though never doesn't create the actaul event) so let's use another RRULE
+     *  circumstances (though never doesn't create the actual event) so let's use another RRULE
      *  parser to validate if the event is real or not.
      *
      *  In this case we're using lib-recur from https://github.com/dmfs/lib-recur through maven.


### PR DESCRIPTION
The android calendar provider does not support RRULE's with BYSETPOS or BYWEEKNO properly, so additional processing has to be done to ensure that duplicate events are not added to the calendar.

This is accomplished by using a separate RRULE processor, [lib-recur](https://github.com/dmfs/lib-recur), to double check that the instance is valid.

Resolves #1132 