### PR TITLE
Migrate to Gradle build version catalog

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,9 +1,9 @@
 import com.android.build.gradle.internal.tasks.factory.dependsOn
 
 plugins {
-	id("com.android.application")
-	id("org.jetbrains.kotlin.android")
-	id("org.ec4j.editorconfig")
+    alias(libs.plugins.android.application)
+    alias(libs.plugins.jetbrains.kotlin.android)
+    alias(libs.plugins.ec4j.editorconfig)
 }
 
 editorconfig {
@@ -124,27 +124,25 @@ android {
 dependencies {
 
 	// Core
-	implementation("androidx.core:core-ktx:1.16.0")
-	implementation(fileTree("include" to arrayOf("*.jar", "*.aar"), "dir" to "libs"))
-	implementation("androidx.preference:preference-ktx:1.2.1")
-	implementation("androidx.appcompat:appcompat:1.7.0")
-	implementation("androidx.constraintlayout:constraintlayout:2.2.1")
-	implementation("com.google.android.material:material:1.12.0")
-	testImplementation("junit:junit:4.13.2")
+    implementation(fileTree("include" to arrayOf("*.jar", "*.aar"), "dir" to "libs"))
 
-	coreLibraryDesugaring("com.android.tools:desugar_jdk_libs:2.1.5")
+	implementation(libs.androidx.core)
+	implementation(libs.androidx.preference)
+	implementation(libs.androidx.appcompat)
+	implementation(libs.androidx.constraintlayout)
+	implementation(libs.google.android.material)
+	testImplementation(libs.junit)
+
+	coreLibraryDesugaring(libs.android.tools.desugar)
 
 	// Coroutines
-	val coroutines_version = "1.10.2"
-	implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutines_version")
-	implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:$coroutines_version")
+	implementation(libs.kotlinx.coroutines.android)
 
 	// https://mvnrepository.com/artifact/org.dmfs/lib-recur
-	implementation("org.dmfs:lib-recur:0.17.1")
+	implementation(libs.dmfs.lib.recur)
 
 	// lifecycle
-	val lifecycle_version = "2.9.0"
-	implementation("androidx.lifecycle:lifecycle-livedata-ktx:$lifecycle_version")
+	implementation(libs.androidx.lifecycle.livedata)
 }
 
 tasks.preBuild.dependsOn(":aarGen")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,11 +2,11 @@ import org.jetbrains.gradle.ext.settings
 import org.jetbrains.gradle.ext.taskTriggers
 
 plugins {
-    id("com.android.application") version "8.10.0" apply false
-    id("com.android.library") version "8.10.0" apply false
-    id("org.jetbrains.kotlin.android") version "2.1.21" apply false
-    id("org.ec4j.editorconfig") version "0.1.0" apply false
-    id("org.jetbrains.gradle.plugin.idea-ext") version "1.1.10" apply true
+    alias(libs.plugins.android.application) apply false
+    alias(libs.plugins.android.library) apply false
+    alias(libs.plugins.jetbrains.kotlin.android) apply false
+    alias(libs.plugins.ec4j.editorconfig) apply false
+    alias(libs.plugins.jetbrains.idea.ext) apply true
 }
 
 // External project configuration start

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,34 @@
+[versions]
+agp = "8.10.0"
+compat = "1.7.0"
+constraint = "2.2.1"
+core = "1.16.0"
+desugar = "2.1.5"
+junit = "4.13.2"
+kotlin = "2.1.21"
+editorconfig = "0.1.0"
+ideaExt = "1.1.10"
+coroutines = "1.10.2"
+libRecur = "0.17.1"
+lifecycle = "2.9.0"
+material = "1.12.0"
+preference = "1.2.1"
+
+[libraries]
+androidx-appcompat = { module = "androidx.appcompat:appcompat", version.ref = "compat" }
+androidx-constraintlayout = { module = "androidx.constraintlayout:constraintlayout", version.ref = "constraint" }
+androidx-core = { module = "androidx.core:core-ktx", version.ref = "core" }
+androidx-lifecycle-livedata = { module = "androidx.lifecycle:lifecycle-livedata-ktx", version.ref = "lifecycle" }
+androidx-preference = { module = "androidx.preference:preference-ktx", version.ref = "preference" }
+android-tools-desugar = { module = "com.android.tools:desugar_jdk_libs", version.ref = "desugar" }
+junit = { module = "junit:junit", version.ref = "junit" }
+kotlinx-coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "coroutines" }
+dmfs-lib-recur = { module = "org.dmfs:lib-recur", version.ref = "libRecur" }
+google-android-material = { module = "com.google.android.material:material", version.ref = "material" }
+
+[plugins]
+android-application = { id = "com.android.application", version.ref = "agp" }
+android-library = { id = "com.android.library", version.ref = "agp" }
+jetbrains-kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
+jetbrains-idea-ext = { id = "org.jetbrains.gradle.plugin.idea-ext", version.ref = "ideaExt" }
+ec4j-editorconfig = { id = "org.ec4j.editorconfig", version.ref = "editorconfig" }


### PR DESCRIPTION
## Summary

This PR migrates Etar to use the new Gradle build version catalog to manage and update dependencies.

Ref: https://developer.android.com/build/migrate-to-catalogs