### PR TITLE
gh#1463 fix wrong day display in widget

### DIFF
--- a/app/src/main/java/com/android/calendar/widget/CalendarAppWidgetModel.java
+++ b/app/src/main/java/com/android/calendar/widget/CalendarAppWidgetModel.java
@@ -60,13 +60,11 @@ class CalendarAppWidgetModel {
     }
 
     public void buildFromCursor(Cursor cursor, String timeZone) {
-        final Time recycle = new Time(timeZone);
         final ArrayList<LinkedList<RowInfo>> mBuckets =
                 new ArrayList<LinkedList<RowInfo>>(CalendarAppWidgetService.MAX_DAYS);
         for (int i = 0; i < CalendarAppWidgetService.MAX_DAYS; i++) {
             mBuckets.add(new LinkedList<RowInfo>());
         }
-        recycle.set(System.currentTimeMillis());
         mShowTZ = !TextUtils.equals(timeZone, Utils.getCurrentTimezone());
         if (mShowTZ) {
             mHomeTZName = TimeZone.getTimeZone(timeZone).getDisplayName(false, TimeZone.SHORT);
@@ -93,6 +91,7 @@ class CalendarAppWidgetModel {
 
             // Adjust all-day times into local timezone
             if (allDay) {
+                final Time recycle = new Time();
                 start = Utils.convertAlldayUtcToLocal(recycle, start, tz);
                 end = Utils.convertAlldayUtcToLocal(recycle, end, tz);
             }
@@ -131,6 +130,7 @@ class CalendarAppWidgetModel {
             if (!bucket.isEmpty()) {
                 // We don't show day header in today
                 if (day != mTodayJulianDay) {
+                    final Time recycle = new Time(timeZone);
                     final DayInfo dayInfo = populateDayInfo(day, recycle);
                     // Add the day header
                     final int dayIndex = mDayInfos.size();

--- a/app/src/main/java/com/android/calendar/widget/CalendarAppWidgetModel.java
+++ b/app/src/main/java/com/android/calendar/widget/CalendarAppWidgetModel.java
@@ -50,7 +50,7 @@ class CalendarAppWidgetModel {
     public CalendarAppWidgetModel(Context context, String timeZone) {
         mNow = System.currentTimeMillis();
         Time time = new Time(timeZone);
-        time.set(System.currentTimeMillis()); // This is needed for gmtoff to be set
+        time.set(mNow); // This is needed for gmtoff to be set
         mTodayJulianDay = Time.getJulianDay(mNow, time.getGmtOffset());
         mMaxJulianDay = mTodayJulianDay + CalendarAppWidgetService.MAX_DAYS - 1;
         mEventInfos = new ArrayList<EventInfo>(50);

--- a/app/src/main/java/com/android/calendar/widget/CalendarAppWidgetModel.java
+++ b/app/src/main/java/com/android/calendar/widget/CalendarAppWidgetModel.java
@@ -204,15 +204,16 @@ class CalendarAppWidgetModel {
 
     private DayInfo populateDayInfo(int julianDay, Time recycle) {
         long millis = recycle.setJulianDay(julianDay);
-        int flags = DateUtils.FORMAT_ABBREV_ALL | DateUtils.FORMAT_SHOW_DATE;
+        int flags =
+            DateUtils.FORMAT_ABBREV_ALL |
+            DateUtils.FORMAT_SHOW_DATE |
+            DateUtils.FORMAT_SHOW_WEEKDAY;
 
         String label;
         if (julianDay == mTodayJulianDay + 1) {
-            flags |= DateUtils.FORMAT_SHOW_WEEKDAY;
             label = mContext.getString(R.string.agenda_tomorrow,
                     Utils.formatDateRange(mContext, millis, millis, flags));
         } else {
-            flags |= DateUtils.FORMAT_SHOW_WEEKDAY;
             label = Utils.formatDateRange(mContext, millis, millis, flags);
         }
         return new DayInfo(julianDay, label);


### PR DESCRIPTION
The bug ultimately came from the fact that:
 - convertAllDayLocalToUtc and convertAllDayUtcToLocal are not guaranteed to preserve any part of the value of their recycle argument
 - older implementation of convertAlldayUtcToLocal just happened to accidentally preserve recycle's timezone
 - newer implementation does not; note that convertAlldayLocalToUtc already didn't preserve recycle's timezone previously
 - the code in buildFromCursor assumed that recycle was preserved, in particular by passing it to populateDayInfo while the latter critically depends on recycle having the correct timezone