### PR TITLE
Allow any day of the week as the week start day

### DIFF
--- a/app/src/main/java/com/android/calendar/Utils.java
+++ b/app/src/main/java/com/android/calendar/Utils.java
@@ -675,13 +675,11 @@ public class Utils {
             startDay = Integer.parseInt(pref);
         }
 
-        if (startDay == Calendar.SATURDAY) {
-            return Time.SATURDAY;
-        } else if (startDay == Calendar.MONDAY) {
-            return Time.MONDAY;
-        } else {
-            return Time.SUNDAY;
-        }
+        return convertCalendarDayToTimeDay(startDay);
+    }
+
+    private static int convertCalendarDayToTimeDay(int calendarDay) {
+        return calendarDay - 1;
     }
 
     /**
@@ -774,9 +772,7 @@ public class Utils {
      * @return true if the column is Saturday position
      */
     public static boolean isSaturday(int column, int firstDayOfWeek) {
-        return (firstDayOfWeek == Time.SUNDAY && column == 6)
-                || (firstDayOfWeek == Time.MONDAY && column == 5)
-                || (firstDayOfWeek == Time.SATURDAY && column == 0);
+        return column == (6 - firstDayOfWeek + 7) % 7;
     }
 
     /**
@@ -787,9 +783,7 @@ public class Utils {
      * @return true if the column is Sunday position
      */
     public static boolean isSunday(int column, int firstDayOfWeek) {
-        return (firstDayOfWeek == Time.SUNDAY && column == 0)
-                || (firstDayOfWeek == Time.MONDAY && column == 6)
-                || (firstDayOfWeek == Time.SATURDAY && column == 1);
+        return column == (-firstDayOfWeek + 7) % 7;
     }
 
     /**
@@ -1434,17 +1428,16 @@ public class Utils {
         weekTime.set(millisSinceEpoch);
         weekTime.normalize();
         int firstDayOfWeek = getFirstDayOfWeek(context);
-        // if the date is on Saturday or Sunday and the start of the week
-        // isn't Monday we may need to shift the date to be in the correct
-        // week
-        if (weekTime.getWeekDay() == Time.SUNDAY
-                && (firstDayOfWeek == Time.SUNDAY || firstDayOfWeek == Time.SATURDAY)) {
-            weekTime.setDay(weekTime.getDay() + 1);
-            weekTime.normalize();
-        } else if (weekTime.getWeekDay() == Time.SATURDAY && firstDayOfWeek == Time.SATURDAY) {
-            weekTime.setDay(weekTime.getDay() + 2);
-            weekTime.normalize();
-        }
+        // ISO 8601 defines a week's number by its Thursday. Any 7-day period
+        // contains exactly one Thursday. Find the Thursday within the user's
+        // current week and return its ISO week number.
+        int weekDay = weekTime.getWeekDay();
+        int daysSinceWeekStart = (weekDay - firstDayOfWeek + 7) % 7;
+        weekTime.setDay(weekTime.getDay() - daysSinceWeekStart);
+        weekTime.normalize();
+        int thursdayOffset = (Time.THURSDAY - firstDayOfWeek + 7) % 7;
+        weekTime.setDay(weekTime.getDay() + thursdayOffset);
+        weekTime.normalize();
         return weekTime.getWeekNumber();
     }
 

--- a/app/src/main/java/com/android/calendar/month/SimpleDayPickerFragment.java
+++ b/app/src/main/java/com/android/calendar/month/SimpleDayPickerFragment.java
@@ -42,7 +42,6 @@ import com.android.calendar.calendarcommon2.Time;
 
 import java.util.Calendar;
 import java.util.HashMap;
-import java.util.Locale;
 
 import ws.xsoh.etar.R;
 
@@ -292,9 +291,7 @@ public class SimpleDayPickerFragment extends ListFragment implements OnScrollLis
      * preference space.
      */
     protected void doResumeUpdates() {
-        // Get default week start based on locale, subtracting one for use with android Time.
-        Calendar cal = Calendar.getInstance(Locale.getDefault());
-        mFirstDayOfWeek = cal.getFirstDayOfWeek() - 1;
+        mFirstDayOfWeek = Utils.getFirstDayOfWeek(getContext());
 
         mShowWeekNumber = false;
 

--- a/app/src/main/java/com/android/calendar/month/SimpleWeeksAdapter.java
+++ b/app/src/main/java/com/android/calendar/month/SimpleWeeksAdapter.java
@@ -33,9 +33,7 @@ import com.android.calendar.CalendarController;
 import com.android.calendar.Utils;
 import com.android.calendar.calendarcommon2.Time;
 
-import java.util.Calendar;
 import java.util.HashMap;
-import java.util.Locale;
 
 /**
  * <p>
@@ -100,9 +98,7 @@ public class SimpleWeeksAdapter extends BaseAdapter implements OnTouchListener {
     public SimpleWeeksAdapter(Context context, HashMap<String, Integer> params) {
         mContext = context;
 
-        // Get default week start based on locale, subtracting one for use with android Time.
-        Calendar cal = Calendar.getInstance(Locale.getDefault());
-        mFirstDayOfWeek = cal.getFirstDayOfWeek() - 1;
+        mFirstDayOfWeek = Utils.getFirstDayOfWeek(mContext);
 
         if (mScale == 0) {
             mScale = context.getResources().getDisplayMetrics().density;

--- a/app/src/main/java/com/android/calendar/settings/GeneralPreferences.kt
+++ b/app/src/main/java/com/android/calendar/settings/GeneralPreferences.kt
@@ -34,6 +34,9 @@ import android.provider.CalendarContract.CalendarCache
 import android.provider.SearchRecentSuggestions
 import android.provider.Settings
 import android.text.TextUtils
+import java.text.DateFormatSymbols
+import java.util.Calendar
+import java.util.Locale
 import android.util.SparseIntArray
 import android.widget.Toast
 import androidx.preference.CheckBoxPreference
@@ -153,6 +156,7 @@ class GeneralPreferences : PreferenceFragmentCompat(),
             preferenceScreen.removePreferenceRecursively(KEY_PURE_BLACK_NIGHT_MODE)
         }
 
+        buildWeekStartEntries()
         buildSnoozeDelayEntries()
         buildDefaultReminderPrefEntries()
         handleUseCustomSnoozeDelayVisibility()
@@ -353,6 +357,22 @@ class GeneralPreferences : PreferenceFragmentCompat(),
         return ring?.getTitle(context)
     }
 
+    private fun buildWeekStartEntries() {
+        val symbols = DateFormatSymbols.getInstance(Locale.getDefault())
+        val weekdays = symbols.weekdays
+        val entries = arrayOf(
+            getString(R.string.week_start_locale_default),
+            weekdays[Calendar.SUNDAY],
+            weekdays[Calendar.MONDAY],
+            weekdays[Calendar.TUESDAY],
+            weekdays[Calendar.WEDNESDAY],
+            weekdays[Calendar.THURSDAY],
+            weekdays[Calendar.FRIDAY],
+            weekdays[Calendar.SATURDAY]
+        )
+        weekStartPref.entries = entries
+    }
+
     private fun buildSnoozeDelayEntries() {
         val values = snoozeDelayPref.entryValues
         val count = values.size
@@ -523,9 +543,13 @@ class GeneralPreferences : PreferenceFragmentCompat(),
 
         // These must be in sync with the array preferences_week_start_day_values
         const val WEEK_START_DEFAULT = "-1"
-        const val WEEK_START_SATURDAY = "7"
         const val WEEK_START_SUNDAY = "1"
         const val WEEK_START_MONDAY = "2"
+        const val WEEK_START_TUESDAY = "3"
+        const val WEEK_START_WEDNESDAY = "4"
+        const val WEEK_START_THURSDAY = "5"
+        const val WEEK_START_FRIDAY = "6"
+        const val WEEK_START_SATURDAY = "7"
         // Default preference values
         const val DEFAULT_DEFAULT_START = "-2"
         const val DEFAULT_START_VIEW = CalendarController.ViewType.WEEK

--- a/app/src/main/res/values-af/arrays.xml
+++ b/app/src/main/res/values-af/arrays.xml
@@ -22,12 +22,6 @@
     <item msgid="2658001219380695677">"SMS"</item>
     <item msgid="7926918288165444873">"Alarm"</item>
   </string-array>
-  <string-array name="preferences_week_start_day_labels">
-    <item msgid="986150274035512339">"Locale-verstek"</item>
-    <item msgid="134027225275475280">"Saterdag"</item>
-    <item msgid="95029346069903091">"Sondag"</item>
-    <item msgid="5840983116375063739">"Maandag"</item>
-  </string-array>
   <string-array name="availability">
     <item msgid="454869065893453189">"Besig"</item>
     <item msgid="6228387173725732140">"Beskikbaar"</item>

--- a/app/src/main/res/values-am/arrays.xml
+++ b/app/src/main/res/values-am/arrays.xml
@@ -22,12 +22,6 @@
     <item msgid="2658001219380695677">"አጭር የፅሁፍ መልዕክት"</item>
     <item msgid="7926918288165444873">"ማንቂያ ደውል"</item>
   </string-array>
-  <string-array name="preferences_week_start_day_labels">
-    <item msgid="986150274035512339">"የአካባቢ ነባሪ"</item>
-    <item msgid="134027225275475280">"ቅዳሜ"</item>
-    <item msgid="95029346069903091">"እሁድ"</item>
-    <item msgid="5840983116375063739">"ሰኞ"</item>
-  </string-array>
   <string-array name="availability">
     <item msgid="454869065893453189">"ተይዟ ል"</item>
     <item msgid="6228387173725732140">"የሚገኝ"</item>

--- a/app/src/main/res/values-ar/arrays.xml
+++ b/app/src/main/res/values-ar/arrays.xml
@@ -22,12 +22,6 @@
     <item msgid="2658001219380695677">"رسائل SMS"</item>
     <item msgid="7926918288165444873">"المنبه"</item>
   </string-array>
-  <string-array name="preferences_week_start_day_labels">
-    <item msgid="986150274035512339">"اللغة الافتراضية"</item>
-    <item msgid="134027225275475280">"السبت"</item>
-    <item msgid="95029346069903091">"الأحد"</item>
-    <item msgid="5840983116375063739">"الاثنين"</item>
-  </string-array>
   <string-array name="availability">
     <item msgid="454869065893453189">"مشغول"</item>
     <item msgid="6228387173725732140">"متواجد"</item>

--- a/app/src/main/res/values-be/arrays.xml
+++ b/app/src/main/res/values-be/arrays.xml
@@ -22,12 +22,6 @@
     <item msgid="2658001219380695677">"SMS"</item>
     <item msgid="7926918288165444873">"Будзільнік"</item>
   </string-array>
-  <string-array name="preferences_week_start_day_labels">
-    <item msgid="986150274035512339">"Рэгiянальная налада па змаўчанні"</item>
-    <item msgid="134027225275475280">"Субота"</item>
-    <item msgid="95029346069903091">"Нядзеля"</item>
-    <item msgid="5840983116375063739">"Панядзелак"</item>
-  </string-array>
   <string-array name="availability">
     <item msgid="454869065893453189">"Заняты"</item>
     <item msgid="6228387173725732140">"Даступны"</item>

--- a/app/src/main/res/values-bg/arrays.xml
+++ b/app/src/main/res/values-bg/arrays.xml
@@ -22,12 +22,6 @@
     <item msgid="2658001219380695677">"SMS"</item>
     <item msgid="7926918288165444873">"Будилник"</item>
   </string-array>
-  <string-array name="preferences_week_start_day_labels">
-    <item msgid="986150274035512339">"Стандартно за локала"</item>
-    <item msgid="134027225275475280">"събота"</item>
-    <item msgid="95029346069903091">"неделя"</item>
-    <item msgid="5840983116375063739">"понеделник"</item>
-  </string-array>
   <string-array name="availability">
     <item msgid="454869065893453189">"Зает/а"</item>
     <item msgid="6228387173725732140">"На разположение"</item>

--- a/app/src/main/res/values-ca/arrays.xml
+++ b/app/src/main/res/values-ca/arrays.xml
@@ -22,12 +22,6 @@
     <item msgid="2658001219380695677">"SMS"</item>
     <item msgid="7926918288165444873">"Alarma"</item>
   </string-array>
-  <string-array name="preferences_week_start_day_labels">
-    <item msgid="986150274035512339">"Regió predeterminada"</item>
-    <item msgid="134027225275475280">"Dissabte"</item>
-    <item msgid="95029346069903091">"Diumenge"</item>
-    <item msgid="5840983116375063739">"Dilluns"</item>
-  </string-array>
   <string-array name="availability">
     <item msgid="454869065893453189">"Ocupat"</item>
     <item msgid="6228387173725732140">"Disponible"</item>

--- a/app/src/main/res/values-cs/arrays.xml
+++ b/app/src/main/res/values-cs/arrays.xml
@@ -22,12 +22,6 @@
     <item msgid="2658001219380695677">"SMS"</item>
     <item msgid="7926918288165444873">"Budík"</item>
   </string-array>
-  <string-array name="preferences_week_start_day_labels">
-    <item msgid="986150274035512339">"Výchozí hodnota regionálního nastavení"</item>
-    <item msgid="134027225275475280">"Sobota"</item>
-    <item msgid="95029346069903091">"Neděle"</item>
-    <item msgid="5840983116375063739">"Pondělí"</item>
-  </string-array>
   <string-array name="availability">
     <item msgid="454869065893453189">"Nemám čas"</item>
     <item msgid="6228387173725732140">"K dispozici"</item>

--- a/app/src/main/res/values-da/arrays.xml
+++ b/app/src/main/res/values-da/arrays.xml
@@ -22,12 +22,6 @@
     <item msgid="2658001219380695677">"Sms"</item>
     <item msgid="7926918288165444873">"Påmindelse"</item>
   </string-array>
-  <string-array name="preferences_week_start_day_labels">
-    <item msgid="986150274035512339">"Landestandard"</item>
-    <item msgid="134027225275475280">"lørdag"</item>
-    <item msgid="95029346069903091">"søndag"</item>
-    <item msgid="5840983116375063739">"mandag"</item>
-  </string-array>
   <string-array name="availability">
     <item msgid="454869065893453189">"Optaget"</item>
     <item msgid="6228387173725732140">"Ledig"</item>

--- a/app/src/main/res/values-de/arrays.xml
+++ b/app/src/main/res/values-de/arrays.xml
@@ -22,12 +22,6 @@
     <item msgid="2658001219380695677">"SMS"</item>
     <item msgid="7926918288165444873">"Wecker"</item>
   </string-array>
-  <string-array name="preferences_week_start_day_labels">
-    <item msgid="986150274035512339">"Gebietsschema - Standard"</item>
-    <item msgid="134027225275475280">"Samstag"</item>
-    <item msgid="95029346069903091">"Sonntag"</item>
-    <item msgid="5840983116375063739">"Montag"</item>
-  </string-array>
   <string-array name="preferences_days_per_week_labels">
     <item>"2 Tage"</item>
     <item>"3 Tage"</item>

--- a/app/src/main/res/values-el/arrays.xml
+++ b/app/src/main/res/values-el/arrays.xml
@@ -22,12 +22,6 @@
     <item msgid="2658001219380695677">"SMS"</item>
     <item msgid="7926918288165444873">"Ξυπνητήρι"</item>
   </string-array>
-  <string-array name="preferences_week_start_day_labels">
-    <item msgid="986150274035512339">"Προεπιλογή τοπικών ρυθμίσεων"</item>
-    <item msgid="134027225275475280">"Σάββατο"</item>
-    <item msgid="95029346069903091">"Κυριακή"</item>
-    <item msgid="5840983116375063739">"Δευτέρα"</item>
-  </string-array>
   <string-array name="availability">
     <item msgid="454869065893453189">"Απασχολημένος/η"</item>
     <item msgid="6228387173725732140">"Διαθέσιμος/η"</item>

--- a/app/src/main/res/values-en-rGB/arrays.xml
+++ b/app/src/main/res/values-en-rGB/arrays.xml
@@ -22,12 +22,6 @@
     <item msgid="2658001219380695677">"SMS"</item>
     <item msgid="7926918288165444873">"Alarm"</item>
   </string-array>
-  <string-array name="preferences_week_start_day_labels">
-    <item msgid="986150274035512339">"Locale default"</item>
-    <item msgid="134027225275475280">"Saturday"</item>
-    <item msgid="95029346069903091">"Sunday"</item>
-    <item msgid="5840983116375063739">"Monday"</item>
-  </string-array>
   <string-array name="availability">
     <item msgid="454869065893453189">"Busy"</item>
     <item msgid="6228387173725732140">"Available"</item>

--- a/app/src/main/res/values-es-rUS/arrays.xml
+++ b/app/src/main/res/values-es-rUS/arrays.xml
@@ -22,12 +22,6 @@
     <item msgid="2658001219380695677">"SMS"</item>
     <item msgid="7926918288165444873">"Alarma"</item>
   </string-array>
-  <string-array name="preferences_week_start_day_labels">
-    <item msgid="986150274035512339">"Configuración regional predeterminada"</item>
-    <item msgid="134027225275475280">"Sábado"</item>
-    <item msgid="95029346069903091">"Domingo"</item>
-    <item msgid="5840983116375063739">"Lunes"</item>
-  </string-array>
   <string-array name="availability">
     <item msgid="454869065893453189">"No disponible"</item>
     <item msgid="6228387173725732140">"Disponible"</item>

--- a/app/src/main/res/values-es/arrays.xml
+++ b/app/src/main/res/values-es/arrays.xml
@@ -22,12 +22,6 @@
     <item msgid="2658001219380695677">"SMS"</item>
     <item msgid="7926918288165444873">"Alarma"</item>
   </string-array>
-  <string-array name="preferences_week_start_day_labels">
-    <item msgid="986150274035512339">"Región predeterminada"</item>
-    <item msgid="134027225275475280">"Sábado"</item>
-    <item msgid="95029346069903091">"Domingo"</item>
-    <item msgid="5840983116375063739">"Lunes"</item>
-  </string-array>
   <string-array name="availability">
     <item msgid="454869065893453189">"Ocupado"</item>
     <item msgid="6228387173725732140">"Disponible"</item>

--- a/app/src/main/res/values-et/arrays.xml
+++ b/app/src/main/res/values-et/arrays.xml
@@ -22,12 +22,6 @@
     <item msgid="2658001219380695677">"SMS"</item>
     <item msgid="7926918288165444873">"Alarm"</item>
   </string-array>
-  <string-array name="preferences_week_start_day_labels">
-    <item msgid="986150274035512339">"Lokaadi vaikeseade"</item>
-    <item msgid="134027225275475280">"Laupäev"</item>
-    <item msgid="95029346069903091">"Pühapäev"</item>
-    <item msgid="5840983116375063739">"Esmaspäev"</item>
-  </string-array>
   <string-array name="availability">
     <item msgid="454869065893453189">"Hõivatud"</item>
     <item msgid="6228387173725732140">"Saadaval"</item>

--- a/app/src/main/res/values-fa/arrays.xml
+++ b/app/src/main/res/values-fa/arrays.xml
@@ -22,12 +22,6 @@
     <item msgid="2658001219380695677">"پیامک"</item>
     <item msgid="7926918288165444873">"زنگ هشدار"</item>
   </string-array>
-  <string-array name="preferences_week_start_day_labels">
-    <item msgid="986150274035512339">"پیش‌فرض محلی"</item>
-    <item msgid="134027225275475280">"شنبه"</item>
-    <item msgid="95029346069903091">"یکشنبه"</item>
-    <item msgid="5840983116375063739">"دوشنبه"</item>
-  </string-array>
   <string-array name="availability">
     <item msgid="454869065893453189">"مشغول"</item>
     <item msgid="6228387173725732140">"موجود"</item>

--- a/app/src/main/res/values-fi/arrays.xml
+++ b/app/src/main/res/values-fi/arrays.xml
@@ -22,12 +22,6 @@
     <item msgid="2658001219380695677">"Tekstiviesti"</item>
     <item msgid="7926918288165444873">"Hälytys"</item>
   </string-array>
-  <string-array name="preferences_week_start_day_labels">
-    <item msgid="986150274035512339">"Oletussijainti"</item>
-    <item msgid="134027225275475280">"lauantai"</item>
-    <item msgid="95029346069903091">"sunnuntai"</item>
-    <item msgid="5840983116375063739">"maanantai"</item>
-  </string-array>
   <string-array name="availability">
     <item msgid="454869065893453189">"Varattu"</item>
     <item msgid="6228387173725732140">"Tavoitettavissa"</item>

--- a/app/src/main/res/values-fr/arrays.xml
+++ b/app/src/main/res/values-fr/arrays.xml
@@ -22,12 +22,6 @@
     <item msgid="2658001219380695677">"SMS"</item>
     <item msgid="7926918288165444873">"Alarme"</item>
   </string-array>
-  <string-array name="preferences_week_start_day_labels">
-    <item msgid="986150274035512339">"Paramètres régionaux par défaut"</item>
-    <item msgid="134027225275475280">"Samedi"</item>
-    <item msgid="95029346069903091">"Dimanche"</item>
-    <item msgid="5840983116375063739">"Lundi"</item>
-  </string-array>
   <string-array name="availability">
     <item msgid="454869065893453189">"Occupé"</item>
     <item msgid="6228387173725732140">"Disponible"</item>

--- a/app/src/main/res/values-hi/arrays.xml
+++ b/app/src/main/res/values-hi/arrays.xml
@@ -22,12 +22,6 @@
     <item msgid="2658001219380695677">"SMS"</item>
     <item msgid="7926918288165444873">"अलार्म"</item>
   </string-array>
-  <string-array name="preferences_week_start_day_labels">
-    <item msgid="986150274035512339">"स्थान डिफ़ॉल्ट"</item>
-    <item msgid="134027225275475280">"शनिवार"</item>
-    <item msgid="95029346069903091">"रविवार"</item>
-    <item msgid="5840983116375063739">"सोमवार"</item>
-  </string-array>
   <string-array name="availability">
     <item msgid="454869065893453189">"व्यस्त"</item>
     <item msgid="6228387173725732140">"उपलब्ध"</item>

--- a/app/src/main/res/values-hr/arrays.xml
+++ b/app/src/main/res/values-hr/arrays.xml
@@ -22,12 +22,6 @@
     <item msgid="2658001219380695677">"SMS"</item>
     <item msgid="7926918288165444873">"Alarm"</item>
   </string-array>
-  <string-array name="preferences_week_start_day_labels">
-    <item msgid="986150274035512339">"Zadana oznaka zemlje"</item>
-    <item msgid="134027225275475280">"Subota"</item>
-    <item msgid="95029346069903091">"Nedjelja"</item>
-    <item msgid="5840983116375063739">"Ponedjeljak"</item>
-  </string-array>
   <string-array name="availability">
     <item msgid="454869065893453189">"Zauzet"</item>
     <item msgid="6228387173725732140">"Dostupan"</item>

--- a/app/src/main/res/values-hu/arrays.xml
+++ b/app/src/main/res/values-hu/arrays.xml
@@ -22,12 +22,6 @@
     <item msgid="2658001219380695677">"SMS"</item>
     <item msgid="7926918288165444873">"Ébresztő"</item>
   </string-array>
-  <string-array name="preferences_week_start_day_labels">
-    <item msgid="986150274035512339">"Helyi alapértelmezett"</item>
-    <item msgid="134027225275475280">"Szombat"</item>
-    <item msgid="95029346069903091">"Vasárnap"</item>
-    <item msgid="5840983116375063739">"Hétfő"</item>
-  </string-array>
   <string-array name="availability">
     <item msgid="454869065893453189">"Elfoglalt"</item>
     <item msgid="6228387173725732140">"Elérhető"</item>

--- a/app/src/main/res/values-in/arrays.xml
+++ b/app/src/main/res/values-in/arrays.xml
@@ -22,12 +22,6 @@
     <item msgid="2658001219380695677">"SMS"</item>
     <item msgid="7926918288165444873">"Alarm"</item>
   </string-array>
-  <string-array name="preferences_week_start_day_labels">
-    <item msgid="986150274035512339">"Lokal default"</item>
-    <item msgid="134027225275475280">"Sabtu"</item>
-    <item msgid="95029346069903091">"Minggu"</item>
-    <item msgid="5840983116375063739">"Senin"</item>
-  </string-array>
   <string-array name="availability">
     <item msgid="454869065893453189">"Sibuk"</item>
     <item msgid="6228387173725732140">"Tersedia"</item>

--- a/app/src/main/res/values-it/arrays.xml
+++ b/app/src/main/res/values-it/arrays.xml
@@ -22,12 +22,6 @@
     <item msgid="2658001219380695677">"SMS"</item>
     <item msgid="7926918288165444873">"Allarme"</item>
   </string-array>
-  <string-array name="preferences_week_start_day_labels">
-    <item msgid="986150274035512339">"Impostazioni internazionali predefinite"</item>
-    <item msgid="134027225275475280">"Sabato"</item>
-    <item msgid="95029346069903091">"Domenica"</item>
-    <item msgid="5840983116375063739">"Lunedì"</item>
-  </string-array>
   <string-array name="availability">
     <item msgid="454869065893453189">"Occupato"</item>
     <item msgid="6228387173725732140">"Disponibile"</item>

--- a/app/src/main/res/values-iw/arrays.xml
+++ b/app/src/main/res/values-iw/arrays.xml
@@ -22,12 +22,6 @@
     <item msgid="2658001219380695677">"SMS"</item>
     <item msgid="7926918288165444873">"התראה"</item>
   </string-array>
-  <string-array name="preferences_week_start_day_labels">
-    <item msgid="986150274035512339">"ברירת מחדל של מיקום"</item>
-    <item msgid="134027225275475280">"יום שבת"</item>
-    <item msgid="95029346069903091">"יום ראשון"</item>
-    <item msgid="5840983116375063739">"יום שני"</item>
-  </string-array>
   <string-array name="availability">
     <item msgid="454869065893453189">"לא פנוי"</item>
     <item msgid="6228387173725732140">"זמין"</item>

--- a/app/src/main/res/values-ja/arrays.xml
+++ b/app/src/main/res/values-ja/arrays.xml
@@ -22,12 +22,6 @@
     <item msgid="2658001219380695677">"SMS"</item>
     <item msgid="7926918288165444873">"アラーム"</item>
   </string-array>
-  <string-array name="preferences_week_start_day_labels">
-    <item msgid="986150274035512339">"ユーザーの言語/地域でのデフォルト設定"</item>
-    <item msgid="134027225275475280">"土曜日"</item>
-    <item msgid="95029346069903091">"日曜日"</item>
-    <item msgid="5840983116375063739">"月曜日"</item>
-  </string-array>
   <string-array name="availability">
     <item msgid="454869065893453189">"予定あり"</item>
     <item msgid="6228387173725732140">"予定なし"</item>

--- a/app/src/main/res/values-ko/arrays.xml
+++ b/app/src/main/res/values-ko/arrays.xml
@@ -22,12 +22,6 @@
     <item msgid="2658001219380695677">"SMS"</item>
     <item msgid="7926918288165444873">"알람"</item>
   </string-array>
-  <string-array name="preferences_week_start_day_labels">
-    <item msgid="986150274035512339">"언어 기본값"</item>
-    <item msgid="134027225275475280">"토요일"</item>
-    <item msgid="95029346069903091">"일요일"</item>
-    <item msgid="5840983116375063739">"월요일"</item>
-  </string-array>
   <string-array name="availability">
     <item msgid="454869065893453189">"바쁨"</item>
     <item msgid="6228387173725732140">"한가함"</item>

--- a/app/src/main/res/values-lt/arrays.xml
+++ b/app/src/main/res/values-lt/arrays.xml
@@ -22,12 +22,6 @@
     <item msgid="2658001219380695677">"SMS"</item>
     <item msgid="7926918288165444873">"Signalas"</item>
   </string-array>
-  <string-array name="preferences_week_start_day_labels">
-    <item msgid="986150274035512339">"Numatytoji lokalė"</item>
-    <item msgid="134027225275475280">"Šeštadienis"</item>
-    <item msgid="95029346069903091">"Sekmadienis"</item>
-    <item msgid="5840983116375063739">"Pirmadienis"</item>
-  </string-array>
   <string-array name="availability">
     <item msgid="454869065893453189">"Užimtas"</item>
     <item msgid="6228387173725732140">"Pasiekiama"</item>

--- a/app/src/main/res/values-lv/arrays.xml
+++ b/app/src/main/res/values-lv/arrays.xml
@@ -22,12 +22,6 @@
     <item msgid="2658001219380695677">"Īsziņa"</item>
     <item msgid="7926918288165444873">"Signāls"</item>
   </string-array>
-  <string-array name="preferences_week_start_day_labels">
-    <item msgid="986150274035512339">"Lokalizācijas noklusējums"</item>
-    <item msgid="134027225275475280">"Sestdiena"</item>
-    <item msgid="95029346069903091">"Svētdiena"</item>
-    <item msgid="5840983116375063739">"Pirmdiena"</item>
-  </string-array>
   <string-array name="availability">
     <item msgid="454869065893453189">"Aizņemts"</item>
     <item msgid="6228387173725732140">"Pieejams"</item>

--- a/app/src/main/res/values-ms/arrays.xml
+++ b/app/src/main/res/values-ms/arrays.xml
@@ -22,12 +22,6 @@
     <item msgid="2658001219380695677">"SMS"</item>
     <item msgid="7926918288165444873">"Penggera"</item>
   </string-array>
-  <string-array name="preferences_week_start_day_labels">
-    <item msgid="986150274035512339">"Lalai tempat peristiwa"</item>
-    <item msgid="134027225275475280">"Sabtu"</item>
-    <item msgid="95029346069903091">"Ahad"</item>
-    <item msgid="5840983116375063739">"Isnin"</item>
-  </string-array>
   <string-array name="availability">
     <item msgid="454869065893453189">"Sibuk"</item>
     <item msgid="6228387173725732140">"Ada"</item>

--- a/app/src/main/res/values-nb/arrays.xml
+++ b/app/src/main/res/values-nb/arrays.xml
@@ -22,12 +22,6 @@
     <item msgid="2658001219380695677">"Tekstmelding"</item>
     <item msgid="7926918288165444873">"Alarm"</item>
   </string-array>
-  <string-array name="preferences_week_start_day_labels">
-    <item msgid="986150274035512339">"Språkstandard"</item>
-    <item msgid="134027225275475280">"Lørdag"</item>
-    <item msgid="95029346069903091">"Søndag"</item>
-    <item msgid="5840983116375063739">"Mandag"</item>
-  </string-array>
   <string-array name="availability">
     <item msgid="454869065893453189">"Opptatt"</item>
     <item msgid="6228387173725732140">"Tilgjengelig"</item>

--- a/app/src/main/res/values-nl/arrays.xml
+++ b/app/src/main/res/values-nl/arrays.xml
@@ -22,12 +22,6 @@
     <item msgid="2658001219380695677">"Sms"</item>
     <item msgid="7926918288165444873">"Alarm"</item>
   </string-array>
-  <string-array name="preferences_week_start_day_labels">
-    <item msgid="986150274035512339">"Standaardlandinstelling"</item>
-    <item msgid="134027225275475280">"Zaterdag"</item>
-    <item msgid="95029346069903091">"Zondag"</item>
-    <item msgid="5840983116375063739">"Maandag"</item>
-  </string-array>
   <string-array name="availability">
     <item msgid="454869065893453189">"Bezet"</item>
     <item msgid="6228387173725732140">"Beschikbaar"</item>

--- a/app/src/main/res/values-pl/arrays.xml
+++ b/app/src/main/res/values-pl/arrays.xml
@@ -22,12 +22,6 @@
     <item msgid="2658001219380695677">"SMS"</item>
     <item msgid="7926918288165444873">"Alarm"</item>
   </string-array>
-  <string-array name="preferences_week_start_day_labels">
-    <item msgid="986150274035512339">"Domyślny dla regionu"</item>
-    <item msgid="134027225275475280">"Sobota"</item>
-    <item msgid="95029346069903091">"Niedziela"</item>
-    <item msgid="5840983116375063739">"Poniedziałek"</item>
-  </string-array>
   <string-array name="availability">
     <item msgid="454869065893453189">"Zajęty"</item>
     <item msgid="6228387173725732140">"Dostępny"</item>

--- a/app/src/main/res/values-pt-rPT/arrays.xml
+++ b/app/src/main/res/values-pt-rPT/arrays.xml
@@ -22,12 +22,6 @@
     <item msgid="2658001219380695677">"SMS"</item>
     <item msgid="7926918288165444873">"Alarme"</item>
   </string-array>
-  <string-array name="preferences_week_start_day_labels">
-    <item msgid="986150274035512339">"Local predefinido"</item>
-    <item msgid="134027225275475280">"Sábado"</item>
-    <item msgid="95029346069903091">"Domingo"</item>
-    <item msgid="5840983116375063739">"Segunda-feira"</item>
-  </string-array>
   <string-array name="availability">
     <item msgid="454869065893453189">"Ocupado"</item>
     <item msgid="6228387173725732140">"Disponível"</item>

--- a/app/src/main/res/values-pt/arrays.xml
+++ b/app/src/main/res/values-pt/arrays.xml
@@ -22,12 +22,6 @@
     <item msgid="2658001219380695677">"SMS"</item>
     <item msgid="7926918288165444873">"Alarme"</item>
   </string-array>
-  <string-array name="preferences_week_start_day_labels">
-    <item msgid="986150274035512339">"Localidade padrão"</item>
-    <item msgid="134027225275475280">"Sábado"</item>
-    <item msgid="95029346069903091">"Domingo"</item>
-    <item msgid="5840983116375063739">"Segunda-feira"</item>
-  </string-array>
   <string-array name="availability">
     <item msgid="454869065893453189">"Ocupado(a)"</item>
     <item msgid="6228387173725732140">"Disponível"</item>

--- a/app/src/main/res/values-ro/arrays.xml
+++ b/app/src/main/res/values-ro/arrays.xml
@@ -22,12 +22,6 @@
     <item msgid="2658001219380695677">"SMS"</item>
     <item msgid="7926918288165444873">"Alarmă"</item>
   </string-array>
-  <string-array name="preferences_week_start_day_labels">
-    <item msgid="986150274035512339">"Codul local prestabilit"</item>
-    <item msgid="134027225275475280">"Sâmbătă"</item>
-    <item msgid="95029346069903091">"Duminică"</item>
-    <item msgid="5840983116375063739">"Luni"</item>
-  </string-array>
   <string-array name="availability">
     <item msgid="454869065893453189">"Ocupat"</item>
     <item msgid="6228387173725732140">"Disponibil"</item>

--- a/app/src/main/res/values-ru/arrays.xml
+++ b/app/src/main/res/values-ru/arrays.xml
@@ -22,12 +22,6 @@
     <item msgid="2658001219380695677">"SMS"</item>
     <item msgid="7926918288165444873">"Сигнал"</item>
   </string-array>
-  <string-array name="preferences_week_start_day_labels">
-    <item msgid="986150274035512339">"Региональные настройки по умолчанию"</item>
-    <item msgid="134027225275475280">"суббота"</item>
-    <item msgid="95029346069903091">"воскресенье"</item>
-    <item msgid="5840983116375063739">"понедельник"</item>
-  </string-array>
   <string-array name="availability">
     <item msgid="454869065893453189">"Занят"</item>
     <item msgid="6228387173725732140">"Доступен"</item>

--- a/app/src/main/res/values-sk/arrays.xml
+++ b/app/src/main/res/values-sk/arrays.xml
@@ -22,12 +22,6 @@
     <item msgid="2658001219380695677">"SMS"</item>
     <item msgid="7926918288165444873">"Budík"</item>
   </string-array>
-  <string-array name="preferences_week_start_day_labels">
-    <item msgid="986150274035512339">"Predvolená hodnota miestneho nastavenia"</item>
-    <item msgid="134027225275475280">"Sobota"</item>
-    <item msgid="95029346069903091">"Nedeľa"</item>
-    <item msgid="5840983116375063739">"Pondelok"</item>
-  </string-array>
   <string-array name="availability">
     <item msgid="454869065893453189">"Zaneprázdnený"</item>
     <item msgid="6228387173725732140">"K dispozícii"</item>

--- a/app/src/main/res/values-sl/arrays.xml
+++ b/app/src/main/res/values-sl/arrays.xml
@@ -22,12 +22,6 @@
     <item msgid="2658001219380695677">"SMS"</item>
     <item msgid="7926918288165444873">"Alarm"</item>
   </string-array>
-  <string-array name="preferences_week_start_day_labels">
-    <item msgid="986150274035512339">"Privzete območne nastavitve"</item>
-    <item msgid="134027225275475280">"Sobota"</item>
-    <item msgid="95029346069903091">"Nedelja"</item>
-    <item msgid="5840983116375063739">"Ponedeljek"</item>
-  </string-array>
   <string-array name="availability">
     <item msgid="454869065893453189">"Zasedeno"</item>
     <item msgid="6228387173725732140">"Na voljo"</item>

--- a/app/src/main/res/values-sr/arrays.xml
+++ b/app/src/main/res/values-sr/arrays.xml
@@ -22,12 +22,6 @@
     <item msgid="2658001219380695677">"SMS"</item>
     <item msgid="7926918288165444873">"Аларм"</item>
   </string-array>
-  <string-array name="preferences_week_start_day_labels">
-    <item msgid="986150274035512339">"Подразумевано за локалитет"</item>
-    <item msgid="134027225275475280">"субота"</item>
-    <item msgid="95029346069903091">"недеља"</item>
-    <item msgid="5840983116375063739">"понедељак"</item>
-  </string-array>
   <string-array name="availability">
     <item msgid="454869065893453189">"Заузет/а"</item>
     <item msgid="6228387173725732140">"Доступан/а"</item>

--- a/app/src/main/res/values-sv/arrays.xml
+++ b/app/src/main/res/values-sv/arrays.xml
@@ -22,12 +22,6 @@
     <item msgid="2658001219380695677">"SMS"</item>
     <item msgid="7926918288165444873">"Larm"</item>
   </string-array>
-  <string-array name="preferences_week_start_day_labels">
-    <item msgid="986150274035512339">"Standardinställning för språkkod"</item>
-    <item msgid="134027225275475280">"lördag"</item>
-    <item msgid="95029346069903091">"söndag"</item>
-    <item msgid="5840983116375063739">"måndag"</item>
-  </string-array>
   <string-array name="availability">
     <item msgid="454869065893453189">"Upptagen"</item>
     <item msgid="6228387173725732140">"Tillgänglig"</item>

--- a/app/src/main/res/values-sw/arrays.xml
+++ b/app/src/main/res/values-sw/arrays.xml
@@ -22,12 +22,6 @@
     <item msgid="2658001219380695677">"Ujumbe mfupi"</item>
     <item msgid="7926918288165444873">"Kengele"</item>
   </string-array>
-  <string-array name="preferences_week_start_day_labels">
-    <item msgid="986150274035512339">"Eneo la kawaida"</item>
-    <item msgid="134027225275475280">"Jumamosi"</item>
-    <item msgid="95029346069903091">"Jumapili"</item>
-    <item msgid="5840983116375063739">"Jumatatu"</item>
-  </string-array>
   <string-array name="availability">
     <item msgid="454869065893453189">"nina shughuli"</item>
     <item msgid="6228387173725732140">"Ninapatikana"</item>

--- a/app/src/main/res/values-th/arrays.xml
+++ b/app/src/main/res/values-th/arrays.xml
@@ -22,12 +22,6 @@
     <item msgid="2658001219380695677">"SMS"</item>
     <item msgid="7926918288165444873">"เตือน"</item>
   </string-array>
-  <string-array name="preferences_week_start_day_labels">
-    <item msgid="986150274035512339">"ตามท้องถิ่น"</item>
-    <item msgid="134027225275475280">"วันเสาร์"</item>
-    <item msgid="95029346069903091">"วันอาทิตย์"</item>
-    <item msgid="5840983116375063739">"วันจันทร์"</item>
-  </string-array>
   <string-array name="availability">
     <item msgid="454869065893453189">"ไม่ว่าง"</item>
     <item msgid="6228387173725732140">"ว่าง"</item>

--- a/app/src/main/res/values-tl/arrays.xml
+++ b/app/src/main/res/values-tl/arrays.xml
@@ -22,12 +22,6 @@
     <item msgid="2658001219380695677">"SMS"</item>
     <item msgid="7926918288165444873">"Alarma"</item>
   </string-array>
-  <string-array name="preferences_week_start_day_labels">
-    <item msgid="986150274035512339">"Lokal na default"</item>
-    <item msgid="134027225275475280">"Sabado"</item>
-    <item msgid="95029346069903091">"Linggo"</item>
-    <item msgid="5840983116375063739">"Lunes"</item>
-  </string-array>
   <string-array name="availability">
     <item msgid="454869065893453189">"Abala"</item>
     <item msgid="6228387173725732140">"Available"</item>

--- a/app/src/main/res/values-tr/arrays.xml
+++ b/app/src/main/res/values-tr/arrays.xml
@@ -22,12 +22,6 @@
     <item msgid="2658001219380695677">"SMS"</item>
     <item msgid="7926918288165444873">"Alarm"</item>
   </string-array>
-  <string-array name="preferences_week_start_day_labels">
-    <item msgid="986150274035512339">"Varsayılan yerel ayar"</item>
-    <item msgid="134027225275475280">"Cumartesi"</item>
-    <item msgid="95029346069903091">"Pazar"</item>
-    <item msgid="5840983116375063739">"Pazartesi"</item>
-  </string-array>
   <string-array name="availability">
     <item msgid="454869065893453189">"Meşgul"</item>
     <item msgid="6228387173725732140">"Uygun"</item>

--- a/app/src/main/res/values-ug/arrays.xml
+++ b/app/src/main/res/values-ug/arrays.xml
@@ -20,12 +20,6 @@
     <item msgid="2658001219380695677">"قىسقا ئۇچۇر"</item>
     <item msgid="7926918288165444873">"قوڭغۇراق"</item>
   </string-array>
-  <string-array name="preferences_week_start_day_labels">
-    <item msgid="986150274035512339">"يەرلىك كۆڭۈلدىكى قىممەت"</item>
-    <item msgid="134027225275475280">"شەنبە"</item>
-    <item msgid="95029346069903091">"يەكشەنبە"</item>
-    <item msgid="5840983116375063739">"دۈشەنبە"</item>
-  </string-array>
   <string-array name="availability">
     <item msgid="454869065893453189">"ئالدىراش"</item>
     <item msgid="6228387173725732140">"ئىشلىتىلىشچان"</item>

--- a/app/src/main/res/values-uk/arrays.xml
+++ b/app/src/main/res/values-uk/arrays.xml
@@ -22,12 +22,6 @@
     <item msgid="2658001219380695677">"SMS"</item>
     <item msgid="7926918288165444873">"Сигнал"</item>
   </string-array>
-  <string-array name="preferences_week_start_day_labels">
-    <item msgid="986150274035512339">"Код мови за умовч."</item>
-    <item msgid="134027225275475280">"Субота"</item>
-    <item msgid="95029346069903091">"Неділя"</item>
-    <item msgid="5840983116375063739">"Понеділок"</item>
-  </string-array>
   <string-array name="availability">
     <item msgid="454869065893453189">"Зайнятий"</item>
     <item msgid="6228387173725732140">"На місці"</item>

--- a/app/src/main/res/values-vi/arrays.xml
+++ b/app/src/main/res/values-vi/arrays.xml
@@ -22,12 +22,6 @@
     <item msgid="2658001219380695677">"SMS"</item>
     <item msgid="7926918288165444873">"Báo thức"</item>
   </string-array>
-  <string-array name="preferences_week_start_day_labels">
-    <item msgid="986150274035512339">"Ngôn ngữ mặc định"</item>
-    <item msgid="134027225275475280">"Thứ Bảy"</item>
-    <item msgid="95029346069903091">"Chủ nhật"</item>
-    <item msgid="5840983116375063739">"Thứ Hai"</item>
-  </string-array>
   <string-array name="availability">
     <item msgid="454869065893453189">"Bận"</item>
     <item msgid="6228387173725732140">"Sẵn có"</item>

--- a/app/src/main/res/values-zh-rCN/arrays.xml
+++ b/app/src/main/res/values-zh-rCN/arrays.xml
@@ -22,12 +22,6 @@
     <item msgid="2658001219380695677">"短信"</item>
     <item msgid="7926918288165444873">"闹钟"</item>
   </string-array>
-  <string-array name="preferences_week_start_day_labels">
-    <item msgid="986150274035512339">"语言区域的默认设置"</item>
-    <item msgid="134027225275475280">"星期六"</item>
-    <item msgid="95029346069903091">"星期日"</item>
-    <item msgid="5840983116375063739">"星期一"</item>
-  </string-array>
   <string-array name="availability">
     <item msgid="454869065893453189">"忙碌"</item>
     <item msgid="6228387173725732140">"有空"</item>

--- a/app/src/main/res/values-zh-rTW/arrays.xml
+++ b/app/src/main/res/values-zh-rTW/arrays.xml
@@ -22,12 +22,6 @@
     <item msgid="2658001219380695677">"簡訊"</item>
     <item msgid="7926918288165444873">"鬧鐘"</item>
   </string-array>
-  <string-array name="preferences_week_start_day_labels">
-    <item msgid="986150274035512339">"地區設定預設值"</item>
-    <item msgid="134027225275475280">"週六"</item>
-    <item msgid="95029346069903091">"週日"</item>
-    <item msgid="5840983116375063739">"週一"</item>
-  </string-array>
   <string-array name="availability">
     <item msgid="454869065893453189">"忙碌"</item>
     <item msgid="6228387173725732140">"有空"</item>

--- a/app/src/main/res/values-zu/arrays.xml
+++ b/app/src/main/res/values-zu/arrays.xml
@@ -22,12 +22,6 @@
     <item msgid="2658001219380695677">"SMS"</item>
     <item msgid="7926918288165444873">"I-alamu"</item>
   </string-array>
-  <string-array name="preferences_week_start_day_labels">
-    <item msgid="986150274035512339">"Okuzenzakalelayo kwezici zakhona"</item>
-    <item msgid="134027225275475280">"Umgqibelo"</item>
-    <item msgid="95029346069903091">"Isonto"</item>
-    <item msgid="5840983116375063739">"Umsombuluko"</item>
-  </string-array>
   <string-array name="availability">
     <item msgid="454869065893453189">"Matasa"</item>
     <item msgid="6228387173725732140">"Yatholakala"</item>

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -125,18 +125,15 @@
         <item>1</item>
     </string-array>
 
-    <string-array name="preferences_week_start_day_labels">
-        <item>Locale default</item>
-        <item>Saturday</item>
-        <item>Sunday</item>
-        <item>Monday</item>
-    </string-array>
-
     <string-array name="preferences_week_start_day_values" translatable="false">
         <item>"-1"</item>
-        <item>"7"</item>
         <item>"1"</item>
         <item>"2"</item>
+        <item>"3"</item>
+        <item>"4"</item>
+        <item>"5"</item>
+        <item>"6"</item>
+        <item>"7"</item>
     </string-array>
 
     <string-array name="preferences_days_per_week_labels" translatable="false">

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -499,6 +499,7 @@
     <string name="preferences_week_start_day_dialog">Week starts on</string>
     <!-- DO NOT TRANSLATE -->
     <string name="preferences_week_start_day_default" translatable="false">-1</string>
+    <string name="week_start_locale_default">Locale default</string>
 
     <string name="preferences_days_per_week_title">Days per week</string>
     <string name="preferences_days_per_week_dialog">Days per week</string>

--- a/app/src/main/res/xml-v26/general_preferences.xml
+++ b/app/src/main/res/xml-v26/general_preferences.xml
@@ -53,7 +53,6 @@
             app:key="preferences_week_start_day"
             app:defaultValue="@string/preferences_week_start_day_default"
             app:title="@string/preferences_week_start_day_title"
-            app:entries="@array/preferences_week_start_day_labels"
             app:entryValues="@array/preferences_week_start_day_values"
             app:dialogTitle="@string/preferences_week_start_day_dialog" />
         <ListPreference

--- a/app/src/main/res/xml/general_preferences.xml
+++ b/app/src/main/res/xml/general_preferences.xml
@@ -53,7 +53,6 @@
             app:key="preferences_week_start_day"
             app:defaultValue="@string/preferences_week_start_day_default"
             app:title="@string/preferences_week_start_day_title"
-            app:entries="@array/preferences_week_start_day_labels"
             app:entryValues="@array/preferences_week_start_day_values"
             app:dialogTitle="@string/preferences_week_start_day_dialog" />
         <ListPreference


### PR DESCRIPTION
## Summary
This PR extends the "Week starts on" preference to allow users to select **any day** of the week (Sunday through Saturday), instead of being limited to only Saturday, Sunday, or Monday.
## Motivation
Currently, Etar only offers four options for the week start day: Locale default, Saturday, Sunday, and Monday. While these cover many locales, some users have work schedules or payroll cycles that start on other days (e.g., Tuesday, Wednesday, Thursday, Friday). Allowing any day improves flexibility and usability.
## Changes
- **`GeneralPreferences.kt`**: Dynamically generates week start day labels from `DateFormatSymbols`, supporting all 7 days. Added constants for Tuesday–Friday (`WEEK_START_TUESDAY` through `WEEK_START_FRIDAY`).
- **`Utils.java`**: Replaced the hardcoded `if-else` chain in `getWeekStartDay()` with a generic `convertCalendarDayToTimeDay()` method that supports any day value.
- **`arrays.xml`**: Removed the hardcoded `preferences_week_start_day_labels` array. Expanded `preferences_week_start_day_values` to include values for all 7 days.
- **`general_preferences.xml` / `general_preferences.xml` (v26)**: Removed the static `app:entries` attribute, since labels are now set dynamically.
- **`strings.xml`**: Added `week_start_locale_default` string resource.
**Before**: Only Locale default, Saturday, Sunday, Monday  
**After**: Locale default + any day (Sunday, Monday, Tuesday, Wednesday, Thursday, Friday, Saturday)
## Testing
Built the debug APK, installed on a Pixel 7a (Android 16), verified that:
- All 7 days appear in the week start day dropdown
- Setting each day correctly updates the calendar view
- Default value (Locale default) still works correctly