### PR TITLE
Add a separate end time zone for events (#84)

### DIFF
--- a/app/src/main/java/com/android/calendar/CalendarEventModel.java
+++ b/app/src/main/java/com/android/calendar/CalendarEventModel.java
@@ -238,6 +238,17 @@ public class CalendarEventModel implements Serializable {
         return true;
     }
 
+    /**
+     * The zone the event's end time is interpreted in. A null or empty {@link #mTimezone2}
+     * means "same as the start zone" so existing events are unaffected.
+     */
+    public String getEndTimezone() {
+        if (mTimezone2 == null || mTimezone2.isEmpty()) {
+            return mTimezone;
+        }
+        return mTimezone2;
+    }
+
     public void clear() {
         mUri = null;
         mId = -1;

--- a/app/src/main/java/com/android/calendar/event/EditEventHelper.java
+++ b/app/src/main/java/com/android/calendar/event/EditEventHelper.java
@@ -99,7 +99,8 @@ public class EditEventHelper {
             Events.ACCOUNT_NAME, // 25
             Events.ACCOUNT_TYPE, // 26
             Events.EXDATE, // 27
-            Events.ORIGINAL_INSTANCE_TIME // 28
+            Events.ORIGINAL_INSTANCE_TIME, // 28
+            Events.EVENT_END_TIMEZONE // 29
     };
     protected static final int EVENT_INDEX_ID = 0;
     protected static final int EVENT_INDEX_TITLE = 1;
@@ -130,6 +131,7 @@ public class EditEventHelper {
     protected static final int EVENT_INDEX_ACCOUNT_TYPE = 26;
     protected static final int EVENT_INDEX_EXDATE = 27;
     protected static final int EVENT_INDEX_ORIGINAL_INSTANCE_TIME = 28;
+    protected static final int EVENT_INDEX_END_TIMEZONE = 29;
 
     public static final String[] REMINDERS_PROJECTION = new String[] {
             Reminders._ID, // 0
@@ -781,23 +783,27 @@ public class EditEventHelper {
         boolean oldAllDay = originalModel.mAllDay;
         String oldRrule = originalModel.mRrule;
         String oldTimezone = originalModel.mTimezone;
+        String oldEndTimezone = originalModel.getEndTimezone();
 
         long newBegin = model.mStart;
         long newEnd = model.mEnd;
         boolean newAllDay = model.mAllDay;
         String newRrule = model.mRrule;
         String newTimezone = model.mTimezone;
+        String newEndTimezone = model.getEndTimezone();
 
         // If none of the time-dependent fields changed, then remove them.
         if (oldBegin == newBegin && oldEnd == newEnd && oldAllDay == newAllDay
                 && TextUtils.equals(oldRrule, newRrule)
-                && TextUtils.equals(oldTimezone, newTimezone)) {
+                && TextUtils.equals(oldTimezone, newTimezone)
+                && TextUtils.equals(oldEndTimezone, newEndTimezone)) {
             values.remove(Events.DTSTART);
             values.remove(Events.DTEND);
             values.remove(Events.DURATION);
             values.remove(Events.ALL_DAY);
             values.remove(Events.RRULE);
             values.remove(Events.EVENT_TIMEZONE);
+            values.remove(Events.EVENT_END_TIMEZONE);
             return;
         }
 
@@ -1208,6 +1214,8 @@ public class EditEventHelper {
         } else {
             model.mTimezone = tz;
         }
+        String endTz = cursor.getString(EVENT_INDEX_END_TIMEZONE);
+        model.mTimezone2 = TextUtils.isEmpty(endTz) ? null : endTz;
         String rRule = cursor.getString(EVENT_INDEX_RRULE);
         model.mRrule = rRule;
         model.mExDate = cursor.getString(EVENT_INDEX_EXDATE);
@@ -1397,6 +1405,7 @@ public class EditEventHelper {
 
         values.put(Events.CALENDAR_ID, calendarId);
         values.put(Events.EVENT_TIMEZONE, timezone);
+        values.put(Events.EVENT_END_TIMEZONE, isAllDay ? Time.TIMEZONE_UTC : model.getEndTimezone());
         values.put(Events.TITLE, title);
         values.put(Events.ALL_DAY, isAllDay ? 1 : 0);
         values.put(Events.DTSTART, startMillis);

--- a/app/src/main/java/com/android/calendar/event/EditEventView.java
+++ b/app/src/main/java/com/android/calendar/event/EditEventView.java
@@ -119,6 +119,9 @@ public class EditEventView implements View.OnClickListener, DialogInterface.OnCa
     private static final String PERIOD_SPACE = ". ";
 
     private static final String FRAG_TAG_TIME_ZONE_PICKER = "timeZonePickerDialogFragment";
+    // Which side (start/end) the time-zone picker is editing; survives recreation in the
+    // dialog's arguments so a rotation while the picker is open doesn't misroute the pick.
+    private static final String BUNDLE_EDITING_END_TIME_ZONE = "editingEndTimeZone";
     private static final String FRAG_TAG_RECUR_PICKER = "recurrencePickerDialogFragment";
     private static StringBuilder mSB = new StringBuilder(50);
     private static Formatter mF = new Formatter(mSB, Locale.getDefault());
@@ -140,8 +143,12 @@ public class EditEventView implements View.OnClickListener, DialogInterface.OnCa
     Button mStartTimeButton;
     Button mEndTimeButton;
     Button mTimezoneButton;
+    Button mEndTimezoneButton;
+    Button mAddEndTimezoneButton;
+    View mEndTimezoneClearButton;
     View mColorPicker;
     View mTimezoneRow;
+    View mEndTimezoneRow;
     TextView mStartTimeHome;
     TextView mStartDateHome;
     TextView mEndTimeHome;
@@ -159,6 +166,7 @@ public class EditEventView implements View.OnClickListener, DialogInterface.OnCa
     TextView mUrlTextView;
     TextView mWhenView;
     TextView mTimezoneTextView;
+    TextView mEndTimezoneTextView;
     MultiAutoCompleteTextView mAttendeesList;
     View mCalendarSelectorGroupBackground;
     View mLocationGroup;
@@ -217,6 +225,8 @@ public class EditEventView implements View.OnClickListener, DialogInterface.OnCa
     private Time mStartTime;
     private Time mEndTime;
     private String mTimezone;
+    private String mEndTimezone;          // empty/null = same as start zone
+    private boolean mEditingEndTimezone;  // which side the tz picker is editing
     private boolean mAllDay = false;
     private int mModification = EditEventHelper.MODIFY_UNINITIALIZED;
     private EventRecurrence mEventRecurrence = new EventRecurrence();
@@ -250,10 +260,36 @@ public class EditEventView implements View.OnClickListener, DialogInterface.OnCa
         mTimezoneButton.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
+                mEditingEndTimezone = false;
                 showTimezoneDialog();
             }
         });
         mTimezoneRow = view.findViewById(R.id.timezone_button_row);
+        mEndTimezoneTextView = (TextView) mView.findViewById(R.id.timezone_end_textView);
+        mEndTimezoneButton = (Button) view.findViewById(R.id.timezone_end_button);
+        mEndTimezoneButton.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                mEditingEndTimezone = true;
+                showTimezoneDialog();
+            }
+        });
+        mEndTimezoneRow = view.findViewById(R.id.timezone_end_button_row);
+        mAddEndTimezoneButton = (Button) view.findViewById(R.id.timezone_add_end_button);
+        mAddEndTimezoneButton.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                mEditingEndTimezone = true;
+                showTimezoneDialog();
+            }
+        });
+        mEndTimezoneClearButton = view.findViewById(R.id.timezone_end_clear);
+        mEndTimezoneClearButton.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                clearEndTimezone();
+            }
+        });
         mStartTimeHome = (TextView) view.findViewById(R.id.start_time_home_tz);
         mStartDateHome = (TextView) view.findViewById(R.id.start_date_home_tz);
         mEndTimeHome = (TextView) view.findViewById(R.id.end_time_home_tz);
