### PR TITLE
fix(duplicate): default duplicated event to the source event's calendar

### DIFF
--- a/app/src/main/java/com/android/calendar/EventInfoFragment.java
+++ b/app/src/main/java/com/android/calendar/EventInfoFragment.java
@@ -1313,6 +1313,11 @@ public class EventInfoFragment extends DialogFragment implements OnCheckedChange
 
         final Intent intent = new Intent(mContext, EditEventActivity.class);
         intent.setType("vnd.android.cursor.item/event");
+        // Default the duplicate to the source event's calendar, but only when it is writeable;
+        // otherwise fall back to the default calendar so we never preselect a read-only one.
+        if (mCanModifyCalendar) {
+            intent.putExtra(CalendarContract.Events.CALENDAR_ID, mEventCursor.getLong(EVENT_INDEX_CALENDAR_ID));
+        }
         intent.putExtra(CalendarContract.Events.TITLE, mEventCursor.getString(EVENT_INDEX_TITLE));
         intent.putExtra(CalendarContract.Events.DESCRIPTION, mEventCursor.getString(EVENT_INDEX_DESCRIPTION));
         intent.putExtra(CalendarContract.Events.EVENT_LOCATION, mEventCursor.getString(EVENT_INDEX_EVENT_LOCATION));


### PR DESCRIPTION
## Problem

Fixes #2126.

When duplicating an event, the new event was attached to the last-used calendar (whichever was selected the last time an event was created), rather than the calendar of the event being duplicated. The reporter expected the duplicate to default to the same calendar as the original, since it is usually for the same activity/person.

## Fix

`EventInfoFragment.duplicateEvent()` builds the intent for the edit screen but never passed `Events.CALENDAR_ID`, so `EditEventFragment` fell back to the default-calendar preference. The receiving side (`EditEventActivity.getEventInfoFromIntent()`) already reads this extra, so the fix is simply to pass the source event's calendar id through.

The extra is only passed when the source calendar is writeable (`mCanModifyCalendar`, i.e. `CAL_ACCESS_CONTRIBUTOR` or higher). A read-only source calendar (e.g. a subscribed or holiday calendar) is not present in the writeable-calendars spinner, so passing its id would make the spinner fall back to the first entry instead of the user's configured default calendar. Guarding on writeability preserves the existing default-calendar fallback for those events.

## Testing

- `./gradlew :app:compileDebugJavaWithJavac` passes.
- Duplicating an event on a writeable calendar now preselects that same calendar in the edit screen.
- Duplicating an event on a read-only calendar continues to fall back to the default calendar.