### PR TITLE
Prevent Etar from overriding external calendar sync settings

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -29,7 +29,6 @@
     <uses-permission android:name="android.permission.WRITE_CALENDAR" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.READ_SYNC_SETTINGS" />
-    <uses-permission android:name="android.permission.WRITE_SYNC_SETTINGS" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SYSTEM_EXEMPTED" />
     <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />

--- a/app/src/main/java/com/android/calendar/settings/CalendarDataStore.kt
+++ b/app/src/main/java/com/android/calendar/settings/CalendarDataStore.kt
@@ -20,7 +20,6 @@ package com.android.calendar.settings
 import android.content.ContentUris
 import android.content.ContentValues
 import android.provider.CalendarContract
-import androidx.core.database.getStringOrNull
 import androidx.fragment.app.FragmentActivity
 import androidx.preference.PreferenceDataStore
 
@@ -44,7 +43,6 @@ class CalendarDataStore(activity: FragmentActivity, calendarId: Long) : Preferen
 
     private fun mapPreferenceKeyToDatabaseKey(key: String): String {
         return when (key) {
-            CalendarPreferences.SYNCHRONIZE_KEY -> CalendarContract.Calendars.SYNC_EVENTS
             CalendarPreferences.VISIBLE_KEY -> CalendarContract.Calendars.VISIBLE
             CalendarPreferences.COLOR_KEY -> CalendarContract.Calendars.CALENDAR_COLOR
             CalendarPreferences.DISPLAY_NAME_KEY -> CalendarContract.Calendars.CALENDAR_DISPLAY_NAME

--- a/app/src/main/java/com/android/calendar/settings/CalendarPreferences.kt
+++ b/app/src/main/java/com/android/calendar/settings/CalendarPreferences.kt
@@ -73,10 +73,6 @@ class CalendarPreferences : PreferenceFragmentCompat() {
         val currentColor = preferenceManager.preferenceDataStore!!.getInt(COLOR_KEY, -1)
         val authenticatorInfo = getAuthenticatorInfo(account)
 
-        val synchronizePreference = SwitchPreference(context).apply {
-            key = SYNCHRONIZE_KEY
-            title = getString(R.string.preferences_calendar_synchronize)
-        }
         val visiblePreference = SwitchPreference(context).apply {
             key = VISIBLE_KEY
             title = getString(R.string.preferences_calendar_visible)
@@ -131,10 +127,6 @@ class CalendarPreferences : PreferenceFragmentCompat() {
         val localAccountInfoPreference = Preference(context).apply {
             title = getString(R.string.preferences_list_add_offline_message)
             isSelectable = false
-        }
-
-        if (!isLocalAccount) {
-            screen.addPreference(synchronizePreference)
         }
 
         screen.addPreference(visiblePreference)
@@ -249,7 +241,6 @@ class CalendarPreferences : PreferenceFragmentCompat() {
 
         const val ARG_CALENDAR_ID = "calendarId"
 
-        const val SYNCHRONIZE_KEY = "synchronize"
         const val VISIBLE_KEY = "visible"
         const val COLOR_KEY = "color"
         const val DISPLAY_NAME_KEY = "displayName"


### PR DESCRIPTION
Etar no longer modifies synchronization settings for external accounts
(e.g. DavX5). This fully resolves the root cause of duplicated calendar
entries.

Synchronization management is now handled exclusively through DavX5 or
the Android system settings, following the intended standard behavior for
external sync adapters.

Fix #1727, #1800 #1814