@@ -365,6 +401,10 @@ public class EditEventView implements View.OnClickListener, DialogInterface.OnCa
         TimeZonePickerDialog tzpd = (TimeZonePickerDialog) fm
                 .findFragmentByTag(FRAG_TAG_TIME_ZONE_PICKER);
         if (tzpd != null) {
+            Bundle tzArgs = tzpd.getArguments();
+            if (tzArgs != null) {
+                mEditingEndTimezone = tzArgs.getBoolean(BUNDLE_EDITING_END_TIME_ZONE, false);
+            }
             tzpd.setOnTimeZoneSetListener(this);
         }
 
@@ -414,35 +454,79 @@ public class EditEventView implements View.OnClickListener, DialogInterface.OnCa
     // Implements OnTimeZoneSetListener
     @Override
     public void onTimeZoneSet(TimeZoneInfo tzi) {
-        setTimezone(tzi.mTzId);
+        if (mEditingEndTimezone) {
+            setEndTimezone(tzi.mTzId);
+        } else {
+            setTimezone(tzi.mTzId);
+        }
         updateHomeTime();
+    }
+
+    private boolean hasDistinctEndTimezone() {
+        return !TextUtils.isEmpty(mEndTimezone);
+    }
+
+    private String effectiveEndTimezone() {
+        return hasDistinctEndTimezone() ? mEndTimezone : mTimezone;
     }
 
     private void setTimezone(String timeZone) {
         mTimezone = timeZone;
         Utils.changeTimezoneOnly(mStartTime, mTimezone);
-        Utils.changeTimezoneOnly(mEndTime, mTimezone);
+        if (!hasDistinctEndTimezone()) {
+            // End zone follows the start until the user adds one explicitly.
+            Utils.changeTimezoneOnly(mEndTime, mTimezone);
+        }
         long startMillis = mStartTime.normalize();
         mEndTime.normalize();
-
         populateTimezone(startMillis);
+    }
+
+    private void setEndTimezone(String timeZone) {
+        mEndTimezone = timeZone;
+        Utils.changeTimezoneOnly(mEndTime, effectiveEndTimezone());
+        mEndTime.normalize();
+        populateTimezone(mStartTime.normalize());
+        updateEndTimezoneViews();
+    }
+
+    /** Clears an explicitly-set end zone so the end follows the start again. */
+    private void clearEndTimezone() {
+        mEndTimezone = null;
+        Utils.changeTimezoneOnly(mEndTime, mTimezone);
+        mEndTime.normalize();
+        populateTimezone(mStartTime.normalize());
+        updateEndTimezoneViews();
+        updateHomeTime();
     }
 
     private void populateTimezone(long eventStartTime) {
         if (mTzPickerUtils == null) {
             mTzPickerUtils = new TimeZonePickerUtils(mActivity);
         }
-        CharSequence displayName =
+        CharSequence startName =
                 mTzPickerUtils.getGmtDisplayName(mActivity, mTimezone, eventStartTime, true);
-
-        mTimezoneTextView.setText(displayName);
-        mTimezoneButton.setText(displayName);
+        mTimezoneTextView.setText(startName);
+        // Prefix the start label only when an end zone is also shown, so single-zone
+        // events look exactly as before.
+        boolean hasEnd = hasDistinctEndTimezone();
+        mTimezoneButton.setText(hasEnd
+                ? mActivity.getString(R.string.start_time_zone, startName) : startName);
+        if (hasEnd) {
+            CharSequence endName = mTzPickerUtils.getGmtDisplayName(
+                    mActivity, mEndTimezone, mEndTime.toMillis(), true);
+            mEndTimezoneTextView.setText(endName);
+            mEndTimezoneButton.setText(mActivity.getString(R.string.end_time_zone, endName));
+        }
     }
 
     private void showTimezoneDialog() {
         Bundle b = new Bundle();
-        b.putLong(TimeZonePickerDialog.BUNDLE_START_TIME_MILLIS, mStartTime.toMillis());
-        b.putString(TimeZonePickerDialog.BUNDLE_TIME_ZONE, mTimezone);
+        long time = mEditingEndTimezone ? mEndTime.toMillis() : mStartTime.toMillis();
+        String zone = mEditingEndTimezone ? effectiveEndTimezone() : mTimezone;
+        b.putLong(TimeZonePickerDialog.BUNDLE_START_TIME_MILLIS, time);
+        b.putString(TimeZonePickerDialog.BUNDLE_TIME_ZONE, zone);
+        b.putBoolean(BUNDLE_EDITING_END_TIME_ZONE, mEditingEndTimezone);
 
         FragmentManager fm = mActivity.getSupportFragmentManager();
         TimeZonePickerDialog tzpd = (TimeZonePickerDialog) fm
@@ -454,6 +538,23 @@ public class EditEventView implements View.OnClickListener, DialogInterface.OnCa
         tzpd.setArguments(b);
         tzpd.setOnTimeZoneSetListener(EditEventView.this);
         tzpd.show(fm, FRAG_TAG_TIME_ZONE_PICKER);
+    }
+
+    /**
+     * The end zone is offered only for non-all-day, non-recurring (DTEND) events, and is
+     * revealed on demand: the end-zone row is shown only once the user adds a distinct end
+     * zone, otherwise an "add end time zone" affordance is shown in its place. All-day and
+     * recurring events keep a single (start) zone.
+     */
+    private void updateEndTimezoneViews() {
+        boolean applicable = !mAllDayCheckBox.isChecked() && TextUtils.isEmpty(mRrule);
+        if (!applicable && hasDistinctEndTimezone()) {
+            mEndTimezone = null; // all-day / recurring keep a single (start) zone
+            populateTimezone(mStartTime.normalize()); // drop the now-stale "Start zone:" prefix
+        }
+        boolean hasEnd = applicable && hasDistinctEndTimezone();
+        mEndTimezoneRow.setVisibility(hasEnd ? View.VISIBLE : View.GONE);
+        mAddEndTimezoneButton.setVisibility(applicable && !hasEnd ? View.VISIBLE : View.GONE);
     }
 
     private void populateRepeats() {
@@ -569,6 +670,7 @@ public class EditEventView implements View.OnClickListener, DialogInterface.OnCa
             mEventRecurrence.parse(mRrule);
         }
         populateRepeats();
