### PR TITLE
No reponse container if no attendee data

### DIFF
--- a/app/src/main/java/com/android/calendar/EventInfoFragment.java
+++ b/app/src/main/java/com/android/calendar/EventInfoFragment.java
@@ -2088,7 +2088,7 @@ public class EventInfoFragment extends DialogFragment implements OnCheckedChange
         // for simplicity).
 
         // TODO Switch to EditEventHelper.canRespond when this class uses CalendarEventModel.
-        if (!mCanModifyCalendar || (mHasAttendeeData && mIsOrganizer && mNumOfAttendees <= 1) ||
+        if (!mCanModifyCalendar || !mHasAttendeeData || (mIsOrganizer && mNumOfAttendees <= 1) ||
                 (mIsOrganizer && !mOwnerCanRespond)) {
             setVisibilityCommon(view, R.id.response_container, View.GONE);
             return;


### PR DESCRIPTION
I am using davx5 to synchronise caldav (and carddav/tasks), all event that come in via davx5 show the response_container. These events always have an organiser set and no attendees. The line 2091 from updateResponse in EventInfoFragment, hides the response_container only if there is attendee data, but in these cases the attendee data is not there. Which should be handled the same as <= 1 attendee.