### PR TITLE
Add GPLv3 copyright profile

### DIFF
--- a/.idea/copyright/GPLv3.xml
+++ b/.idea/copyright/GPLv3.xml
@@ -1,0 +1,6 @@
+<component name="CopyrightManager">
+  <copyright>
+    <option name="notice" value=" Copyright (c) &amp;#36;today.year The Etar Project&#10; &#10;This program is free software: you can redistribute it and/or modify&#10;it under the terms of the GNU General Public License as published by&#10;the Free Software Foundation, either version 3 of the License, or&#10;(at your option) any later version.&#10;&#10;This program is distributed in the hope that it will be useful,&#10;but WITHOUT ANY WARRANTY; without even the implied warranty of&#10;MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the&#10;GNU General Public License for more details.&#10;&#10;You should have received a copy of the GNU General Public License&#10;along with this program.  If not, see &lt;https://www.gnu.org/licenses/&gt;." />
+    <option name="myName" value="GPLv3" />
+  </copyright>
+</component>

--- a/.idea/copyright/profiles_settings.xml
+++ b/.idea/copyright/profiles_settings.xml
@@ -1,0 +1,7 @@
+<component name="CopyrightManager">
+  <settings default="GPLv3">
+    <module2copyright>
+      <element module="All" copyright="GPLv3" />
+    </module2copyright>
+  </settings>
+</component>


### PR DESCRIPTION
To ensure newly created files have copyright properly applied.

Is the license under "The Etar Project", since that's what the readme had the project referred to as, Or "Etar Group"?