### PR TITLE
Fix event creation from Month view sometimes default to the wrong day

### DIFF
--- a/app/src/main/java/com/android/calendar/month/MonthByWeekAdapter.java
+++ b/app/src/main/java/com/android/calendar/month/MonthByWeekAdapter.java
@@ -328,10 +328,10 @@ public class MonthByWeekAdapter extends SimpleWeeksAdapter {
             // Else, check if the day we tapped has any events scheduled to it.
             int viewJulianDay = Time.getJulianDay(day.normalize(), day.getGmtOffset());
             int dayIndex = viewJulianDay - mFirstJulianDay;
-            boolean dayHasEvents = mEventDayList.subList(dayIndex, dayIndex+1)
+            boolean dayHasEvents = mEventDayList.subList(dayIndex, dayIndex + 1)
                      .stream().anyMatch(l -> !l.isEmpty());
 
-            if(dayHasEvents) {
+            if (dayHasEvents) {
                 // If there are events on that day, switch to the detailed view for that day
                 mController.sendEvent(mContext, EventType.GO_TO, day, day, -1,
                         ViewType.DETAIL,

--- a/app/src/main/java/com/android/calendar/month/MonthByWeekAdapter.java
+++ b/app/src/main/java/com/android/calendar/month/MonthByWeekAdapter.java
@@ -339,9 +339,8 @@ public class MonthByWeekAdapter extends SimpleWeeksAdapter {
                                 | CalendarController.EXTRA_GOTO_BACK_TO_PREVIOUS, null, null);
             } else {
                 // If there are *no* events on that day, let the user create one
-                long selectedTimeInMillis = mSelectedDay.normalize();
                 mController.sendEventRelatedEventWithExtra(this, EventType.CREATE_EVENT, -1,
-                        selectedTimeInMillis, 0, 0, 0,0, -1);
+                        day.normalize(), 0, 0, 0,0, -1);
             }
         }
     }

--- a/app/src/main/java/com/android/calendar/month/MonthByWeekAdapter.java
+++ b/app/src/main/java/com/android/calendar/month/MonthByWeekAdapter.java
@@ -325,11 +325,24 @@ public class MonthByWeekAdapter extends SimpleWeeksAdapter {
             mController.sendEvent(mContext, EventType.GO_TO, day, day, -1,
                     ViewType.CURRENT, CalendarController.EXTRA_GOTO_DATE, null, null);
         } else {
-            // Else , switch to the detailed view
-            mController.sendEvent(mContext, EventType.GO_TO, day, day, -1,
-                    ViewType.DETAIL,
-                            CalendarController.EXTRA_GOTO_DATE
-                            | CalendarController.EXTRA_GOTO_BACK_TO_PREVIOUS, null, null);
+            // Else, check if the day we tapped has any events scheduled to it.
+            int viewJulianDay = Time.getJulianDay(day.normalize(), day.getGmtOffset());
+            int dayIndex = viewJulianDay - mFirstJulianDay;
+            boolean dayHasEvents = mEventDayList.subList(dayIndex, dayIndex+1)
+                     .stream().anyMatch(l -> !l.isEmpty());
+
+            if(dayHasEvents) {
+                // If there are events on that day, switch to the detailed view for that day
+                mController.sendEvent(mContext, EventType.GO_TO, day, day, -1,
+                        ViewType.DETAIL,
+                        CalendarController.EXTRA_GOTO_DATE
+                                | CalendarController.EXTRA_GOTO_BACK_TO_PREVIOUS, null, null);
+            } else {
+                // If there are *no* events on that day, let the user create one
+                long selectedTimeInMillis = mSelectedDay.normalize();
+                mController.sendEventRelatedEventWithExtra(this, EventType.CREATE_EVENT, -1,
+                        selectedTimeInMillis, 0, 0, 0,0, -1);
+            }
         }
     }
 


### PR DESCRIPTION
Previously, tapping on a day in month view would always take you to the agenda/detail view for that day. However if your calendar contains more events than will fit into the available vertical space (which most calendars do), it'll switch to agenda view and then immediately process an "on scroll" callback, which will cause the "selected date/time" to update as if the user had scrolled through their agenda.

Since this update changes the selected timestamp to whatever is currently visibly shown on the agenda, the scroll will always change the selected date to another day that *does* have an existing event.

The result of all of this is that if you have a full calendar with some empty days, and you tap on those days and then tap the "add event" widget, you probably won't check the date (I often don't) so it'll create an event on the wrong date and confuse you later.

This commit works around that problem by changing the behaviour of month view: If you tap on a day that already has events then it'll keep the existing behaviour of changing to the detail view. However if you tap on a day that has no events at all, it will go straight to the "create an event" view.

Personally, I would anticipate that creating an event is what users are trying to do most of the time when they tap on an empty day anyway, so in theory this also saves an extra tap for a common workflow.

This resolves #1531.