### PR TITLE
Fix taping on the event from the widget open concrete event.

### DIFF
--- a/app/src/main/java/com/android/calendar/widget/CalendarAppWidgetProvider.java
+++ b/app/src/main/java/com/android/calendar/widget/CalendarAppWidgetProvider.java
@@ -87,11 +87,14 @@ public class CalendarAppWidgetProvider extends AppWidgetProvider {
     static PendingIntent getLaunchPendingIntentTemplate(Context context) {
         Intent launchIntent = new Intent();
         launchIntent.setAction(Intent.ACTION_VIEW);
-        launchIntent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TASK |
-                Intent.FLAG_ACTIVITY_TASK_ON_HOME);
-        launchIntent.setClass(context, AllInOneActivity.class);
+        launchIntent.setPackage(context.getPackageName());
+        launchIntent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK |
+                Intent.FLAG_ACTIVITY_CLEAR_TASK |
+                Intent.FLAG_ACTIVITY_TASK_ON_HOME |
+                Intent.FLAG_GRANT_READ_URI_PERMISSION);
+
         return PendingIntent.getActivity(context, 0 /* no requestCode */, launchIntent,
-                PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE);
+                PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_MUTABLE);
     }
 
     /**
@@ -239,7 +242,7 @@ public class CalendarAppWidgetProvider extends AppWidgetProvider {
             Intent intent = new Intent(Intent.ACTION_VIEW);
             intent.setClass(context, EditEventActivity.class);
             intent.putExtra(EXTRA_EVENT_ALL_DAY, false);
-            intent.putExtra(CalendarContract.Events.CALENDAR_ID, -1);
+            intent.putExtra(CalendarContract.Events.CALENDAR_ID, -1L);
 
             final PendingIntent addEventPendingIntent = PendingIntent.getActivity(
                     context, 0 /* no requestCode */, intent, PendingIntent.FLAG_IMMUTABLE);


### PR DESCRIPTION
Fix #1180 

Making PendingIntent mutable otherwise fillInIntent don't work. Therefore I hat to make template Intent explicit to satisfy androids security requirements. Correctly passing the -1L as a Long for the "Add Event" button to avoid log errors. 