+        updateEndTimezoneViews();
     }
 
     // This is called if the user cancels the "No calendars" dialog.
@@ -687,6 +789,7 @@ public class EditEventView implements View.OnClickListener, DialogInterface.OnCa
             }
 
             mModel.mTimezone = Time.TIMEZONE_UTC;
+            mModel.mTimezone2 = null;
 
             // refresh UI to new start & end times
             setDate(mStartDateButton, mStartTime.toMillis());
@@ -694,11 +797,12 @@ public class EditEventView implements View.OnClickListener, DialogInterface.OnCa
             setDate(mEndDateButton, mEndTime.toMillis());
             setTime(mEndTimeButton, mEndTime.toMillis());
         } else {
-            mStartTime.setTimezone(mTimezone);
-            mEndTime.setTimezone(mTimezone);
-            mModel.mStart = mStartTime.toMillis();
-            mModel.mEnd = mEndTime.toMillis();
+            long[] startEnd = EventTimezoneUtils.startEndMillis(
+                    mStartTime, mTimezone, mEndTime, effectiveEndTimezone());
+            mModel.mStart = startEnd[0];
+            mModel.mEnd = startEnd[1];
             mModel.mTimezone = mTimezone;
+            mModel.mTimezone2 = hasDistinctEndTimezone() ? mEndTimezone : null;
         }
         mModel.mAccessLevel = mAccessLevelSpinner.getSelectedItemPosition();
         // TODO set correct availability value
