### PR TITLE
Use stable sync ID for alert de-duplication

### DIFF
--- a/app/src/main/java/com/android/calendar/alerts/AlertService.java
+++ b/app/src/main/java/com/android/calendar/alerts/AlertService.java
@@ -466,11 +466,17 @@ public class AlertService extends Service {
 
         ContentResolver cr = context.getContentResolver();
         HashMap<Long, NotificationInfo> eventIds = new HashMap<Long, NotificationInfo>();
+        HashMap<Long, String> stableEventIdCache = new HashMap<Long, String>();
         int numFired = 0;
         try {
             while (alertCursor.moveToNext()) {
                 final long alertId = alertCursor.getLong(ALERT_INDEX_ID);
                 final long eventId = alertCursor.getLong(ALERT_INDEX_EVENT_ID);
+                String stableEventId = stableEventIdCache.get(eventId);
+                if (stableEventId == null) {
+                    stableEventId = AlertUtils.getStableEventId(context, eventId);
+                    stableEventIdCache.put(eventId, stableEventId);
+                }
                 final long calendarId = alertCursor.getLong(ALERT_INDEX_CALENDAR_ID);
                 final int minutes = alertCursor.getInt(ALERT_INDEX_MINUTES);
                 final String eventName = alertCursor.getString(ALERT_INDEX_TITLE);
@@ -498,8 +504,8 @@ public class AlertService extends Service {
                     // we can get refires for non-dismissed alerts after app installation, or if the
                     // SharedPrefs was cleared too early.  This means alerts that were timed while
                     // the phone was off may show up silently in the notification bar.
-                    boolean alreadyFired = AlertUtils.hasAlertFiredInSharedPrefs(context, eventId,
-                            beginTime, alarmTime);
+                    boolean alreadyFired = AlertUtils.hasAlertFiredInSharedPrefs(context,
+                            stableEventId, beginTime, alarmTime);
                     if (!alreadyFired) {
                         newAlertOverride = true;
                     }
@@ -523,6 +529,7 @@ public class AlertService extends Service {
                     if (AlertUtils.BYPASS_DB) {
                         msgBuilder.append(" newAlertOverride: " + newAlertOverride);
                     }
+                    msgBuilder.append(" stableEventId:").append(stableEventId);
                     Log.d(TAG, msgBuilder.toString());
                 }
 
@@ -548,11 +555,24 @@ public class AlertService extends Service {
                 if (sendAlert) {
                     if (state == CalendarAlerts.STATE_SCHEDULED || newAlertOverride) {
                         newState = CalendarAlerts.STATE_FIRED;
-                        numFired++;
-                        // If quiet hours are forcing the alarm to be silent,
-                        // keep newAlert as false so it will not make noise.
-                        if (!forceQuiet) {
-                            newAlert = true;
+
+                        // When using local storage to track alert state (BYPASS_DB),
+                        // check if this alert was already fired previously.  The
+                        // calendar provider may re-insert SCHEDULED alert entries
+                        // when events are re-synced (e.g. contact birthday events
+                        // during a contact sync), which would otherwise cause
+                        // duplicate notifications with sound/vibrate.
+                        boolean alreadyFired = AlertUtils.BYPASS_DB
+                                && AlertUtils.hasAlertFiredInSharedPrefs(
+                                        context, stableEventId, beginTime, alarmTime);
+
+                        if (!alreadyFired) {
+                            numFired++;
+                            // If quiet hours are forcing the alarm to be silent,
+                            // keep newAlert as false so it will not make noise.
+                            if (!forceQuiet) {
+                                newAlert = true;
+                            }
                         }
 
                         // Record the received time in the CalendarAlerts table.
@@ -570,7 +590,7 @@ public class AlertService extends Service {
                     state = newState;
 
                     if (AlertUtils.BYPASS_DB) {
-                        AlertUtils.setAlertFiredInSharedPrefs(context, eventId, beginTime,
+                        AlertUtils.setAlertFiredInSharedPrefs(context, stableEventId, beginTime,
                                 alarmTime);
                     }
                 }

--- a/app/src/main/java/com/android/calendar/alerts/AlertUtils.java
+++ b/app/src/main/java/com/android/calendar/alerts/AlertUtils.java
@@ -27,6 +27,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.pm.PackageManager;
+import android.database.Cursor;
 import android.net.Uri;
 import android.provider.CalendarContract;
 import android.provider.CalendarContract.CalendarAlerts;
@@ -256,10 +257,36 @@ public class AlertUtils {
         return context.getSharedPreferences(ALERTS_SHARED_PREFS_NAME, Context.MODE_PRIVATE);
     }
 
-    private static String getFiredAlertsKey(long eventId, long beginTime,
+    static String getStableEventId(Context context, long eventId) {
+        if (ContextCompat.checkSelfPermission(context, Manifest.permission.READ_CALENDAR)
+                != PackageManager.PERMISSION_GRANTED) {
+            return "e:" + eventId;
+        }
+        Cursor cursor = null;
+        try {
+            cursor = context.getContentResolver().query(
+                    ContentUris.withAppendedId(CalendarContract.Events.CONTENT_URI, eventId),
+                    new String[] { CalendarContract.Events._SYNC_ID }, null, null, null);
+            if (cursor != null && cursor.moveToFirst()) {
+                String syncId = cursor.getString(0);
+                if (syncId != null && !syncId.isEmpty()) {
+                    return "s:" + syncId;
+                }
+            }
+        } catch (Exception e) {
+            Log.w(TAG, "Failed to look up sync id for event " + eventId, e);
+        } finally {
+            if (cursor != null) {
+                cursor.close();
+            }
+        }
+        return "e:" + eventId;
+    }
+
+    private static String getFiredAlertsKey(String stableEventId, long beginTime,
             long alarmTime) {
         StringBuilder sb = new StringBuilder(KEY_FIRED_ALERT_PREFIX);
-        sb.append(eventId);
+        sb.append(stableEventId);
         sb.append("_");
         sb.append(beginTime);
         sb.append("_");
@@ -270,22 +297,22 @@ public class AlertUtils {
     /**
      * Returns whether the SharedPrefs storage indicates we have fired the alert before.
      */
-    static boolean hasAlertFiredInSharedPrefs(Context context, long eventId, long beginTime,
-            long alarmTime) {
+    static boolean hasAlertFiredInSharedPrefs(Context context, String stableEventId,
+            long beginTime, long alarmTime) {
         SharedPreferences prefs = getFiredAlertsTable(context);
-        return prefs.contains(getFiredAlertsKey(eventId, beginTime, alarmTime));
+        return prefs.contains(getFiredAlertsKey(stableEventId, beginTime, alarmTime));
     }
 
     /**
      * Store fired alert info in the SharedPrefs.
      */
-    static void setAlertFiredInSharedPrefs(Context context, long eventId, long beginTime,
+    static void setAlertFiredInSharedPrefs(Context context, String stableEventId, long beginTime,
             long alarmTime) {
         // Store alarm time as the value too so we don't have to parse all the keys to flush
         // old alarms out of the table later.
         SharedPreferences prefs = getFiredAlertsTable(context);
         SharedPreferences.Editor editor = prefs.edit();
-        editor.putLong(getFiredAlertsKey(eventId, beginTime, alarmTime), alarmTime);
+        editor.putLong(getFiredAlertsKey(stableEventId, beginTime, alarmTime), alarmTime);
         editor.apply();
     }
 


### PR DESCRIPTION
Contact birthday events are periodically deleted and re-inserted by the contacts sync, which assigns them a new Events._id. The existing de-dup key (preference_alert_<eventId>_…) would miss the old entry,  causing the birthday reminder to fire again with sound after each sync.

This PR replaces eventId in the key with the event's _sync_id when present (s:<syncId>), falling back to _id for never-synced local events (e:<eventId>). The sync ID survives re-insertion and stays stable across syncs.

Follow-up to https://github.com/Etar-Group/Etar-Calendar/pull/2050

Tested on my phone with nextcloud calendars. 
