### PR TITLE
fix(alerts): show DST-aware timezone label in reminder notifications

### DIFF
--- a/app/src/main/java/com/android/calendar/alerts/AlertUtils.java
+++ b/app/src/main/java/com/android/calendar/alerts/AlertUtils.java
@@ -177,8 +177,6 @@ public class AlertUtils {
                 startMillis, flags));
 
         if (!allDay && tz != Utils.getCurrentTimezone()) {
-            // Assumes time was set to the current tz
-            time.set(startMillis);
             TimeZone displayTz = TimeZone.getTimeZone(tz);
             sb.append(" ").append(displayTz.getDisplayName(
                     displayTz.inDaylightTime(new java.util.Date(startMillis)),

--- a/app/src/main/java/com/android/calendar/alerts/AlertUtils.java
+++ b/app/src/main/java/com/android/calendar/alerts/AlertUtils.java
@@ -179,8 +179,10 @@ public class AlertUtils {
         if (!allDay && tz != Utils.getCurrentTimezone()) {
             // Assumes time was set to the current tz
             time.set(startMillis);
-            sb.append(" ").append(TimeZone.getTimeZone(tz).getDisplayName(
-                    false, TimeZone.SHORT, Locale.getDefault()));
+            TimeZone displayTz = TimeZone.getTimeZone(tz);
+            sb.append(" ").append(displayTz.getDisplayName(
+                    displayTz.inDaylightTime(new java.util.Date(startMillis)),
+                    TimeZone.SHORT, Locale.getDefault()));
         }
 
         if (eventDay == today + 1) {


### PR DESCRIPTION
## Problem

Reminder notifications for an event in a non-local timezone show the **standard-time** zone label even when the event falls inside DST (#2120). Example: an event at **Sat 30 May 2026, 12:00 Europe/London** (British Summer Time, GMT+1) shows `12:00 GMT` in the notification instead of `12:00 GMT+1` / `BST`. The local time is correct — only the zone label is wrong.

## Cause

`AlertUtils.formatTimeLocation()` builds the label with a hardcoded `daylightTime = false`:

```java
sb.append(" ").append(TimeZone.getTimeZone(tz).getDisplayName(
        false, TimeZone.SHORT, Locale.getDefault()));
```

`TimeZone.getDisplayName(boolean daylightTime, …)` ignores the date and returns the name for the mode named by the flag, so it always yields the standard-time name (`GMT`), never the DST name (`BST`/`GMT+1`). The event editor and timezone picker already render DST-aware labels (`TimeZoneData` uses `getDisplayName(tz.inDaylightTime(date), …)`), so only the notification path was inconsistent.

## Fix

Derive the DST flag from the event's start via `TimeZone.inDaylightTime()`, mirroring `TimeZoneData`:

```java
TimeZone displayTz = TimeZone.getTimeZone(tz);
sb.append(" ").append(displayTz.getDisplayName(
        displayTz.inDaylightTime(new Date(startMillis)),
        TimeZone.SHORT, Locale.getDefault()));
```

## Verification

Standalone JDK check of the exact expression (the resulting label string is ICU/JDK-dependent, but the behaviour is not):

| Event (Europe/London) | `inDaylightTime` | before (`false`) | after (fix) |
|---|---|---|---|
| 30 May 2026 12:00 (BST) | true | `GMT` | `BST` |
| 15 Jan 2026 12:00 (GMT) | false | `GMT` | `GMT` |

Standard-time dates are unchanged (no regression); America/New_York behaves the same (`EST` → `EDT` in summer).