@@ -845,6 +949,7 @@ public class EditEventView implements View.OnClickListener, DialogInterface.OnCa
             long begin = model.mStart;
             long end = model.mEnd;
             mTimezone = model.mTimezone; // this will be UTC for all day events
+            mEndTimezone = model.mTimezone2; // empty/null = same as start
 
             // Set up the starting times
             if (begin > 0) {
@@ -853,7 +958,7 @@ public class EditEventView implements View.OnClickListener, DialogInterface.OnCa
                 mStartTime.normalize();
             }
             if (end > 0) {
-                mEndTime.setTimezone(mTimezone);
+                mEndTime.setTimezone(effectiveEndTimezone());
                 mEndTime.set(end);
                 mEndTime.normalize();
             }
@@ -893,6 +998,7 @@ public class EditEventView implements View.OnClickListener, DialogInterface.OnCa
             // also be robust against model having non-normalised all day event
             // (start or end not midnight UTC or timezone not UTC), and force that
             mTimezone = Utils.getTimeZone(mActivity, null);
+            mEndTimezone = null;
             {
                 int year = mStartTime.getYear();
                 int month = mStartTime.getMonth();
@@ -930,6 +1036,7 @@ public class EditEventView implements View.OnClickListener, DialogInterface.OnCa
         }
 
         populateTimezone(mStartTime.normalize());
