### PR TITLE
Add recurrence rule support for importing calendar event from .ics file

### DIFF
--- a/app/src/main/java/com/android/calendar/ImportActivity.java
+++ b/app/src/main/java/com/android/calendar/ImportActivity.java
@@ -162,6 +162,8 @@ public class ImportActivity extends Activity {
                 IcalendarUtils.uncleanseString(firstEvent.getProperty(VEvent.URL)));
         calIntent.putExtra(CalendarContract.Events.ORGANIZER,
                 IcalendarUtils.uncleanseString(firstEvent.getProperty(VEvent.ORGANIZER)));
+        calIntent.putExtra(CalendarContract.Events.RRULE,
+                IcalendarUtils.uncleanseString(firstEvent.getProperty(VEvent.RRULE)));
 
         if (firstEvent.mAttendees.size() > 0) {
             StringBuilder builder = new StringBuilder();

--- a/app/src/main/java/com/android/calendar/icalendar/VEvent.java
+++ b/app/src/main/java/com/android/calendar/icalendar/VEvent.java
@@ -45,6 +45,7 @@ public class VEvent {
     public static String DESCRIPTION = "DESCRIPTION";
     public static String ATTENDEE = "ATTENDEE";
     public static String CATEGORIES = "CATEGORIES";
+    public static String RRULE = "RRULE";
 
     // Stores the -arity of the attributes that this component can have
     private static HashMap<String, Integer> sPropertyList = new HashMap<String, Integer>();
@@ -66,6 +67,7 @@ public class VEvent {
         sPropertyList.put(DTSTAMP,1);
         sPropertyList.put(SUMMARY,1);
         sPropertyList.put(DESCRIPTION,1);
+        sPropertyList.put(RRULE, 1);
 
         sPropertyList.put(ATTENDEE, Integer.MAX_VALUE);
         sPropertyList.put(CATEGORIES, Integer.MAX_VALUE);


### PR DESCRIPTION
The recurrence rule (RRULE) property has been added to the VEvent class. This property represents a recurrence rule, such as "FREQ=WEEKLY;COUNT=10;BYDAY=MO". The property list in the VEvent also has been updated to include RRULE.

The ImportActivity class now includes the RRULE property when creating a calendar intent. This allows the recurrence rule of an event to be imported along with other properties.

It creates the correct recurrence rule while importing a recurring calendar event from an .ics file.

Fixes #1316. 