### PR TITLE
Fix delete dialog crash when activity is destroyed

### DIFF
--- a/app/src/main/java/com/android/calendar/DeleteEventHelper.java
+++ b/app/src/main/java/com/android/calendar/DeleteEventHelper.java
@@ -268,6 +268,13 @@ public class DeleteEventHelper {
         // just some of them.
         String rRule = model.mRrule;
         String originalEvent = model.mOriginalSyncId;
+
+        if (!(mContext instanceof Activity activity)) {
+            return;
+        }
+        if (activity.isFinishing() || activity.isDestroyed()) {
+            return;
+        }
         if (TextUtils.isEmpty(rRule)) {
             AlertDialog dialog = new MaterialAlertDialogBuilder(mContext)
                     .setMessage(R.string.delete_this_event_title)


### PR DESCRIPTION
### Problem 
`WindowManager.BadTokenException` crashes occur when trying to show delete confirmation dialog after the Activity has been destroyed

### Solution
- Add activity lifecycle validation before showing delete dialogs
- Check if context is valid Activity instance using pattern matching
- Prevent WindowManager.BadTokenException

Fixes #1877 