### PR TITLE
Time switchTimezone: Also update timezone attribute, Fixes recurrence end date

### DIFF
--- a/app/src/main/java/com/android/calendar/calendarcommon2/Time.java
+++ b/app/src/main/java/com/android/calendar/calendarcommon2/Time.java
@@ -212,6 +212,7 @@ public class Time {
     }
 
     public void switchTimezone(String timezone) {
+        this.timezone = timezone;
         long msBefore = mCalendar.getTimeInMillis();
         mCalendar.setTimeZone(TimeZone.getTimeZone(timezone));
         mCalendar.setTimeInMillis(msBefore);

--- a/app/src/main/java/com/android/calendar/recurrencepicker/RecurrencePickerDialog.java
+++ b/app/src/main/java/com/android/calendar/recurrencepicker/RecurrencePickerDialog.java
@@ -340,6 +340,10 @@ public class RecurrencePickerDialog extends DialogFragment implements OnItemSele
                     model.endDate.switchTimezone(Time.TIMEZONE_UTC);
                     model.endDate.normalize();
                     er.until = model.endDate.format2445();
+                    if (!er.until.endsWith("Z")) {
+                        // Safeguard to not create invalid data
+                        throw new IllegalStateException("UNTIL parameter not in UTC");
+                    }
                     er.count = 0;
                 } else {
                     throw new IllegalStateException("end = END_BY_DATE but endDate is null");


### PR DESCRIPTION
When using `switchTimezone` the `timezone` attribute is not updated but only the internal Gregorian calendar.

In the case of the end date in the `RecurrencePickerDialog`, the chain of side effects
basically causes the `format2445` function to replace the `UTC` timezone with the wrong timezone.
I've documented what I think happened in https://github.com/Etar-Group/Etar-Calendar/issues/2019#issuecomment-3755107334.

This one line fixes the `RecurrencePickerDialog` generating invalid calendar data #2019.
I've also added a panic to ensure that we never generate a non-UTC end date.

