### PR TITLE
fix go-to date

### DIFF
--- a/app/src/main/java/com/android/calendar/AllInOneActivity.java
+++ b/app/src/main/java/com/android/calendar/AllInOneActivity.java
@@ -935,15 +935,6 @@ public class AllInOneActivity extends AbstractCalendarActivity implements EventH
                     selectedTime.setMonth(monthOfYear);
                     selectedTime.setDay(dayOfMonth);
 
-                    Calendar c = Calendar.getInstance();
-                    c.set(year, monthOfYear, dayOfMonth);
-                    int weekday = c.get(Calendar.DAY_OF_WEEK);
-                    if (weekday == 1) {
-                        selectedTime.setWeekDay(7);
-                    } else {
-                        selectedTime.setWeekDay(weekday - 1);
-                    }
-
                     long extras = CalendarController.EXTRA_GOTO_TIME | CalendarController.EXTRA_GOTO_DATE;
                     mController.sendEvent(this, EventType.GO_TO, selectedTime, null, selectedTime, -1, ViewType.CURRENT, extras, null, null);
                 }


### PR DESCRIPTION
setting the week-day here was once necessary when Etar was still using `android.text.format.Time`, where the days where 0-indexed (`java.util.Calendar`s days are 1-indexed).

doing this with `com.android.calendarcommon2.Time` is wrong, and will result in sundays being one week ahead.

additionally, setting the `DAY_OF_WEEK` without updating the `WEEK_OF_MONTH` will result in the old value of `WEEK_OF_MONTH` being used, as `Calendar` expects these to be set in combination when doing the computation: https://github.com/openjdk-mirror/jdk7u-jdk/blob/f4d80957e89a19a29bb9f9807d2a28351ed7f7df/src/share/classes/java/util/Calendar.java#L1729-L1740

fixes https://github.com/Etar-Group/Etar-Calendar/issues/1666
fixes https://github.com/Etar-Group/Etar-Calendar/issues/1596
fixes https://github.com/Etar-Group/Etar-Calendar/issues/1251
