### PR TITLE
Don't reuse timeObj to avoid incorrect alarm time

### DIFF
--- a/app/src/main/java/com/android/calendar/alerts/AlarmScheduler.java
+++ b/app/src/main/java/com/android/calendar/alerts/AlarmScheduler.java
@@ -206,7 +206,7 @@ public class AlarmScheduler {
                 long localStartTime;
                 if (allday) {
                     // Adjust allday to local time.
-                    localStartTime = Utils.convertAlldayUtcToLocal(timeObj, begin,
+                    localStartTime = Utils.convertAlldayUtcToLocal(null, begin,
                             Utils.getCurrentTimezone());
                 } else {
                     localStartTime = begin;


### PR DESCRIPTION
This prevents the shared timeObj from having its timezone accidentally changed to UTC. 