### PR TITLE
ArrayIndexOutOfBoundsException

### DIFF
--- a/app/src/main/java/com/android/calendar/DayView.java
+++ b/app/src/main/java/com/android/calendar/DayView.java
@@ -2521,6 +2521,9 @@ public class DayView extends View implements View.OnCreateContextMenuListener,
         int deltaY = hourStep * totCellHeight;
         int y = i * totCellHeight + mHoursTextHeight / 2 - HOUR_GAP;
         for (; i < 24; i += hourStep) {
+            if (i < 0) {
+                continue;
+            }
             String time = mHourStrs[i];
             canvas.drawText(time, HOURS_LEFT_MARGIN, y, p);
             y += deltaY;


### PR DESCRIPTION
Under certain unforeseen circumstances (presumably during scrolling or a rapid change of view), mFirstHour is set to -1 or is not updated to a valid value (0-23) in time before the onDraw method is called.

The change prevents the array from ever being accessed with a negative index.

Fix #1620