### PR TITLE
Remove FOREGROUND_SERVICE_DATA_SYNC permission

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -30,7 +30,6 @@
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.READ_SYNC_SETTINGS" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
-    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SYSTEM_EXEMPTED" />
     <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
     <uses-permission android:name="android.permission.REQUEST_IGNORE_BATTERY_OPTIMIZATIONS"/>
@@ -270,7 +269,7 @@
 
         <service android:name="com.android.calendar.alerts.AlertService"
             android:exported="false"
-            android:foregroundServiceType="dataSync|systemExempted" />
+            android:foregroundServiceType="systemExempted" />
 
         <service android:name="com.android.calendar.alerts.DismissAlarmsService" />
 

--- a/app/src/main/java/com/android/calendar/alerts/AlertService.java
+++ b/app/src/main/java/com/android/calendar/alerts/AlertService.java
@@ -16,7 +16,6 @@
 
 package com.android.calendar.alerts;
 
-import static android.content.pm.ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC;
 import static android.content.pm.ServiceInfo.FOREGROUND_SERVICE_TYPE_SYSTEM_EXEMPTED;
 
 import android.Manifest;
@@ -943,7 +942,7 @@ public class AlertService extends Service {
                     if (Utils.isUpsideDownCakeOrLater()) {
                         serviceType = FOREGROUND_SERVICE_TYPE_SYSTEM_EXEMPTED;
                     } else {
-                        serviceType = FOREGROUND_SERVICE_TYPE_DATA_SYNC;
+                        serviceType = 0;
                     }
                     ServiceCompat.startForeground(this, 1337, notification, serviceType);
                 } else {


### PR DESCRIPTION
Foreground service types are required since Android 14. Before that, they were optional. Two permissions for the same basic foreground service are therefore not necessary here. Fix #1720