### PR TITLE
fix(edit): remove event URL when the field is cleared

### DIFF
--- a/app/src/main/java/com/android/calendar/event/EditEventHelper.java
+++ b/app/src/main/java/com/android/calendar/event/EditEventHelper.java
@@ -495,27 +495,34 @@ public class EditEventHelper {
 
         ContentProviderOperation.Builder b;
 
-        if (model.mUrl != null && !model.mUrl.isBlank()) {
+        boolean hasUrl = model.mUrl != null && !model.mUrl.isBlank();
+        if (hasUrl || !newEvent) {
             Uri extendedPropUri = ExtendedProperty.contentUri(model.mCalendarAccountName, model.mCalendarAccountType);
-            values.clear();
-            values.put(ExtendedProperties.NAME, ExtendedProperty.URL_NAME);
-            values.put(ExtendedProperties.VALUE, model.mUrl);
 
-            if (newEvent) {
-                b = ContentProviderOperation.newInsert(extendedPropUri)
-                        .withValues(values);
-                b.withValueBackReference(ExtendedProperties.EVENT_ID, eventIdIndex);
-            } else {
-                values.put(ExtendedProperties.EVENT_ID, model.mId);
-                // First delete the URL extended properties associated with the event
+            if (!newEvent) {
+                // First delete any URL extended property associated with the event so that
+                // clearing the URL removes it and re-saving does not duplicate it.
                 b = ContentProviderOperation.newDelete(extendedPropUri)
                         .withSelection(EXTENDED_WHERE_EVENT_NAME, new String[] { Long.toString(model.mId), ExtendedProperty.URL_NAME });
                 ops.add(b.build());
-                // And then, insert the new url
-                b = ContentProviderOperation.newInsert(extendedPropUri)
-                        .withValues(values);
             }
-            ops.add(b.build());
+
+            if (hasUrl) {
+                values.clear();
+                values.put(ExtendedProperties.NAME, ExtendedProperty.URL_NAME);
+                values.put(ExtendedProperties.VALUE, model.mUrl);
+
+                if (newEvent) {
+                    b = ContentProviderOperation.newInsert(extendedPropUri)
+                            .withValues(values);
+                    b.withValueBackReference(ExtendedProperties.EVENT_ID, eventIdIndex);
+                } else {
+                    values.put(ExtendedProperties.EVENT_ID, model.mId);
+                    b = ContentProviderOperation.newInsert(extendedPropUri)
+                            .withValues(values);
+                }
+                ops.add(b.build());
+            }
         }
 
         boolean hasAttendeeData = model.mHasAttendeeData;


### PR DESCRIPTION
## Problem

Fixes #1980.

When editing an event, clearing the URL field does not remove the URL: after saving, the old URL is still there. It can be changed to a different URL, but not emptied.

## Cause

The event URL is not a column on the event row; it is stored as a `CalendarContract.ExtendedProperties` row (NAME `.../url`, linked by EVENT_ID). In `EditEventHelper.saveEvent()` the whole delete-and-reinsert block for that row was gated on the URL being non-blank:

```java
if (model.mUrl != null && !model.mUrl.isBlank()) { ... }
```

So when the user cleared the field, the block was skipped entirely and the delete of the existing URL property never ran — the stale row survived.

## Fix

Restructure so that for an existing event the stale URL property is always deleted first, and a new row is inserted only when a non-blank URL remains:

- existing event, URL cleared → delete stale row, insert nothing (the #1980 case)
- existing event, URL present → delete stale row, insert new value (unchanged behavior)
- new event, URL present → insert with back-reference, no delete (unchanged)
- new event, no URL → nothing to do (unchanged)

This mirrors the delete-then-insert-if-any pattern already used by `saveReminders()` in the same file. `ExtendedProperties` has no upsert, so delete-before-insert is required to avoid duplicate rows; the delete on an unchanged save is a no-op within the same atomic batch.

## Testing

- `./gradlew :app:compileDebugJavaWithJavac` passes.
- Editing an event and clearing the URL now removes it after save.
- Changing the URL to a new value still round-trips; adding a URL to a new event is unchanged.