### PR TITLE
Android 14 support

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -101,7 +101,7 @@ dependencies {
     // Core
     implementation 'androidx.core:core-ktx:1.10.0'
     implementation fileTree(include: ['*.jar', '*.aar'], dir: 'libs')
-    implementation 'androidx.preference:preference:1.1.1'
+    implementation 'androidx.preference:preference:1.2.1'
     implementation 'androidx.appcompat:appcompat:1.6.1'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
     implementation 'com.google.android.material:material:1.8.0'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,11 +12,11 @@ editorconfig {
 android {
     namespace 'ws.xsoh.etar'
     testNamespace 'com.android.calendar.tests'
-    compileSdk 33
+    compileSdk 34
 
     defaultConfig {
         minSdk 21
-        targetSdk 33
+        targetSdk 34
         versionCode 36
         versionName "1.0.36"
         applicationId "ws.xsoh.etar"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -99,7 +99,7 @@ android {
 dependencies {
 
     // Core
-    implementation 'androidx.core:core-ktx:1.10.0'
+    implementation 'androidx.core:core-ktx:1.12.0'
     implementation fileTree(include: ['*.jar', '*.aar'], dir: 'libs')
     implementation 'androidx.preference:preference:1.2.1'
     implementation 'androidx.appcompat:appcompat:1.6.1'

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -265,7 +265,9 @@
             </intent-filter>
         </receiver>
 
-        <service android:name="com.android.calendar.alerts.AlertService" />
+        <service android:name="com.android.calendar.alerts.AlertService"
+            android:exported="false"
+            android:foregroundServiceType="dataSync" />
 
         <service android:name="com.android.calendar.alerts.DismissAlarmsService" />
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -30,6 +30,7 @@
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.READ_SYNC_SETTINGS" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SYSTEM_EXEMPTED" />
     <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
     <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS"/>
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
@@ -267,7 +268,7 @@
 
         <service android:name="com.android.calendar.alerts.AlertService"
             android:exported="false"
-            android:foregroundServiceType="dataSync" />
+            android:foregroundServiceType="dataSync|systemExempted" />
 
         <service android:name="com.android.calendar.alerts.DismissAlarmsService" />
 

--- a/app/src/main/java/com/android/calendar/AllInOneActivity.java
+++ b/app/src/main/java/com/android/calendar/AllInOneActivity.java
@@ -23,7 +23,6 @@ import static android.provider.CalendarContract.EXTRA_EVENT_BEGIN_TIME;
 import static android.provider.CalendarContract.EXTRA_EVENT_END_TIME;
 
 import android.Manifest;
-import android.app.AlarmManager;
 import android.animation.Animator;
 import android.animation.Animator.AnimatorListener;
 import android.animation.ObjectAnimator;
@@ -597,9 +596,8 @@ public class AllInOneActivity extends AbstractCalendarActivity implements EventH
         mController.registerFirstEventHandler(HANDLER_KEY, this);
         mOnSaveInstanceStateCalled = false;
 
-        AlarmManager alarmManager = (AlarmManager) getSystemService(Context.ALARM_SERVICE);
         if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.S) {
-            if (!alarmManager.canScheduleExactAlarms()) {
+            if (!Utils.canScheduleAlarms(this)) {
                 Intent intent = new Intent();
                 intent.setAction(Settings.ACTION_REQUEST_SCHEDULE_EXACT_ALARM);
                 startActivity(intent);

--- a/app/src/main/java/com/android/calendar/Utils.java
+++ b/app/src/main/java/com/android/calendar/Utils.java
@@ -1787,7 +1787,7 @@ public class Utils {
         filter.addAction(Intent.ACTION_LOCALE_CHANGED);
 
         CalendarBroadcastReceiver r = new CalendarBroadcastReceiver(callback);
-        c.registerReceiver(r, filter);
+        ContextCompat.registerReceiver(c, r, filter, ContextCompat.RECEIVER_NOT_EXPORTED);
         return r;
     }
 

--- a/app/src/main/java/com/android/calendar/Utils.java
+++ b/app/src/main/java/com/android/calendar/Utils.java
@@ -21,6 +21,7 @@ import static android.provider.CalendarContract.EXTRA_EVENT_BEGIN_TIME;
 import android.Manifest;
 import android.accounts.Account;
 import android.app.Activity;
+import android.app.AlarmManager;
 import android.app.PendingIntent;
 import android.app.SearchManager;
 import android.content.BroadcastReceiver;
@@ -54,6 +55,7 @@ import android.util.Log;
 import android.widget.Toast;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.RequiresApi;
 import androidx.appcompat.widget.SearchView;
 import androidx.core.content.ContextCompat;
 import androidx.core.graphics.ColorUtils;
@@ -204,6 +206,19 @@ public class Utils {
     static boolean mMinutesLoaded = false;
     private static boolean mAllowWeekForDetailView = false;
     private static String sVersion = null;
+
+    @RequiresApi(api = Build.VERSION_CODES.S)
+    public static boolean canScheduleAlarms(Context context) {
+        AlarmManager alarmManager = (AlarmManager) context.getSystemService(Context.ALARM_SERVICE);
+        return alarmManager.canScheduleExactAlarms();
+    }
+
+    /**
+     * Returns whether the SDK is the UpsideDownCake release or later.
+     */
+    public static boolean isUpsideDownCakeOrLater() {
+        return Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE;
+    }
 
     /**
      * Returns whether the SDK is the Q release or later.

--- a/app/src/main/java/com/android/calendar/Utils.java
+++ b/app/src/main/java/com/android/calendar/Utils.java
@@ -206,10 +206,24 @@ public class Utils {
     private static String sVersion = null;
 
     /**
+     * Returns whether the SDK is the Q release or later.
+     */
+    public static boolean isQOrLater() {
+        return Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q;
+    }
+
+    /**
      * Returns whether the SDK is the Oreo release or later.
      */
     public static boolean isOreoOrLater() {
         return Build.VERSION.SDK_INT >= Build.VERSION_CODES.O;
+    }
+
+    /**
+     * Returns whether the SDK is the Marshmallow release or later.
+     */
+    public static boolean isMOrLater() {
+        return Build.VERSION.SDK_INT >= Build.VERSION_CODES.M;
     }
 
     /**

--- a/app/src/main/java/com/android/calendar/alerts/AlertReceiver.java
+++ b/app/src/main/java/com/android/calendar/alerts/AlertReceiver.java
@@ -17,7 +17,9 @@
 
 package com.android.calendar.alerts;
 
+import static android.content.pm.ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC;
 import static com.android.calendar.alerts.AlertService.ALERT_CHANNEL_ID;
+import static com.android.calendar.alerts.AlertService.FOREGROUND_CHANNEL_ID;
 
 import android.app.Notification;
 import android.app.PendingIntent;
@@ -48,6 +50,9 @@ import android.text.style.TextAppearanceSpan;
 import android.text.style.URLSpan;
 import android.util.Log;
 import android.widget.Toast;
+
+import androidx.core.app.NotificationCompat;
+import androidx.core.app.ServiceCompat;
 
 import com.android.calendar.DynamicTheme;
 import com.android.calendar.Utils;
@@ -132,14 +137,18 @@ public class AlertReceiver extends BroadcastReceiver {
             }
             mStartingService.acquire();
 
-            if (pm.isIgnoringBatteryOptimizations(context.getPackageName())) {
-                if (Utils.isOreoOrLater()) {
-                    context.startForegroundService(intent);
+            if (Utils.isMOrLater()) {
+                if (pm.isIgnoringBatteryOptimizations(context.getPackageName())) {
+                    if (Utils.isOreoOrLater()) {
+                        context.startForegroundService(intent);
+                    } else {
+                        context.startService(intent);
+                    }
                 } else {
-                    context.startService(intent);
+                    Log.d(TAG, "Battery optimizations are not disabled");
                 }
             } else {
-                Log.d(TAG, "Battery optimizations are not disabled");
+                context.startService(intent);
             }
         }
     }

--- a/app/src/main/java/com/android/calendar/alerts/AlertReceiver.java
+++ b/app/src/main/java/com/android/calendar/alerts/AlertReceiver.java
@@ -140,6 +140,9 @@ public class AlertReceiver extends BroadcastReceiver {
             if (Utils.isMOrLater()) {
                 if (pm.isIgnoringBatteryOptimizations(context.getPackageName())) {
                     if (Utils.isOreoOrLater()) {
+                        if (Utils.isUpsideDownCakeOrLater() && !Utils.canScheduleAlarms(context)) {
+                            return;
+                        }
                         context.startForegroundService(intent);
                     } else {
                         context.startService(intent);

--- a/app/src/main/java/com/android/calendar/alerts/AlertService.java
+++ b/app/src/main/java/com/android/calendar/alerts/AlertService.java
@@ -17,6 +17,7 @@
 package com.android.calendar.alerts;
 
 import static android.content.pm.ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC;
+import static android.content.pm.ServiceInfo.FOREGROUND_SERVICE_TYPE_SYSTEM_EXEMPTED;
 
 import android.Manifest;
 import android.annotation.TargetApi;
@@ -934,12 +935,13 @@ public class AlertService extends Service {
                         .setShowWhen(false)
                         .build();
                 if (Utils.isQOrLater()) {
-                    ServiceCompat.startForeground(
-                            this,
-                            1337,
-                            notification,
-                            FOREGROUND_SERVICE_TYPE_DATA_SYNC
-                    );
+                    int serviceType;
+                    if (Utils.isUpsideDownCakeOrLater()) {
+                        serviceType = FOREGROUND_SERVICE_TYPE_SYSTEM_EXEMPTED;
+                    } else {
+                        serviceType = FOREGROUND_SERVICE_TYPE_DATA_SYNC;
+                    }
+                    ServiceCompat.startForeground(this, 1337, notification, serviceType);
                 } else {
                     startForeground(1337, notification);
                 }

--- a/app/src/main/java/com/android/calendar/alerts/AlertService.java
+++ b/app/src/main/java/com/android/calendar/alerts/AlertService.java
@@ -16,6 +16,8 @@
 
 package com.android.calendar.alerts;
 
+import static android.content.pm.ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC;
+
 import android.Manifest;
 import android.annotation.TargetApi;
 import android.app.Notification;
@@ -48,6 +50,7 @@ import android.util.Log;
 
 import androidx.core.app.NotificationCompat;
 import androidx.core.app.NotificationManagerCompat;
+import androidx.core.app.ServiceCompat;
 import androidx.core.content.ContextCompat;
 
 import com.android.calendar.Utils;
@@ -924,14 +927,22 @@ public class AlertService extends Service {
         if (intent != null) {
 
             if (Utils.isOreoOrLater()) {
-
                 createChannels(this);
                 Notification notification = new NotificationCompat.Builder(this, FOREGROUND_CHANNEL_ID)
                         .setContentTitle(getString(R.string.foreground_notification_title))
                         .setSmallIcon(R.drawable.stat_notify_calendar)
                         .setShowWhen(false)
                         .build();
-                startForeground(1337, notification);
+                if (Utils.isQOrLater()) {
+                    ServiceCompat.startForeground(
+                            this,
+                            1337,
+                            notification,
+                            FOREGROUND_SERVICE_TYPE_DATA_SYNC
+                    );
+                } else {
+                    startForeground(1337, notification);
+                }
             }
 
             Message msg = mServiceHandler.obtainMessage();

--- a/app/src/main/java/com/android/calendar/settings/GeneralPreferences.kt
+++ b/app/src/main/java/com/android/calendar/settings/GeneralPreferences.kt
@@ -262,8 +262,9 @@ class GeneralPreferences : PreferenceFragmentCompat(),
         super.onStop()
     }
 
-    override fun onSharedPreferenceChanged(sharedPreferences: SharedPreferences, key: String) {
+    override fun onSharedPreferenceChanged(sharedPreferences: SharedPreferences, key: String?) {
         val a = activity ?: return
+        key ?: return
 
         BackupManager.dataChanged(a.packageName)
 


### PR DESCRIPTION
## Summary

- Bump libraries to the latest stable release (AOSP builds need this)
- Specify foreground service types, Use FOREGROUND_SERVICE_TYPE_DATA_SYNC from Android 10 to 13, FOREGROUND_SERVICE_TYPE_SYSTEM_EXEMPTED from Android 14
- Bump compile and target SDK to 14

## Test

New install > Grant all permissions > create new event in an offline calendar > Notice event notification appears and Etar doesn't crashes