### PR TITLE
Fix duplicate contact birthday notifications

### DIFF
--- a/app/src/main/java/com/android/calendar/alerts/AlertService.java
+++ b/app/src/main/java/com/android/calendar/alerts/AlertService.java
@@ -548,11 +548,24 @@ public class AlertService extends Service {
                 if (sendAlert) {
                     if (state == CalendarAlerts.STATE_SCHEDULED || newAlertOverride) {
                         newState = CalendarAlerts.STATE_FIRED;
-                        numFired++;
-                        // If quiet hours are forcing the alarm to be silent,
-                        // keep newAlert as false so it will not make noise.
-                        if (!forceQuiet) {
-                            newAlert = true;
+
+                        // When using local storage to track alert state (BYPASS_DB),
+                        // check if this alert was already fired previously.  The
+                        // calendar provider may re-insert SCHEDULED alert entries
+                        // when events are re-synced (e.g. contact birthday events
+                        // during a contact sync), which would otherwise cause
+                        // duplicate notifications with sound/vibrate.
+                        boolean alreadyFired = AlertUtils.BYPASS_DB
+                                && AlertUtils.hasAlertFiredInSharedPrefs(
+                                        context, eventId, beginTime, alarmTime);
+
+                        if (!alreadyFired) {
+                            numFired++;
+                            // If quiet hours are forcing the alarm to be silent,
+                            // keep newAlert as false so it will not make noise.
+                            if (!forceQuiet) {
+                                newAlert = true;
+                            }
                         }
 
                         // Record the received time in the CalendarAlerts table.


### PR DESCRIPTION
The calendar provider may re-insert SCHEDULED alert entries when contact events are re-synced, causing notifications to fire again with sound/vibrate. Before treating a SCHEDULED alert as new, check SharedPrefs (BYPASS_DB) to see if it was already fired.


I have tried this fix for a couple of weeks on my phone and seems to be working ok. 

Fixes #1031