### PR TITLE
AllInOneActivity: Don't request disabling doze on pre-M devices

### DIFF
--- a/app/src/main/java/com/android/calendar/AllInOneActivity.java
+++ b/app/src/main/java/com/android/calendar/AllInOneActivity.java
@@ -424,6 +424,8 @@ public class AllInOneActivity extends AbstractCalendarActivity implements EventH
     }
 
     private void checkAndRequestDisablingDoze() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) return;
+
         if (!dozeDisabled()) {
             Intent intent = new Intent();
             intent.setAction(Settings.ACTION_REQUEST_IGNORE_BATTERY_OPTIMIZATIONS);
@@ -433,6 +435,8 @@ public class AllInOneActivity extends AbstractCalendarActivity implements EventH
     }
 
     private Boolean dozeDisabled() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) return true;
+
         String packageName = getApplicationContext().getPackageName();
         PowerManager pm = (PowerManager) getApplicationContext().getSystemService(Context.POWER_SERVICE);
         return pm.isIgnoringBatteryOptimizations(packageName);


### PR DESCRIPTION
## Summary

Devices running < Android 6.0+ don't require disabling doze. Avoid using the new APIs causing the crash.

## Related Issues

- https://github.com/Etar-Group/Etar-Calendar/issues/1439