### PR TITLE
 Fix timezone bug when processing allday events

### DIFF
--- a/app/src/main/java/com/android/calendar/AllInOneActivity.java
+++ b/app/src/main/java/com/android/calendar/AllInOneActivity.java
@@ -1347,10 +1347,14 @@ public class AllInOneActivity extends AbstractCalendarActivity implements EventH
                 if (event.startTime != null && event.endTime != null) {
                     // Event is all day , adjust the goto time to local time
                     if (event.isAllDay()) {
-                        Utils.convertAlldayUtcToLocal(
-                                event.startTime, event.startTime.toMillis(), mTimeZone);
-                        Utils.convertAlldayUtcToLocal(
-                                event.endTime, event.endTime.toMillis(), mTimeZone);
+                        long start = Utils.convertAlldayUtcToLocal(
+                                null, event.startTime.toMillis(), mTimeZone);
+                        long end = Utils.convertAlldayUtcToLocal(
+                                null, event.endTime.toMillis(), mTimeZone);
+                        event.startTime.setTimezone(mTimeZone);
+                        event.startTime.set(start);
+                        event.endTime.setTimezone(mTimeZone);
+                        event.endTime.set(end);
                     }
                     mController.sendEvent(this, EventType.GO_TO, event.startTime, event.endTime,
                             event.selectedTime, event.id, ViewType.AGENDA,

--- a/app/src/main/java/com/android/calendar/agenda/AgendaByDayAdapter.java
+++ b/app/src/main/java/com/android/calendar/agenda/AgendaByDayAdapter.java
@@ -306,8 +306,8 @@ public class AgendaByDayAdapter extends BaseAdapter {
             long instanceId = cursor.getLong(AgendaWindowAdapter.INDEX_INSTANCE_ID);
             boolean allDay = cursor.getInt(AgendaWindowAdapter.INDEX_ALL_DAY) != 0;
             if (allDay) {
-                startTime = Utils.convertAlldayUtcToLocal(tempTime, startTime, mTimeZone);
-                endTime = Utils.convertAlldayUtcToLocal(tempTime, endTime, mTimeZone);
+                startTime = Utils.convertAlldayUtcToLocal(null, startTime, mTimeZone);
+                endTime = Utils.convertAlldayUtcToLocal(null, endTime, mTimeZone);
             }
             // Skip over the days outside of the adapter's range
             startDay = Math.max(startDay, dayAdapterInfo.start);


### PR DESCRIPTION
As soon as one all-day event is processed, the shared object is silently switched to UTC, causing all subsequent calculations in the loop that rely on that object's timezone to be incorrect. Passing null to force a fresh new Time object. Partly fix #382