+        updateEndTimezoneViews();
 
         SharedPreferences prefs = GeneralPreferences.Companion.getSharedPreferences(mActivity);
         String defaultReminderString = prefs.getString(
@@ -1204,6 +1311,12 @@ public class EditEventView implements View.OnClickListener, DialogInterface.OnCa
             if (TextUtils.isEmpty(mUrlTextView.getText())) {
                 mUrlGroup.setVisibility(View.GONE);
             }
+            // Show the read-only end-zone row only when a distinct end zone is set.
+            View endTzRow = mView.findViewById(R.id.timezone_end_textview_row);
+            if (endTzRow != null) {
+                boolean distinctEndZone = hasDistinctEndTimezone() && !mAllDayCheckBox.isChecked();
+                endTzRow.setVisibility(distinctEndZone ? View.VISIBLE : View.GONE);
+            }
             mCalendarsSpinner.setEnabled(false);
         } else {
             for (View v : mViewOnlyList) {
@@ -1372,8 +1485,9 @@ public class EditEventView implements View.OnClickListener, DialogInterface.OnCa
         // calls to TimeZone#getDefault()
         // TODO fix this if/when DateUtils allows for passing in a timezone
         String dateString;
+        String tz = (view == mEndDateButton) ? effectiveEndTimezone() : mTimezone;
         synchronized (TimeZone.class) {
-            TimeZone.setDefault(TimeZone.getTimeZone(mTimezone));
+            TimeZone.setDefault(TimeZone.getTimeZone(tz));
             dateString = DateUtils.formatDateTime(mActivity, millis, flags);
             // setting the default back to null restores the correct behavior
             TimeZone.setDefault(null);
@@ -1396,8 +1510,9 @@ public class EditEventView implements View.OnClickListener, DialogInterface.OnCa
         // calls to TimeZone#getDefault()
         // TODO fix this if/when DateUtils allows for passing in a timezone
         String timeString;
+        String tz = (view == mEndTimeButton) ? effectiveEndTimezone() : mTimezone;
         synchronized (TimeZone.class) {
-            TimeZone.setDefault(TimeZone.getTimeZone(mTimezone));
+            TimeZone.setDefault(TimeZone.getTimeZone(tz));
             timeString = DateUtils.formatDateTime(mActivity, millis, flags);
             TimeZone.setDefault(null);
         }
@@ -1439,6 +1554,7 @@ public class EditEventView implements View.OnClickListener, DialogInterface.OnCa
             mStartTimeButton.setVisibility(View.GONE);
             mEndTimeButton.setVisibility(View.GONE);
             mTimezoneRow.setVisibility(View.GONE);
+            updateEndTimezoneViews();
         } else {
             if (mEndTime.getHour() == 0 && mEndTime.getMinute() == 0) {
                 if (mAllDay != isChecked) {
@@ -1452,6 +1568,7 @@ public class EditEventView implements View.OnClickListener, DialogInterface.OnCa
             mStartTimeButton.setVisibility(View.VISIBLE);
             mEndTimeButton.setVisibility(View.VISIBLE);
             mTimezoneRow.setVisibility(View.VISIBLE);
+            updateEndTimezoneViews();
         }
 
         // If this is a new event, and if availability has not yet been
@@ -1535,7 +1652,9 @@ public class EditEventView implements View.OnClickListener, DialogInterface.OnCa
      */
     private void updateHomeTime() {
         String tz = Utils.getTimeZone(mActivity, null);
-        if (!mAllDayCheckBox.isChecked() && !TextUtils.equals(tz, mTimezone)
+        if (!mAllDayCheckBox.isChecked()
+                && (!TextUtils.equals(tz, mTimezone)
+                        || !TextUtils.equals(tz, effectiveEndTimezone()))
                 && mModification != EditEventHelper.MODIFY_UNINITIALIZED) {
             int flags = DateUtils.FORMAT_SHOW_TIME;
             boolean is24Format = DateFormat.is24HourFormat(mActivity);
@@ -1633,8 +1752,6 @@ public class EditEventView implements View.OnClickListener, DialogInterface.OnCa
             endTime.setHour(hourOfDay + hourDuration);
             endTime.setMinute(minute + minuteDuration);
 
-            // Update tz in case the start time switched from/to DLS
-            populateTimezone(startMillis);
         } else {
             // The end time was changed.
             startMillis = startTime.toMillis();
@@ -1646,10 +1763,12 @@ public class EditEventView implements View.OnClickListener, DialogInterface.OnCa
             if (endTime.compareTo(startTime) < 0) {
                 endTime.setDay(startTime.getDay() + 1);
             }
-            // Call populateTimezone if we support end time zone as well
         }
 
         endMillis = endTime.normalize();
+
+        // Refresh both zone labels in case the start/end time switched from/to DST.
+        populateTimezone(startMillis);
 
         setDate(mEndDateButton, endMillis);
         setTime(mStartTimeButton, startMillis);
@@ -1715,9 +1834,6 @@ public class EditEventView implements View.OnClickListener, DialogInterface.OnCa
 
             // If the start date has changed then update the repeats.
             populateRepeats();
-
-            // Update tz in case the start time switched from/to DLS
-            populateTimezone(startMillis);
         } else {
             // The end date was changed.
             startMillis = startTime.toMillis();
@@ -1732,8 +1848,10 @@ public class EditEventView implements View.OnClickListener, DialogInterface.OnCa
                 endTime.set(startTime);
                 endMillis = startMillis;
             }
-            // Call populateTimezone if we support end time zone as well
         }
+
+        // Refresh both zone labels in case the start/end date switched from/to DST.
+        populateTimezone(startMillis);
 
         setDate(mStartDateButton, startMillis);
         setDate(mEndDateButton, endMillis);

--- a/app/src/main/java/com/android/calendar/event/EventTimezoneUtils.java
+++ b/app/src/main/java/com/android/calendar/event/EventTimezoneUtils.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.calendar.event;
+
+import com.android.calendar.calendarcommon2.Time;
+
+/**
+ * Turns the editor's wall-clock start/end {@link Time}s into absolute UTC millis,
+ * interpreting each side in its own time zone. The wall-clock fields are retained;
+ * only the zone changes (so identical to the single-zone path when both zones match).
+ */
+public final class EventTimezoneUtils {
+
+    private EventTimezoneUtils() {}
+
+    /** Returns {@code [startMillis, endMillis]}. Mutates the zones of the passed Times. */
+    public static long[] startEndMillis(Time start, String startTz, Time end, String endTz) {
+        start.setTimezone(startTz);
+        end.setTimezone(endTz);
+        return new long[] { start.toMillis(), end.toMillis() };
+    }
+}

--- a/app/src/main/res/layout/edit_event_all.xml
+++ b/app/src/main/res/layout/edit_event_all.xml
@@ -32,6 +32,12 @@
             android:layout_height="wrap_content"
             app:constraint_referenced_ids="timezone_icon,timezone_button" />
 
+        <androidx.constraintlayout.widget.Group
+            android:id="@+id/timezone_end_button_row"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            app:constraint_referenced_ids="timezone_end_icon,timezone_end_button,timezone_end_clear" />
+
         <!-- CALENDARS SELECTOR for new events -->
         <com.google.android.material.textfield.TextInputEditText
             android:id="@+id/title"
@@ -240,13 +246,64 @@
             app:layout_constraintStart_toEndOf="@+id/timezone_icon"
             app:layout_constraintTop_toBottomOf="@+id/end_date" />
 
+        <!-- Reveal-on-demand affordance for a separate end time zone (shown when none is set) -->
+        <Button
+            android:id="@+id/timezone_add_end_button"
+            style="@style/Widget.Material3.Button.TextButton.Icon"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="12dp"
+            android:text="@string/add_end_time_zone"
+            app:icon="@drawable/ic_add"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/timezone_button" />
+
+        <ImageView
+            android:id="@+id/timezone_end_icon"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="12dp"
+            android:src="@drawable/ic_outline_public"
+            app:layout_constraintBottom_toBottomOf="@+id/timezone_end_button"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="@+id/timezone_end_button" />
+
+        <Button
+            android:id="@+id/timezone_end_button"
+            style="@style/Widget.Material3.Button.OutlinedButton"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="12dp"
+            android:contentDescription="@string/accessibility_pick_end_time_zone"
+            android:gravity="start|center_vertical"
+            android:lineSpacingExtra="4dp"
+            android:paddingHorizontal="12dp"
+            app:layout_constraintEnd_toStartOf="@+id/timezone_end_clear"
+            app:layout_constraintStart_toEndOf="@+id/timezone_end_icon"
+            app:layout_constraintTop_toBottomOf="@+id/timezone_add_end_button" />
+
+        <ImageView
+            android:id="@+id/timezone_end_clear"
+            android:layout_width="48dp"
+            android:layout_height="48dp"
+            android:layout_marginEnd="12dp"
+            android:background="?attr/selectableItemBackgroundBorderless"
+            android:clickable="true"
+            android:contentDescription="@string/accessibility_clear_end_time_zone"
+            android:focusable="true"
+            android:padding="12dp"
+            android:src="@drawable/ic_close"
+            app:layout_constraintBottom_toBottomOf="@+id/timezone_end_button"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="@+id/timezone_end_button" />
+
         <View
             android:id="@+id/view7"
             style="@style/EditEventSeparator"
             android:layout_marginTop="4dp"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/timezone_button" />
+            app:layout_constraintTop_toBottomOf="@+id/timezone_end_button" />
 
         <androidx.constraintlayout.widget.Group
             android:id="@+id/response_group"
@@ -736,6 +793,26 @@
 
         <TextView
             android:id="@+id/timezone_textView"
+            style="@style/TextAppearance.EditEvent_Value"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginLeft="24dip"
+            android:layout_marginRight="24dip" />
+    </LinearLayout>
+
+    <!-- END TIME ZONE - Read-only textview version -->
+    <LinearLayout
+        android:id="@+id/timezone_end_textview_row"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="4dip"
+        android:focusable="true"
+        android:minHeight="48dip"
+        android:orientation="vertical"
+        android:visibility="gone">
+
+        <TextView
+            android:id="@+id/timezone_end_textView"
             style="@style/TextAppearance.EditEvent_Value"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -617,6 +617,16 @@
     <string name="accessibility_pick_end_time">End time</string>
     <!-- Select a time zone for a new event [CHAR LIMIT = NONE]-->
     <string name="accessibility_pick_time_zone">Time zone</string>
+    <!-- Select the end time zone for an event [CHAR LIMIT = NONE]-->
+    <string name="accessibility_pick_end_time_zone">End time zone</string>
+    <!-- Label on the event start time zone button; %1$s is the zone name [CHAR LIMIT=NONE]-->
+    <string name="start_time_zone">Start zone: %1$s</string>
+    <!-- Label on the event end time zone button; %1$s is the zone name [CHAR LIMIT=NONE]-->
+    <string name="end_time_zone">End zone: %1$s</string>
+    <!-- Action button that reveals the separate end time zone picker [CHAR LIMIT=30]-->
+    <string name="add_end_time_zone">Add end time zone</string>
+    <!-- Description of the button that removes a separately-set end time zone [CHAR LIMIT=NONE]-->
+    <string name="accessibility_clear_end_time_zone">Remove end time zone</string>
     <!-- Select a time zone for a new event [CHAR LIMIT = NONE]-->
     <string name="accessibility_pick_recurrence">Repeat event</string>
     <!-- Add a reminder to an event [CHAR LIMIT = NONE]-->

--- a/app/src/test/java/com/android/calendar/CalendarEventModelTest.java
+++ b/app/src/test/java/com/android/calendar/CalendarEventModelTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.calendar;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+/** Framework-free unit tests for {@link CalendarEventModel} end-zone fallback. */
+public class CalendarEventModelTest {
+
+    @Test
+    public void endTimezoneFallsBackToStartWhenEmpty() {
+        CalendarEventModel m = new CalendarEventModel();
+        m.mTimezone = "America/New_York";
+
+        m.mTimezone2 = null;
+        assertEquals("America/New_York", m.getEndTimezone());
+
+        m.mTimezone2 = "";
+        assertEquals("America/New_York", m.getEndTimezone());
+    }
+
+    @Test
+    public void endTimezoneUsesItsOwnValueWhenSet() {
+        CalendarEventModel m = new CalendarEventModel();
+        m.mTimezone = "America/New_York";
+        m.mTimezone2 = "Europe/London";
+        assertEquals("Europe/London", m.getEndTimezone());
+    }
+}

--- a/app/src/test/java/com/android/calendar/event/EventTimezoneUtilsTest.java
+++ b/app/src/test/java/com/android/calendar/event/EventTimezoneUtilsTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2026 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.calendar.event;
+
+import static org.junit.Assert.assertEquals;
+
+import com.android.calendar.calendarcommon2.Time;
+
+import org.junit.Test;
+
+public class EventTimezoneUtilsTest {
+
+    @Test
+    public void interpretsStartAndEndInTheirOwnZones() {
+        // 2026-08-30 10:00 Tokyo (UTC+9)   -> 01:00 UTC
+        Time start = new Time("Asia/Tokyo");
+        start.set(0, 0, 10, 30, 7, 2026);
+        // 2026-08-30 15:30 Colombo (UTC+5:30) -> 10:00 UTC
+        Time end = new Time("Asia/Colombo");
+        end.set(0, 30, 15, 30, 7, 2026);
+
+        long[] se = EventTimezoneUtils.startEndMillis(start, "Asia/Tokyo", end, "Asia/Colombo");
+
+        Time utcStart = new Time(Time.TIMEZONE_UTC);
+        utcStart.set(0, 0, 1, 30, 7, 2026);
+        Time utcEnd = new Time(Time.TIMEZONE_UTC);
+        utcEnd.set(0, 0, 10, 30, 7, 2026);
+
+        assertEquals(utcStart.toMillis(), se[0]);
+        assertEquals(utcEnd.toMillis(), se[1]);
+        assertEquals(9L * 60 * 60 * 1000, se[1] - se[0]); // 9h apart
+    }
+
+    @Test
+    public void matchesSingleZoneWhenZonesAreEqual() {
+        Time start = new Time("Asia/Tokyo");
+        start.set(0, 0, 10, 30, 7, 2026);
+        Time end = new Time("Asia/Tokyo");
+        end.set(0, 0, 12, 30, 7, 2026);
+
+        long[] se = EventTimezoneUtils.startEndMillis(start, "Asia/Tokyo", end, "Asia/Tokyo");
+
+        assertEquals(2L * 60 * 60 * 1000, se[1] - se[0]); // 2h apart, same zone
+    }
+}


### PR DESCRIPTION
This implements #84 — letting an event's start and end be in different time zones (the flight case: depart in the origin zone, arrive in the destination zone).

## Approach

Etar stores events in the system `CalendarContract` provider, which already has a native `EVENT_END_TIMEZONE` column — so the end zone is stored there directly (no schema change or migration) and round-trips through CalDAV sync adapters for free. The model's previously-unused `mTimezone2` field becomes the end zone; an empty value means "same as start", so existing events are unaffected.

## UI — revealed on demand

Single-zone events look exactly as before: one timezone row. A small **Add end time zone** button reveals a separate **End zone** row (with a clear ✕) and labels the two as *Start zone* / *End zone*. Clearing it — or switching to all-day/recurring — returns the end to "same as start". The existing home-time readout now appears whenever either zone differs from your device zone.

Recurring events (which use `DURATION`, not `DTEND`) and all-day events keep a single zone.

## How to test

1. Create a timed event → the editor is unchanged (one zone row) plus an **Add end time zone** button.
2. Tap it and set a different end zone (e.g. start `Etc/UTC`, end `Asia/Colombo` at +5:30) → an **End zone** row appears, the start row becomes **Start zone:**, and the device-zone readout shows under the times.
3. Save and reopen → both zones persist; the provider row has `eventEndTimezone` set.
4. Tap ✕ → reverts to a single zone row. Toggle **All day** or add a **repeat** → the end-zone UI hides.

Includes unit tests for the end-zone fallback and the per-side instant conversion (Tokyo → Colombo).

## Follow-ups (not in this PR)

- The event **details/view** screen (`EventInfoFragment`) still renders the time range in a single zone; surfacing the end zone there is a small follow-up I'm happy to send next.
- `.ics` import/export of `TZID`/`VTIMEZONE` for the end zone is also planned as a follow-up; export still writes correct absolute instants today.

Happy to adjust the UX if you'd prefer a different approach.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
